### PR TITLE
markdown_live_preview: Wrap long table cell content instead of overflowing

### DIFF
--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -1773,7 +1773,17 @@ fn render_table_block(
                 let weak = editor.clone();
                 let cell_range = cell_range.clone();
                 cell = cell
-                    .child(MarkdownElement::new(markdown.clone(), style.clone()))
+                    // `min_w_0` is load-bearing: as a flex item the markdown
+                    // container would otherwise take its min-content width,
+                    // which for text measured without a definite width is the
+                    // whole unwrapped line. The cell itself still shrinks to
+                    // its column share, so long content spills over the border
+                    // instead of wrapping.
+                    .child(
+                        div()
+                            .min_w_0()
+                            .child(MarkdownElement::new(markdown.clone(), style.clone())),
+                    )
                     .cursor_text()
                     .on_mouse_down(MouseButton::Left, move |_, window, cx| {
                         cx.stop_propagation();

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -1554,6 +1554,36 @@ async fn test_drag_column_between_others(cx: &mut TestAppContext) {
     );
 }
 
+#[gpui::test]
+async fn test_table_cell_wraps_long_content(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        | Field | Path |
+        | --- | --- |
+        | Curriculum vitae | `~/Documents/CV/HarryWang-CV-Oct-2025.pdf` or enter `https://harrywang.me` in the website field, then attach the same file again so the archive copy stays in sync |
+        | Report | x |
+    "});
+    cx.executor().run_until_parked();
+
+    let long = cx
+        .cx
+        .debug_bounds("mdlp-cell-0-1")
+        .expect("long cell rendered");
+    let short = cx
+        .cx
+        .debug_bounds("mdlp-cell-1-1")
+        .expect("short cell rendered");
+
+    assert!(
+        long.size.height > short.size.height,
+        "long cell content must wrap inside its column and grow the row, got long={:?} short={:?}",
+        long.size,
+        short.size
+    );
+}
+
 // --- Contract tests ---
 //
 // These pin behavior this crate relies on from `editor` and `gpui` rather than


### PR DESCRIPTION
Table cells in the live-preview table widget are flex containers, so the `MarkdownElement` inside each cell is a flex item with `min-width: auto`. GPUI text measured without a definite width reports its whole unwrapped line as its min-content size, so the cell shrank to its column share while the text kept its full width and spilled past the cell border. Any row holding a long path or URL overflowed the table.

Giving the cell content an explicit `min-width: 0` lets it shrink to the column, which hands the text a definite width to wrap against.

## Verification

Measured from a real rendered window via `debug_bounds`:

| | long cell | short cell |
| --- | --- | --- |
| before | 1036px x 33px | 1036px x 33px |
| after | 1036px x 54px | 1036px x 33px |

Before, a ~170-character cell rendered on one line and overflowed its border. After, it wraps to two lines and the row grows, and the following row starts exactly at the taller row's bottom edge, so the table reflows correctly.

`test_table_cell_wraps_long_content` fails on the old code and passes on the new one. All 35 tests in the crate pass.

## Suggested .rules additions

Proposing this for `crates/markdown_live_preview/.rules` (a trap, not a map) — reviewer's call:

> Text inside a flex container needs `min_w_0()` on its wrapper to wrap. A flex item's automatic minimum size is its min-content width, and GPUI measures text without a definite width as one unwrapped line, so long content silently overflows its container instead of wrapping.

Release Notes:

- Fixed long content in markdown live-preview table cells overflowing the table instead of wrapping.