### PR TITLE
Render inline and display LaTeX math in markdown buffers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ The fork's own changes are small and additive:
 | Area | Files |
 | --- | --- |
 | Live preview (the feature) | `crates/markdown_live_preview/` |
+| LaTeX math rendering for live preview | `crates/math_render/` |
 | PDF viewer (adopted from zed#51040) | `crates/pdf_viewer/` |
 | Live Typst/LaTeX preview | `crates/typeset_preview/` |
 | Concealment + highlight hooks live preview needs | `crates/editor/src/display_map.rs`, `display_map/fold_map.rs`, `fold.rs` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "accesskit"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5297,7 +5313,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6109,7 +6125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6466,6 +6482,17 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fancy-regex"
@@ -7352,7 +7379,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11067,6 +11094,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "math_render"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gpui",
+ "ratex-layout",
+ "ratex-parser",
+ "ratex-svg",
+ "ratex-types",
+ "usvg",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11920,7 +11960,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12909,6 +12949,15 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
 
 [[package]]
 name = "p256"
@@ -14674,7 +14723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes 1.11.1",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.11.0",
  "log",
  "multimap",
@@ -15008,7 +15057,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15186,6 +15235,114 @@ name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "ratex-font"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7b73531dabe934a3e725ed5c90d18dacf43778b7a208381390943a9a8c24db"
+dependencies = [
+ "phf 0.11.3",
+ "ratex-types",
+]
+
+[[package]]
+name = "ratex-font-loader"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6542b55c6273b2ca3eb66021da061dfc84bc8303b434e1332218b63728742b7e"
+dependencies = [
+ "ab_glyph",
+ "ratex-font",
+ "ratex-katex-fonts",
+ "ratex-types",
+ "ratex-unicode-font",
+]
+
+[[package]]
+name = "ratex-katex-fonts"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c915a17fd71c41374d1ec19651a26ca352e757e1342391c2cbc5b825dacaa64b"
+dependencies = [
+ "rust-embed",
+]
+
+[[package]]
+name = "ratex-layout"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792738e2e36683cd20de742296a5233759565efc8cd03831064a0ccfb1fe0f7"
+dependencies = [
+ "ratex-font",
+ "ratex-parser",
+ "ratex-types",
+ "serde_json",
+]
+
+[[package]]
+name = "ratex-lexer"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f704add86d7bf4c4ecc7767f45ab38a44f1bbfa4b49725b2ae53c32e83b8a61e"
+dependencies = [
+ "ratex-types",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ratex-parser"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "079ec2e7ac6bc76137a6de093a173d1f901139a51318589ab9ce17139c21a6f0"
+dependencies = [
+ "fancy-regex 0.14.0",
+ "ratex-font",
+ "ratex-lexer",
+ "ratex-types",
+ "regex",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "ratex-svg"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a0948b4d4926858332fe04471e861f54103e655a64f74cc1b3eac0c59bf67bb"
+dependencies = [
+ "ab_glyph",
+ "base64 0.22.1",
+ "ratex-font",
+ "ratex-font-loader",
+ "ratex-katex-fonts",
+ "ratex-types",
+ "ratex-unicode-font",
+]
+
+[[package]]
+name = "ratex-types"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cf0be3d050525f0f7d37af55a443d7648c222ccc617639950e3de1f8e6f9900"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "ratex-unicode-font"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c460464b7fba27343b2b391179ac6c86fcffac5116455158e2b08ce80866fd8"
+dependencies = [
+ "fontdb",
+ "system-fonts",
+ "ttf-parser",
+]
 
 [[package]]
 name = "rav1e"
@@ -16164,7 +16321,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17569,7 +17726,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -18587,6 +18744,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-fonts"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46ba78ea149d4bb0626dacad10aa789eedc83395889890a0e6e7ec69a4577442"
+dependencies = [
+ "fontdb",
+ "sys-locale",
+ "web-sys",
+]
+
+[[package]]
 name = "system-interface"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18795,7 +18963,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20241,9 +20409,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
@@ -21869,7 +22037,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10981,6 +10981,7 @@ dependencies = [
 name = "markdown_live_preview"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "collections",
  "editor",
  "gpui",
@@ -10988,6 +10989,7 @@ dependencies = [
  "language",
  "log",
  "markdown",
+ "math_render",
  "multi_buffer",
  "pretty_assertions",
  "project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ members = [
     "crates/markdown",
     "crates/markdown_live_preview",
     "crates/markdown_preview",
+    "crates/math_render",
     "crates/media",
     "crates/menu",
     "crates/mermaid_render",
@@ -405,6 +406,7 @@ lsp_locations = { path = "crates/lsp_locations" }
 markdown = { path = "crates/markdown" }
 markdown_live_preview = { path = "crates/markdown_live_preview" }
 markdown_preview = { path = "crates/markdown_preview" }
+math_render = { path = "crates/math_render" }
 media = { path = "crates/media" }
 menu = { path = "crates/menu" }
 mermaid_render = { path = "crates/mermaid_render" }
@@ -767,6 +769,10 @@ pulldown-cmark = { version = "0.13.0", default-features = false }
 quick-xml = "0.38"
 quote = "1.0.9"
 rand = "0.9"
+ratex-layout = "0.1.14"
+ratex-parser = "0.1.14"
+ratex-svg = "0.1.14"
+ratex-types = "0.1.14"
 raw-window-handle = "0.6"
 rayon = "1.8"
 regex = "1.5"

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -2638,7 +2638,7 @@ pub fn paste_clipboard_image(editor: &Editor, cx: &mut App) -> bool {
         .trim_matches('/')
         .to_string();
     let attachments_directory = if attachments_folder.is_empty() {
-        note_directory.clone()
+        note_directory
     } else {
         note_directory.join(&attachments_folder)
     };

--- a/crates/grammars/src/markdown-inline/injections.scm
+++ b/crates/grammars/src/markdown-inline/injections.scm
@@ -1,6 +1,3 @@
 ((html_tag) @injection.content
   (#set! injection.language "html")
   (#set! injection.combined))
-
-((latex_block) @injection.content
-  (#set! injection.language "latex"))

--- a/crates/markdown_live_preview/Cargo.toml
+++ b/crates/markdown_live_preview/Cargo.toml
@@ -12,12 +12,14 @@ workspace = true
 path = "src/markdown_live_preview.rs"
 
 [dependencies]
+anyhow.workspace = true
 collections.workspace = true
 editor.workspace = true
 gpui.workspace = true
 log.workspace = true
 language.workspace = true
 markdown.workspace = true
+math_render.workspace = true
 multi_buffer.workspace = true
 settings.workspace = true
 text.workspace = true

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -19,12 +19,13 @@ use editor::{
     },
 };
 use gpui::{
-    App, AppContext as _, Context, Empty, Entity, Focusable as _, FontWeight, HighlightStyle,
+    App, AppContext as _, Context, Empty, Entity, Focusable as _, FontWeight, HighlightStyle, Hsla,
     ImageSource, IntoElement, MouseButton, Resource, SharedString, SharedUri, StrikethroughStyle,
-    Subscription, TextStyleRefinement, WeakEntity, Window, actions, rems,
+    Subscription, TextStyleRefinement, WeakEntity, Window, actions, img, rems,
 };
 use language::LanguageName;
 use markdown::{HeadingLevelStyles, Markdown, MarkdownElement, MarkdownFont, MarkdownStyle};
+use math_render::{MathStyle, MathTheme};
 use multi_buffer::{
     Anchor, MultiBufferOffset, MultiBufferRow, MultiBufferSnapshot, ToOffset as _, ToPoint as _,
 };
@@ -75,21 +76,23 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
     }
 
     let mut subscriptions = Vec::new();
-    subscriptions.push(cx.subscribe_self(|editor, event: &EditorEvent, cx| match event {
-        EditorEvent::Reparsed(_) => recompute(editor, cx),
-        EditorEvent::SelectionsChanged { .. } => {
-            if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
-                let resizing = addon
-                    .last_resize_at
-                    .is_some_and(|at| at.elapsed() < std::time::Duration::from_millis(500));
-                if !resizing {
-                    addon.selected_image = None;
+    subscriptions.push(
+        cx.subscribe_self(|editor, event: &EditorEvent, cx| match event {
+            EditorEvent::Reparsed(_) => recompute(editor, cx),
+            EditorEvent::SelectionsChanged { .. } => {
+                if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                    let resizing = addon
+                        .last_resize_at
+                        .is_some_and(|at| at.elapsed() < std::time::Duration::from_millis(500));
+                    if !resizing {
+                        addon.selected_image = None;
+                    }
                 }
+                apply_decorations(editor, cx);
             }
-            apply_decorations(editor, cx);
-        }
-        _ => {}
-    }));
+            _ => {}
+        }),
+    );
 
     subscriptions.push(cx.observe_global::<theme::GlobalTheme>(|editor, cx| {
         let markers = editor
@@ -104,9 +107,9 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
             weak_editor
                 .update(cx, |editor, cx| {
                     if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
-                        let enabled = addon.enabled_override.unwrap_or_else(|| {
-                            MarkdownLivePreviewSettings::get_global(cx).enabled
-                        });
+                        let enabled = addon
+                            .enabled_override
+                            .unwrap_or_else(|| MarkdownLivePreviewSettings::get_global(cx).enabled);
                         addon.enabled_override = Some(!enabled);
                     }
                     recompute(editor, cx);
@@ -121,7 +124,9 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
     subscriptions.push(
         editor.register_action::<editor::actions::Paste>(move |_, _window, cx| {
             let handled = weak_editor
-                .update(cx, |editor, cx| editor::items::paste_clipboard_image(editor, cx))
+                .update(cx, |editor, cx| {
+                    editor::items::paste_clipboard_image(editor, cx)
+                })
                 .unwrap_or(false);
             if !handled {
                 cx.propagate();
@@ -132,13 +137,13 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
     // Backspace/Delete removes a selected table row/column (Obsidian-style)
     // instead of editing text; without a selection they pass through.
     let weak_editor = cx.weak_entity();
-    subscriptions.push(
-        editor.register_action::<editor::actions::Backspace>(move |_, _window, cx| {
+    subscriptions.push(editor.register_action::<editor::actions::Backspace>(
+        move |_, _window, cx| {
             if !delete_selected_table_unit(&weak_editor, cx) {
                 cx.propagate();
             }
-        }),
-    );
+        },
+    ));
     let weak_editor = cx.weak_entity();
     subscriptions.push(
         editor.register_action::<editor::actions::Delete>(move |_, _window, cx| {
@@ -268,6 +273,16 @@ enum InlineKind {
         /// The range of the `[ ]`/`[x]` marker itself, edited on toggle.
         marker_range: Range<Anchor>,
     },
+    /// A LaTeX formula (`$x$` or `$$x$$`), rendered as a typeset image.
+    ///
+    /// Rendering is asynchronous, so the placeholder reads whatever the shared
+    /// [`MathCache`] holds for `source`; until that resolves it falls back to
+    /// the LaTeX source, which is also what a formula that fails to parse keeps
+    /// showing.
+    Math {
+        source: SharedString,
+        style: MathStyle,
+    },
 }
 
 struct BlockMarker {
@@ -300,6 +315,14 @@ enum BlockRenderKind {
         display_width: Option<f32>,
         destination: Option<String>,
         alt: String,
+    },
+    /// Display math (`$$...$$` alone on its lines), rendered as a centered
+    /// typeset formula. Unlike other blocks, revealing its source does not
+    /// remove the widget: the rendering stays below the source lines and
+    /// live-updates while the formula is edited, following Obsidian.
+    Math {
+        /// The LaTeX between the delimiters.
+        source: String,
     },
 }
 
@@ -375,6 +398,9 @@ struct ActiveTableCell {
 struct AppliedBlock {
     range: Range<Anchor>,
     source: String,
+    /// True when the widget is placed below its source lines instead of
+    /// replacing them — display math while its source is revealed.
+    below: bool,
     block_id: CustomBlockId,
 }
 
@@ -418,7 +444,11 @@ const CITATION: usize = 6;
 /// bold/italic styling, overriding the theme's source-mode markup colors
 /// (e.g. blue non-slanted italics, orange bold), plus a real line-through for
 /// strikethrough, which themes color but never strike.
-fn apply_emphasis_highlights(editor: &mut Editor, markers: Option<&MarkerSet>, cx: &mut Context<Editor>) {
+fn apply_emphasis_highlights(
+    editor: &mut Editor,
+    markers: Option<&MarkerSet>,
+    cx: &mut Context<Editor>,
+) {
     let text_color = cx.theme().colors().text;
     let accent_color = cx.theme().colors().text_accent;
     let muted_color = cx.theme().colors().text_muted;
@@ -550,15 +580,33 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
         // the rest of the line rendered.
         let reveal_span = match &marker.kind {
             InlineKind::Hide { reveal_span } => reveal_span,
-            InlineKind::Bullet | InlineKind::Checkbox { .. } => &marker.range,
+            // Math reveals when the selection touches the formula, so putting
+            // the cursor in it hands back the LaTeX to edit.
+            InlineKind::Bullet | InlineKind::Checkbox { .. } | InlineKind::Math { .. } => {
+                &marker.range
+            }
         };
-        let span =
-            reveal_span.start.to_offset(&snapshot).0..reveal_span.end.to_offset(&snapshot).0;
+        let span = reveal_span.start.to_offset(&snapshot).0..reveal_span.end.to_offset(&snapshot).0;
         let revealed = selection_offsets
             .iter()
             .any(|selection| selection.start <= span.end && span.start <= selection.end);
         if revealed {
             continue;
+        }
+        // Start the render here rather than in the placeholder closure, which
+        // runs every frame; by the time it draws, the cache holds at least a
+        // pending entry.
+        if let InlineKind::Math { source, style } = &marker.kind {
+            let text_color = cx.theme().colors().editor_foreground;
+            request_math_render(
+                MathKey {
+                    source: source.clone(),
+                    style: *style,
+                    color: u32::from(gpui::Rgba::from(text_color)),
+                },
+                text_color,
+                cx,
+            );
         }
         concealments.push(Concealment {
             range: marker.range.clone(),
@@ -570,13 +618,15 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
 
     // --- Block widgets ---
 
-    let mut desired_blocks: HashMap<(usize, usize), (&BlockMarker, String)> = HashMap::default();
+    let mut desired_blocks: HashMap<(usize, usize), (&BlockMarker, String, bool)> =
+        HashMap::default();
     for marker in &markers.blocks {
         let start = marker.range.start.to_point(&snapshot);
         let end = marker.range.end.to_point(&snapshot);
         if start > end {
             continue;
         }
+        let mut below = false;
         if rows_intersect(&selection_rows, start.row, end.row) {
             // Casual clicks land the cursor on widget rows constantly, which
             // made tables and images explode into source; those two reveal
@@ -590,7 +640,12 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
                 let revealed_end = revealed.end.to_point(&snapshot).row;
                 revealed_start <= end.row && start.row <= revealed_end
             });
-            if !needs_explicit_reveal || explicitly_revealed {
+            if matches!(marker.kind, BlockRenderKind::Math { .. }) {
+                // Editing display math keeps the rendering on screen: the
+                // widget moves below the revealed source and live-updates
+                // as the formula is typed, following Obsidian.
+                below = true;
+            } else if !needs_explicit_reveal || explicitly_revealed {
                 continue;
             }
         }
@@ -610,7 +665,7 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
             source.push_str("\n\n");
             source.push_str(&markers.definitions);
         }
-        desired_blocks.insert((start_offset.0, end_offset.0), (marker, source));
+        desired_blocks.insert((start_offset.0, end_offset.0), (marker, source, below));
     }
 
     let mut new_applied_blocks = Vec::new();
@@ -620,7 +675,7 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
         let end = applied.range.end.to_offset(&snapshot).0;
         let keep = desired_blocks
             .get(&(start, end))
-            .is_some_and(|(_, source)| *source == applied.source);
+            .is_some_and(|(_, source, below)| *source == applied.source && *below == applied.below);
         if keep {
             desired_blocks.remove(&(start, end));
             new_applied_blocks.push(applied);
@@ -639,7 +694,7 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
         .read(cx)
         .as_singleton()
         .and_then(|buffer| buffer.read(cx).language_registry());
-    for (marker, source) in desired_blocks.into_values() {
+    for (marker, source, below) in desired_blocks.into_values() {
         let render = match &marker.kind {
             BlockRenderKind::Markdown => {
                 let markdown = cx.new(|cx| {
@@ -727,22 +782,46 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
                     SharedString::from(alt.clone()),
                 )
             }
-            BlockRenderKind::Rule => {
-                render_rule_block(weak_editor.clone(), marker.range.clone(), marker.indent_columns)
-            }
+            BlockRenderKind::Rule => render_rule_block(
+                weak_editor.clone(),
+                marker.range.clone(),
+                marker.indent_columns,
+            ),
             BlockRenderKind::Frontmatter => {
                 render_frontmatter_block(weak_editor.clone(), marker.range.clone(), source.clone())
             }
-
+            BlockRenderKind::Math { source } => {
+                let text_color = cx.theme().colors().editor_foreground;
+                request_math_render(
+                    MathKey {
+                        source: SharedString::from(source.clone()),
+                        style: MathStyle::Display,
+                        color: u32::from(gpui::Rgba::from(text_color)),
+                    },
+                    text_color,
+                    cx,
+                );
+                render_math_block(
+                    weak_editor.clone(),
+                    marker.range.clone(),
+                    SharedString::from(source.clone()),
+                    below,
+                )
+            }
+        };
+        let placement = if below {
+            BlockPlacement::Below(marker.range.end)
+        } else {
+            BlockPlacement::Replace(marker.range.start..=marker.range.end)
         };
         blocks_to_insert.push(BlockProperties {
-            placement: BlockPlacement::Replace(marker.range.start..=marker.range.end),
+            placement,
             height: Some(marker.height_estimate),
             style: BlockStyle::Flex,
             render,
             priority: 0,
         });
-        pending_applied.push((marker.range.clone(), source));
+        pending_applied.push((marker.range.clone(), source, below));
     }
 
     if !block_ids_to_remove.is_empty() {
@@ -750,10 +829,11 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
     }
     if !blocks_to_insert.is_empty() {
         let block_ids = editor.insert_blocks(blocks_to_insert, None, cx);
-        for ((range, source), block_id) in pending_applied.into_iter().zip(block_ids) {
+        for ((range, source, below), block_id) in pending_applied.into_iter().zip(block_ids) {
             new_applied_blocks.push(AppliedBlock {
                 range,
                 source,
+                below,
                 block_id,
             });
         }
@@ -852,13 +932,119 @@ fn rows_intersect(selection_rows: &[Range<u32>], start_row: u32, end_row: u32) -
         .any(|rows| rows.start <= end_row && start_row <= rows.end)
 }
 
+/// Identity of a rendered formula. Two formulas that agree on every field
+/// rasterize identically, so the cache is shared across editors: the same
+/// equation in two panes is typeset once.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct MathKey {
+    source: SharedString,
+    style: MathStyle,
+    /// Packed RGBA, since `Hsla` is not hashable and the color is baked into
+    /// the SVG's fill.
+    color: u32,
+}
+
+enum MathEntry {
+    /// A background render is in flight; callers show the LaTeX source.
+    Pending,
+    Ready {
+        image: Arc<gpui::RenderImage>,
+        /// Fraction of the image's height that sits below the text baseline.
+        baseline_fraction: f32,
+        /// Width of the image in ems, used to size the inline element so it
+        /// takes exactly the space the glyphs occupy.
+        width_em: f32,
+        height_em: f32,
+    },
+    /// The formula does not parse. Callers keep showing the source, which is
+    /// also what the user needs to see in order to fix it.
+    Failed,
+}
+
+/// Rasterized formulas, keyed by content.
+///
+/// This is a global rather than per-editor state because rendering depends
+/// only on [`MathKey`], and because the placeholder closure that reads it
+/// receives just an `&mut App`.
+#[derive(Default)]
+struct MathCache {
+    entries: HashMap<MathKey, MathEntry>,
+}
+
+impl gpui::Global for MathCache {}
+
+/// Em size the SVG is rasterized at. Larger than any realistic buffer font so
+/// the outlines stay crisp when the element scales them down to the line's
+/// actual size.
+const MATH_RASTER_EM: f32 = 64.0;
+
+/// Ensures a render for `key` is in flight or complete, and returns whether
+/// the cache already holds a finished image.
+///
+/// Called from `apply_decorations` rather than from the placeholder closure:
+/// kicking off work during render would spawn a task on every frame.
+fn request_math_render(key: MathKey, text_color: Hsla, cx: &mut App) {
+    if cx.default_global::<MathCache>().entries.contains_key(&key) {
+        return;
+    }
+    cx.global_mut::<MathCache>()
+        .entries
+        .insert(key.clone(), MathEntry::Pending);
+
+    let svg_renderer = cx.svg_renderer();
+    let theme = MathTheme {
+        text_color,
+        font_size: MATH_RASTER_EM,
+    };
+    cx.spawn(async move |cx| {
+        let rendered = cx
+            .background_spawn({
+                let key = key.clone();
+                async move {
+                    let rendered = math_render::render_to_svg(&key.source, key.style, &theme)?;
+                    let image = svg_renderer
+                        .render_single_frame(rendered.svg.as_bytes(), 1.0)
+                        .map_err(|error| anyhow::anyhow!("{error}"))?;
+                    anyhow::Ok((rendered, image))
+                }
+            })
+            .await;
+
+        cx.update(|cx| {
+            let entry = match rendered {
+                Ok((rendered, image)) => {
+                    let total_em = rendered.height_em + rendered.depth_em;
+                    let size = image.size(0);
+                    let width_em = if total_em > 0.0 && size.height.0 > 0 {
+                        size.width.0 as f32 / size.height.0 as f32 * total_em
+                    } else {
+                        0.0
+                    };
+                    MathEntry::Ready {
+                        image,
+                        baseline_fraction: rendered.baseline_fraction(),
+                        width_em,
+                        height_em: total_em,
+                    }
+                }
+                Err(_) => MathEntry::Failed,
+            };
+            cx.global_mut::<MathCache>().entries.insert(key, entry);
+            // The placeholder closures read the cache during render, so every
+            // open editor needs a repaint to pick the new image up.
+            cx.refresh_windows();
+        });
+    })
+    .detach();
+}
+
 fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPlaceholder {
     // Pure hides collapse to zero-width text; bullets and checkboxes keep the
     // default placeholder text, whose visual is replaced by the rendered
     // element at its measured width.
     let collapsed_text = match &marker.kind {
         InlineKind::Hide { .. } => Some(SharedString::new_static("")),
-        InlineKind::Bullet | InlineKind::Checkbox { .. } => None,
+        InlineKind::Bullet | InlineKind::Checkbox { .. } | InlineKind::Math { .. } => None,
     };
     let render: Arc<dyn Send + Sync + Fn(_, _, &mut App) -> gpui::AnyElement> = match &marker.kind {
         InlineKind::Hide { .. } => Arc::new(|_, _, _| Empty.into_any_element()),
@@ -894,6 +1080,59 @@ fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPl
                 .into_any_element()
             })
         }
+        InlineKind::Math { source, style } => {
+            let source = source.clone();
+            let style = *style;
+            Arc::new(move |_, _, cx: &mut App| {
+                let theme_settings = theme_settings::ThemeSettings::get_global(cx);
+                let font_size = theme_settings.buffer_font_size(cx);
+                let buffer_font = theme_settings.buffer_font.clone();
+                let text_color = cx.theme().colors().editor_foreground;
+                let key = MathKey {
+                    source: source.clone(),
+                    style,
+                    color: u32::from(gpui::Rgba::from(text_color)),
+                };
+
+                match cx.default_global::<MathCache>().entries.get(&key) {
+                    Some(MathEntry::Ready {
+                        image,
+                        baseline_fraction,
+                        width_em,
+                        height_em,
+                    }) => {
+                        let height = font_size * *height_em;
+                        let width = font_size * *width_em;
+                        // Shift down by the part of the formula that hangs
+                        // below the baseline, so the typeset baseline lands on
+                        // the surrounding text's baseline instead of the
+                        // image floating mid-line.
+                        let descent = height * *baseline_fraction;
+                        div()
+                            .h(height)
+                            .w(width)
+                            .child(
+                                img(ImageSource::Render(image.clone()))
+                                    .h(height)
+                                    .w(width)
+                                    .relative()
+                                    .top(descent),
+                            )
+                            .into_any_element()
+                    }
+                    // While a render is in flight — and permanently for a
+                    // formula that does not parse — fall back to the LaTeX
+                    // source, so the text never disappears out from under
+                    // the user.
+                    Some(MathEntry::Pending) | Some(MathEntry::Failed) | None => div()
+                        .font(buffer_font)
+                        .text_size(font_size)
+                        .text_color(text_color)
+                        .child(source.clone())
+                        .into_any_element(),
+                }
+            })
+        }
     };
     FoldPlaceholder {
         render,
@@ -909,6 +1148,17 @@ fn marker_content_key(kind: &InlineKind) -> u64 {
         InlineKind::Hide { .. } => 0,
         InlineKind::Bullet => 1,
         InlineKind::Checkbox { checked, .. } => 2 + u64::from(*checked),
+        // Editing a formula changes what its placeholder must draw even though
+        // its range is unchanged, so the source has to take part in the key or
+        // the concealment is reused with a stale image.
+        InlineKind::Math { source, style } => {
+            use std::hash::{Hash as _, Hasher as _};
+            let mut hasher = collections::FxHasher::default();
+            source.hash(&mut hasher);
+            style.hash(&mut hasher);
+            // Keep clear of the discriminants above.
+            4 + hasher.finish()
+        }
     }
 }
 
@@ -983,13 +1233,16 @@ fn render_markdown_block(
     })
 }
 
-
 /// Per-column flex weights approximating content-based column sizing.
 fn table_column_weights(structure: &TableStructure, snapshot: &MultiBufferSnapshot) -> Vec<f32> {
-    let columns = structure
-        .header
-        .len()
-        .max(structure.rows.iter().map(|row| row.len()).max().unwrap_or(0));
+    let columns = structure.header.len().max(
+        structure
+            .rows
+            .iter()
+            .map(|row| row.len())
+            .max()
+            .unwrap_or(0),
+    );
     let mut weights = vec![3.0_f32; columns];
     let mut measure = |cells: &[Range<Anchor>]| {
         for (index, range) in cells.iter().enumerate() {
@@ -1094,24 +1347,22 @@ fn start_cell_edit(
             },
         ));
         let weak = weak_editor.clone();
-        subscriptions.push(editor.register_action::<editor::actions::Tab>(
-            move |_, window, cx| {
+        subscriptions.push(
+            editor.register_action::<editor::actions::Tab>(move |_, window, cx| {
                 let next = next_cell.clone();
                 weak.update(cx, |editor, cx| {
                     commit_active_cell(editor, cx);
                 })
                 .log_err();
                 match next {
-                    Some(next) => {
-                        start_cell_edit(weak.clone(), next, window, cx)
-                    }
+                    Some(next) => start_cell_edit(weak.clone(), next, window, cx),
                     None => {
                         weak.update(cx, |editor, cx| refocus_main_editor(editor, window, cx))
                             .log_err();
                     }
                 }
-            },
-        ));
+            }),
+        );
         let weak = weak_editor.clone();
         subscriptions.push(editor.register_action::<editor::actions::Cancel>(
             move |_, window, cx| {
@@ -1349,8 +1600,8 @@ fn parse_table_at(
     }
     // The block may over-extend into adjacent prose that happens to contain a
     // pipe; anchor on the delimiter row and take the line above as header.
-    let delimiter_row = (first_row + 1..=last_row)
-        .find(|row| is_delimiter_row(&line_at(*row).0))?;
+    let delimiter_row =
+        (first_row + 1..=last_row).find(|row| is_delimiter_row(&line_at(*row).0))?;
     let header_row = delimiter_row - 1;
 
     let split_row = |row: u32| -> Vec<Range<Anchor>> {
@@ -1379,7 +1630,9 @@ fn parse_table_at(
     let mut rows: Vec<Vec<Range<Anchor>>> = (delimiter_row + 1..=last_row).map(split_row).collect();
 
     let mut header = header;
-    let columns = header.len().max(rows.iter().map(|row| row.len()).max().unwrap_or(0));
+    let columns = header
+        .len()
+        .max(rows.iter().map(|row| row.len()).max().unwrap_or(0));
     let sentinel = || Anchor::Min..Anchor::Min;
     header.resize_with(columns, sentinel);
     for row in &mut rows {
@@ -1387,7 +1640,8 @@ fn parse_table_at(
     }
 
     let table_start = Point::new(header_row, 0).to_offset(snapshot);
-    let table_end = Point::new(last_row, snapshot.line_len(MultiBufferRow(last_row))).to_offset(snapshot);
+    let table_end =
+        Point::new(last_row, snapshot.line_len(MultiBufferRow(last_row))).to_offset(snapshot);
     Some((
         table_start..table_end,
         TableStructure {
@@ -1402,8 +1656,14 @@ fn parse_table_at(
 enum TableStructuralChange {
     AddColumn,
     AddRow,
-    MoveRow { from: usize, to: usize },
-    MoveColumn { from: usize, to: usize },
+    MoveRow {
+        from: usize,
+        to: usize,
+    },
+    MoveColumn {
+        from: usize,
+        to: usize,
+    },
     DeleteRow(usize),
     DeleteColumn(usize),
     /// Rewrites the table without structural additions, materializing any
@@ -1433,7 +1693,9 @@ fn apply_table_structural_change(
 ) {
     commit_active_cell(editor, cx);
     let Some((table_offsets, structure)) = fresh_table_at(editor, stale_table_range, cx) else {
-        log::warn!("markdown live preview: no table found at click position; ignoring structural change");
+        log::warn!(
+            "markdown live preview: no table found at click position; ignoring structural change"
+        );
         return;
     };
     let structure = &structure;
@@ -1656,7 +1918,9 @@ fn render_table_block(
                 (Some(TableUnit::Column(_)), Some(TableBoundary::Column(boundary))) => {
                     if boundary == column {
                         Some(false)
-                    } else if boundary == structure.header.len() && column + 1 == structure.header.len() {
+                    } else if boundary == structure.header.len()
+                        && column + 1 == structure.header.len()
+                    {
                         Some(true)
                     } else {
                         None
@@ -1684,7 +1948,9 @@ fn render_table_block(
                 .debug_selector(|| {
                     format!(
                         "mdlp-cell-{}-{column}",
-                        data_row.map(|row| row.to_string()).unwrap_or_else(|| "h".into())
+                        data_row
+                            .map(|row| row.to_string())
+                            .unwrap_or_else(|| "h".into())
                     )
                 })
                 .flex_grow(1.)
@@ -1706,7 +1972,8 @@ fn render_table_block(
                     _ => this,
                 })
                 .when(is_header, |this| {
-                    this.bg(colors.elevated_surface_background).font_weight(FontWeight::BOLD)
+                    this.bg(colors.elevated_surface_background)
+                        .font_weight(FontWeight::BOLD)
                 })
                 .when(in_selected_unit, |this| {
                     this.bg(colors.element_selected)
@@ -1754,21 +2021,20 @@ fn render_table_block(
                 // in normalized form so the cell exists to edit.
                 let weak = editor.clone();
                 let normalize_range = table_range.clone();
-                cell = cell.cursor_text().on_mouse_down(
-                    MouseButton::Left,
-                    move |_, _window, cx| {
-                        cx.stop_propagation();
-                        weak.update(cx, |editor, cx| {
-                            apply_table_structural_change(
-                                editor,
-                                &normalize_range,
-                                TableStructuralChange::Normalize,
-                                cx,
-                            );
-                        })
-                        .log_err();
-                    },
-                );
+                cell =
+                    cell.cursor_text()
+                        .on_mouse_down(MouseButton::Left, move |_, _window, cx| {
+                            cx.stop_propagation();
+                            weak.update(cx, |editor, cx| {
+                                apply_table_structural_change(
+                                    editor,
+                                    &normalize_range,
+                                    TableStructuralChange::Normalize,
+                                    cx,
+                                );
+                            })
+                            .log_err();
+                        });
             } else {
                 let weak = editor.clone();
                 let cell_range = cell_range.clone();
@@ -1856,61 +2122,63 @@ fn render_table_block(
 
         let mut grid = v_flex().flex_grow(1.);
         // Column handles.
-        grid = grid.child(
-            h_flex().child(div().w(handle_width)).children(
-                structure.header.iter().enumerate().map(|(column, _)| {
-                    let weight = column_weights.get(column).copied().unwrap_or(8.);
-                    let selected = selected_unit == Some(TableUnit::Column(column));
-                    div()
-                        .id(("mdlp-column-handle", column))
-                        .debug_selector(|| format!("mdlp-column-handle-{column}"))
-                        .flex_grow(1.)
-                        .flex_basis(gpui::px(weight * 8.))
-                        .min_w(gpui::px(48.))
-                        .h(gpui::px(10.))
-                        .px_2()
-                        .cursor_pointer()
-                        .child(handle_pill(selected).w_full().h(gpui::px(4.)).mt(gpui::px(3.)))
-                        .on_mouse_down(MouseButton::Left, record_press.clone())
-                        .on_mouse_up(MouseButton::Left, select_unit(TableUnit::Column(column)))
-                        .on_drag_move::<TableColumnDrag>({
-                            let weak = editor.clone();
-                            let strip_table_range = table_range.clone();
-                            move |event, _, cx| {
-                                if !event.bounds.contains(&event.event.position) {
-                                    return;
-                                }
-                                if event.drag(cx).table_start != strip_table_range.start {
-                                    return;
-                                }
-                                let after = event.event.position.x > event.bounds.center().x;
-                                let boundary =
-                                    TableBoundary::Column(column + usize::from(after));
-                                set_drop_boundary(&weak, &strip_table_range, boundary, cx);
+        grid = grid.child(h_flex().child(div().w(handle_width)).children(
+            structure.header.iter().enumerate().map(|(column, _)| {
+                let weight = column_weights.get(column).copied().unwrap_or(8.);
+                let selected = selected_unit == Some(TableUnit::Column(column));
+                div()
+                    .id(("mdlp-column-handle", column))
+                    .debug_selector(|| format!("mdlp-column-handle-{column}"))
+                    .flex_grow(1.)
+                    .flex_basis(gpui::px(weight * 8.))
+                    .min_w(gpui::px(48.))
+                    .h(gpui::px(10.))
+                    .px_2()
+                    .cursor_pointer()
+                    .child(
+                        handle_pill(selected)
+                            .w_full()
+                            .h(gpui::px(4.))
+                            .mt(gpui::px(3.)),
+                    )
+                    .on_mouse_down(MouseButton::Left, record_press.clone())
+                    .on_mouse_up(MouseButton::Left, select_unit(TableUnit::Column(column)))
+                    .on_drag_move::<TableColumnDrag>({
+                        let weak = editor.clone();
+                        let strip_table_range = table_range.clone();
+                        move |event, _, cx| {
+                            if !event.bounds.contains(&event.event.position) {
+                                return;
                             }
-                        })
-                        .on_drag(
-                            TableColumnDrag {
-                                table_start: table_range.start,
-                                column,
-                            },
-                            {
-                                let weak = editor.clone();
-                                let drag_table_range = table_range.clone();
-                                move |_, _, _, cx| {
-                                    record_drag_source(
-                                        &weak,
-                                        &drag_table_range,
-                                        TableUnit::Column(column),
-                                        cx,
-                                    );
-                                    cx.new(|_| EmptyDragPreview)
-                                }
-                            },
-                        )
-                }),
-            ),
-        );
+                            if event.drag(cx).table_start != strip_table_range.start {
+                                return;
+                            }
+                            let after = event.event.position.x > event.bounds.center().x;
+                            let boundary = TableBoundary::Column(column + usize::from(after));
+                            set_drop_boundary(&weak, &strip_table_range, boundary, cx);
+                        }
+                    })
+                    .on_drag(
+                        TableColumnDrag {
+                            table_start: table_range.start,
+                            column,
+                        },
+                        {
+                            let weak = editor.clone();
+                            let drag_table_range = table_range.clone();
+                            move |_, _, _, cx| {
+                                record_drag_source(
+                                    &weak,
+                                    &drag_table_range,
+                                    TableUnit::Column(column),
+                                    cx,
+                                );
+                                cx.new(|_| EmptyDragPreview)
+                            }
+                        },
+                    )
+            }),
+        ));
         let row_handle = |data_row: Option<usize>| {
             let container = div().w(handle_width).py_1().pr(gpui::px(4.)).flex();
             match data_row {
@@ -1992,40 +2260,11 @@ fn render_table_block(
             }
         };
         let accent = colors.border_focused;
-        grid = grid.child(
-            h_flex()
-                .items_stretch()
-                .when_some(row_insertion(None), |this, after| {
-                    let bar = div()
-                        .absolute()
-                        .left_0()
-                        .right_0()
-                        .h(gpui::px(3.))
-                        .bg(accent);
-                    this.relative().child(if after {
-                        bar.bottom(gpui::px(-2.))
-                    } else {
-                        bar.top(gpui::px(-2.))
-                    })
-                })
-                .on_drag_move::<TableRowDrag>(row_track_drag(None))
-                .child(row_handle(None))
-                .child(h_flex().flex_grow(1.).children(
-                    header_markdown.iter().enumerate().map(|(column, markdown)| {
-                        let empty = Range {
-                            start: Anchor::Min,
-                            end: Anchor::Min,
-                        };
-                        let range = structure.header.get(column).unwrap_or(&empty);
-                        render_cell(range, markdown, column, None)
-                    }),
-                )),
-        );
-        for (row_index, row_markdown) in rows_markdown.iter().enumerate() {
-            grid = grid.child(
+        grid =
+            grid.child(
                 h_flex()
                     .items_stretch()
-                    .when_some(row_insertion(Some(row_index)), |this, after| {
+                    .when_some(row_insertion(None), |this, after| {
                         let bar = div()
                             .absolute()
                             .left_0()
@@ -2038,11 +2277,45 @@ fn render_table_block(
                             bar.top(gpui::px(-2.))
                         })
                     })
-                    .on_drag_move::<TableRowDrag>(row_track_drag(Some(row_index)))
-                    .child(row_handle(Some(row_index)))
+                    .on_drag_move::<TableRowDrag>(row_track_drag(None))
+                    .child(row_handle(None))
                     .child(
-                        h_flex().flex_grow(1.).children(row_markdown.iter().enumerate().map(
-                            |(column, markdown)| {
+                        h_flex()
+                            .flex_grow(1.)
+                            .children(header_markdown.iter().enumerate().map(
+                                |(column, markdown)| {
+                                    let empty = Range {
+                                        start: Anchor::Min,
+                                        end: Anchor::Min,
+                                    };
+                                    let range = structure.header.get(column).unwrap_or(&empty);
+                                    render_cell(range, markdown, column, None)
+                                },
+                            )),
+                    ),
+            );
+        for (row_index, row_markdown) in rows_markdown.iter().enumerate() {
+            grid =
+                grid.child(
+                    h_flex()
+                        .items_stretch()
+                        .when_some(row_insertion(Some(row_index)), |this, after| {
+                            let bar = div()
+                                .absolute()
+                                .left_0()
+                                .right_0()
+                                .h(gpui::px(3.))
+                                .bg(accent);
+                            this.relative().child(if after {
+                                bar.bottom(gpui::px(-2.))
+                            } else {
+                                bar.top(gpui::px(-2.))
+                            })
+                        })
+                        .on_drag_move::<TableRowDrag>(row_track_drag(Some(row_index)))
+                        .child(row_handle(Some(row_index)))
+                        .child(h_flex().flex_grow(1.).children(
+                            row_markdown.iter().enumerate().map(|(column, markdown)| {
                                 let empty = Range {
                                     start: Anchor::Min,
                                     end: Anchor::Min,
@@ -2053,10 +2326,9 @@ fn render_table_block(
                                     .and_then(|row| row.get(column))
                                     .unwrap_or(&empty);
                                 render_cell(range, markdown, column, Some(row_index))
-                            },
+                            }),
                         )),
-                    ),
-            );
+                );
         }
 
         let add_column_editor = editor.clone();
@@ -2066,42 +2338,48 @@ fn render_table_block(
         let reveal_source_editor = editor.clone();
         let reveal_source_range = table_range.clone();
 
-        let unit_button = |id: &'static str,
-                           icon: IconName,
-                           action: Option<(TableStructuralChange, Option<TableUnit>)>| {
-            let weak = editor.clone();
-            let action_range = table_range.clone();
-            let enabled = action.is_some();
-            div()
-                .id(id)
-                .px_1()
-                .py_0p5()
-                .rounded_sm()
-                .child(Icon::new(icon).size(IconSize::XSmall).color(if enabled {
-                    Color::Muted
-                } else {
-                    Color::Disabled
-                }))
-                .when_some(action, move |this, (change, new_unit)| {
-                    this.cursor_pointer()
-                        .hover(|this| this.bg(colors.element_hover))
-                        .on_mouse_down(MouseButton::Left, move |_, _, cx| {
-                            cx.stop_propagation();
-                            weak.update(cx, |editor, cx| {
-                                apply_table_structural_change(editor, &action_range, change, cx);
-                                if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
-                                    addon.selected_table_unit =
-                                        new_unit.map(|unit| TableUnitSelection {
-                                            table_range: action_range.clone(),
-                                            unit,
-                                        });
-                                }
-                                cx.notify();
+        let unit_button =
+            |id: &'static str,
+             icon: IconName,
+             action: Option<(TableStructuralChange, Option<TableUnit>)>| {
+                let weak = editor.clone();
+                let action_range = table_range.clone();
+                let enabled = action.is_some();
+                div()
+                    .id(id)
+                    .px_1()
+                    .py_0p5()
+                    .rounded_sm()
+                    .child(Icon::new(icon).size(IconSize::XSmall).color(if enabled {
+                        Color::Muted
+                    } else {
+                        Color::Disabled
+                    }))
+                    .when_some(action, move |this, (change, new_unit)| {
+                        this.cursor_pointer()
+                            .hover(|this| this.bg(colors.element_hover))
+                            .on_mouse_down(MouseButton::Left, move |_, _, cx| {
+                                cx.stop_propagation();
+                                weak.update(cx, |editor, cx| {
+                                    apply_table_structural_change(
+                                        editor,
+                                        &action_range,
+                                        change,
+                                        cx,
+                                    );
+                                    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                                        addon.selected_table_unit =
+                                            new_unit.map(|unit| TableUnitSelection {
+                                                table_range: action_range.clone(),
+                                                unit,
+                                            });
+                                    }
+                                    cx.notify();
+                                })
+                                .log_err();
                             })
-                            .log_err();
-                        })
-                })
-        };
+                    })
+            };
         let controls = selected_unit.map(|unit| {
             let rows_len = structure.rows.len();
             let columns_len = structure.header.len();
@@ -2112,11 +2390,11 @@ fn render_table_block(
                 TableUnit::Column(column) => (columns_len > 1 && column < columns_len)
                     .then_some((TableStructuralChange::DeleteColumn(column), None)),
             };
-            h_flex()
-                .gap_1()
-                .pb_1()
-                .pl(handle_width)
-                .child(unit_button("mdlp-unit-delete", IconName::Trash, delete))
+            h_flex().gap_1().pb_1().pl(handle_width).child(unit_button(
+                "mdlp-unit-delete",
+                IconName::Trash,
+                delete,
+            ))
         });
 
         let apply_boundary_drop = |weak: WeakEntity<Editor>,
@@ -2222,89 +2500,86 @@ fn render_table_block(
                     .max_w(max_width * 0.95)
                     .children(controls)
                     .child(
-                        h_flex()
-                            .items_stretch()
-                            .child(grid)
-                            .child(
-                                v_flex()
-                                    .w(gpui::px(22.))
-                                    .child(
-                                        // Reveal the table's markdown source.
-                                        div()
-                                            .id("mdlp-table-source")
-                                            .h(gpui::px(22.))
-                                            .flex()
-                                            .items_center()
-                                            .justify_center()
-                                            .cursor_pointer()
-                                            .text_color(colors.text_muted)
-                                            .opacity(0.)
-                                            .group_hover("mdlp-table", |this| this.opacity(0.7))
-                                            .hover(|this| this.opacity(1.))
-                                            .child(
-                                                Icon::new(IconName::Code)
-                                                    .size(IconSize::XSmall)
-                                                    .color(Color::Muted),
-                                            )
-                                            .tooltip(ui::Tooltip::text("Edit table source"))
-                                            .on_mouse_down(MouseButton::Left, move |_, window, cx| {
-                                                cx.stop_propagation();
-                                                reveal_source_editor
-                                                    .update(cx, |editor, cx| {
-                                                        if let Some(addon) =
-                                                            editor.addon_mut::<LivePreviewAddon>()
-                                                        {
-                                                            addon.source_revealed =
-                                                                Some(reveal_source_range.clone());
-                                                        }
-                                                        let snapshot =
-                                                            editor.buffer().read(cx).snapshot(cx);
-                                                        let offset = reveal_source_range
-                                                            .start
-                                                            .to_offset(&snapshot);
-                                                        editor.change_selections(
-                                                            Default::default(),
-                                                            window,
-                                                            cx,
-                                                            |selections| {
-                                                                selections
-                                                                    .select_ranges([offset..offset]);
-                                                            },
-                                                        );
-                                                    })
-                                                    .log_err();
-                                            }),
-                                    )
-                                    .child(
-                                        // Add column to the right.
-                                        div()
-                                            .id("mdlp-add-column")
-                                            .flex_grow(1.)
-                                            .flex()
-                                            .items_center()
-                                            .justify_center()
-                                            .cursor_pointer()
-                                            .text_color(colors.text_muted)
-                                            .opacity(0.)
-                                            .group_hover("mdlp-table", |this| this.opacity(0.7))
-                                            .hover(|this| this.opacity(1.))
-                                            .child("+")
-                                            .tooltip(ui::Tooltip::text("Add column to the right"))
-                                            .on_mouse_down(MouseButton::Left, move |_, _, cx| {
-                                                cx.stop_propagation();
-                                                add_column_editor
-                                                    .update(cx, |editor, cx| {
-                                                        apply_table_structural_change(
-                                                            editor,
-                                                            &add_column_range,
-                                                            TableStructuralChange::AddColumn,
-                                                            cx,
-                                                        );
-                                                    })
-                                                    .log_err();
-                                            }),
-                                    ),
-                            ),
+                        h_flex().items_stretch().child(grid).child(
+                            v_flex()
+                                .w(gpui::px(22.))
+                                .child(
+                                    // Reveal the table's markdown source.
+                                    div()
+                                        .id("mdlp-table-source")
+                                        .h(gpui::px(22.))
+                                        .flex()
+                                        .items_center()
+                                        .justify_center()
+                                        .cursor_pointer()
+                                        .text_color(colors.text_muted)
+                                        .opacity(0.)
+                                        .group_hover("mdlp-table", |this| this.opacity(0.7))
+                                        .hover(|this| this.opacity(1.))
+                                        .child(
+                                            Icon::new(IconName::Code)
+                                                .size(IconSize::XSmall)
+                                                .color(Color::Muted),
+                                        )
+                                        .tooltip(ui::Tooltip::text("Edit table source"))
+                                        .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+                                            cx.stop_propagation();
+                                            reveal_source_editor
+                                                .update(cx, |editor, cx| {
+                                                    if let Some(addon) =
+                                                        editor.addon_mut::<LivePreviewAddon>()
+                                                    {
+                                                        addon.source_revealed =
+                                                            Some(reveal_source_range.clone());
+                                                    }
+                                                    let snapshot =
+                                                        editor.buffer().read(cx).snapshot(cx);
+                                                    let offset = reveal_source_range
+                                                        .start
+                                                        .to_offset(&snapshot);
+                                                    editor.change_selections(
+                                                        Default::default(),
+                                                        window,
+                                                        cx,
+                                                        |selections| {
+                                                            selections
+                                                                .select_ranges([offset..offset]);
+                                                        },
+                                                    );
+                                                })
+                                                .log_err();
+                                        }),
+                                )
+                                .child(
+                                    // Add column to the right.
+                                    div()
+                                        .id("mdlp-add-column")
+                                        .flex_grow(1.)
+                                        .flex()
+                                        .items_center()
+                                        .justify_center()
+                                        .cursor_pointer()
+                                        .text_color(colors.text_muted)
+                                        .opacity(0.)
+                                        .group_hover("mdlp-table", |this| this.opacity(0.7))
+                                        .hover(|this| this.opacity(1.))
+                                        .child("+")
+                                        .tooltip(ui::Tooltip::text("Add column to the right"))
+                                        .on_mouse_down(MouseButton::Left, move |_, _, cx| {
+                                            cx.stop_propagation();
+                                            add_column_editor
+                                                .update(cx, |editor, cx| {
+                                                    apply_table_structural_change(
+                                                        editor,
+                                                        &add_column_range,
+                                                        TableStructuralChange::AddColumn,
+                                                        cx,
+                                                    );
+                                                })
+                                                .log_err();
+                                        }),
+                                ),
+                        ),
                     )
                     .child(
                         // Add row below.
@@ -2411,7 +2686,10 @@ fn render_image_block(
             .upgrade()
             .map(|editor_entity| {
                 let editor_ref = editor_entity.read(block_cx.app);
-                let snapshot = editor_ref.buffer().read(block_cx.app).snapshot(block_cx.app);
+                let snapshot = editor_ref
+                    .buffer()
+                    .read(block_cx.app)
+                    .snapshot(block_cx.app);
                 editor_ref
                     .addon::<LivePreviewAddon>()
                     .and_then(|addon| addon.selected_image.as_ref())
@@ -2475,48 +2753,38 @@ fn render_image_block(
                 }
             })
             .when_some(content_width, |this, width| this.w(width))
-            .when(content_width.is_none(), |this| {
-                this.max_w(max_width * 0.66)
-            })
+            .when(content_width.is_none(), |this| this.max_w(max_width * 0.66))
             .child(image_content);
 
         if selected {
             content = content
                 .child(
                     // Reveal-source button, top right.
-                    div()
-                        .absolute()
-                        .top_1()
-                        .right_1()
-                        .child(
-                            IconButton::new("mdlp-show-source", IconName::Code)
-                                .style(ButtonStyle::Filled)
-                                .on_click(move |_, window, cx| {
-                                    cx.stop_propagation();
-                                    reveal_editor
-                                        .update(cx, |editor, cx| {
-                                            if let Some(addon) =
-                                                editor.addon_mut::<LivePreviewAddon>()
-                                            {
-                                                addon.source_revealed =
-                                                    Some(reveal_range.clone());
-                                            }
-                                            let snapshot =
-                                                editor.buffer().read(cx).snapshot(cx);
-                                            let offset = start.to_offset(&snapshot);
-                                            editor.change_selections(
-                                                Default::default(),
-                                                window,
-                                                cx,
-                                                |selections| {
-                                                    selections
-                                                        .select_ranges([offset..offset]);
-                                                },
-                                            );
-                                        })
-                                        .log_err();
-                                }),
-                        ),
+                    div().absolute().top_1().right_1().child(
+                        IconButton::new("mdlp-show-source", IconName::Code)
+                            .style(ButtonStyle::Filled)
+                            .on_click(move |_, window, cx| {
+                                cx.stop_propagation();
+                                reveal_editor
+                                    .update(cx, |editor, cx| {
+                                        if let Some(addon) = editor.addon_mut::<LivePreviewAddon>()
+                                        {
+                                            addon.source_revealed = Some(reveal_range.clone());
+                                        }
+                                        let snapshot = editor.buffer().read(cx).snapshot(cx);
+                                        let offset = start.to_offset(&snapshot);
+                                        editor.change_selections(
+                                            Default::default(),
+                                            window,
+                                            cx,
+                                            |selections| {
+                                                selections.select_ranges([offset..offset]);
+                                            },
+                                        );
+                                    })
+                                    .log_err();
+                            }),
+                    ),
                 )
                 .child(
                     // Resize handle, bottom right.
@@ -2561,10 +2829,9 @@ fn render_image_block(
             })
             .on_drag_move::<ImageResizeDrag>(move |event, _window, cx| {
                 let drag = event.drag(cx);
-                let width = (event.event.position.x
-                    - event.bounds.left()
-                    - drag.content_left_offset)
-                    .max(gpui::px(64.));
+                let width =
+                    (event.event.position.x - event.bounds.left() - drag.content_left_offset)
+                        .max(gpui::px(64.));
                 let width = (f32::from(width) / 4.).round() * 4.;
                 let drag_range = drag.range.clone();
                 drag_editor
@@ -2640,6 +2907,86 @@ fn render_rule_block(
                     .log_err();
             })
             .child(div().flex_1().h(gpui::px(2.)).bg(border_color))
+            .into_any_element()
+    })
+}
+
+/// Renders display math as a centered formula.
+///
+/// In replace mode (`below == false`) the widget stands in for the source
+/// lines, so while the render is pending — or permanently, if the LaTeX does
+/// not parse — it shows the source text instead: the buffer content must
+/// never disappear. In below mode the source lines are already visible above
+/// the widget, so those states render nothing.
+fn render_math_block(
+    editor: WeakEntity<Editor>,
+    range: Range<Anchor>,
+    source: SharedString,
+    below: bool,
+) -> RenderBlock {
+    Arc::new(move |block_cx| {
+        let editor = editor.clone();
+        let start = range.start;
+        let cx = &mut *block_cx.app;
+        let theme_settings = theme_settings::ThemeSettings::get_global(cx);
+        let font_size = theme_settings.buffer_font_size(cx);
+        let buffer_font = theme_settings.buffer_font.clone();
+        let text_color = cx.theme().colors().editor_foreground;
+        let key = MathKey {
+            source: source.clone(),
+            style: MathStyle::Display,
+            color: u32::from(gpui::Rgba::from(text_color)),
+        };
+
+        let content = match cx.default_global::<MathCache>().entries.get(&key) {
+            Some(MathEntry::Ready {
+                image,
+                width_em,
+                height_em,
+                ..
+            }) => {
+                let height = font_size * *height_em;
+                let width = font_size * *width_em;
+                img(ImageSource::Render(image.clone()))
+                    .h(height)
+                    .w(width)
+                    .into_any_element()
+            }
+            _ if below => Empty.into_any_element(),
+            _ => div()
+                .font(buffer_font)
+                .text_size(font_size)
+                .text_color(text_color)
+                .child(source.clone())
+                .into_any_element(),
+        };
+
+        div()
+            .w(block_cx.max_width)
+            .py(block_cx.line_height * 0.25)
+            .flex()
+            .justify_center()
+            .items_center()
+            .when(!below, |this| {
+                this.cursor_pointer()
+                    .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+                        editor
+                            .update(cx, |editor, cx| {
+                                let snapshot = editor.buffer().read(cx).snapshot(cx);
+                                let offset = start.to_offset(&snapshot);
+                                editor.change_selections(
+                                    Default::default(),
+                                    window,
+                                    cx,
+                                    |selections| {
+                                        selections.select_ranges([offset..offset]);
+                                    },
+                                );
+                            })
+                            .log_err();
+                    })
+            })
+            .child(content)
             .into_any_element()
     })
 }
@@ -2879,8 +3226,7 @@ impl Extraction<'_> {
     fn anchor_range(&self, range: Range<usize>) -> Range<Anchor> {
         // Bias the anchors inward so text inserted at the boundaries falls
         // outside the hidden range rather than growing it.
-        self.snapshot
-            .anchor_after(MultiBufferOffset(range.start))
+        self.snapshot.anchor_after(MultiBufferOffset(range.start))
             ..self.snapshot.anchor_before(MultiBufferOffset(range.end))
     }
 
@@ -2892,6 +3238,96 @@ impl Extraction<'_> {
                     reveal_span: self.anchor_range(reveal_span),
                 },
             });
+        }
+    }
+
+    /// Claims a `latex_block` node (`$x$` or `$$x$$`) as a math marker
+    /// spanning the delimiters as well as the body, so concealing it replaces
+    /// the whole construct with one typeset image.
+    ///
+    /// The grammar treats a run of one or more `$` as the delimiter, so the
+    /// opening run's length is what separates inline from display math.
+    /// Following Obsidian, `$...$` requires a non-space immediately inside
+    /// each delimiter — so prose like "cost $5 and $10" stays prose — while
+    /// `$$...$$` tolerates padding. Display math that sits alone on its lines
+    /// becomes a centered block; mid-line `$$...$$` renders inline (in display
+    /// style) because a block replacement would swallow its neighbors.
+    fn latex(&mut self, node: tree_sitter::Node) {
+        let mut delimiters = Vec::new();
+        for index in 0..node.child_count() as u32 {
+            let Some(child) = node.child(index) else {
+                continue;
+            };
+            if child.kind() == "latex_span_delimiter" {
+                delimiters.push(child);
+            }
+        }
+        // An unterminated `$` parses without a closing delimiter; leave it as
+        // plain text so typing a lone dollar sign does not flicker.
+        let (Some(open), Some(close)) = (delimiters.first(), delimiters.last()) else {
+            return;
+        };
+        if delimiters.len() < 2 || open.end_byte() > close.start_byte() {
+            return;
+        }
+
+        let Some(source) = self.text.get(open.end_byte()..close.start_byte()) else {
+            return;
+        };
+        if source.trim().is_empty() {
+            return;
+        }
+
+        let display = open.byte_range().len() >= 2;
+        if !display
+            && (source.starts_with(|c: char| c.is_whitespace())
+                || source.ends_with(|c: char| c.is_whitespace()))
+        {
+            return;
+        }
+
+        if display && self.node_is_alone_on_its_lines(node) {
+            let (start_row, end_row) = self.node_rows(node);
+            let height_estimate = (end_row - start_row + 1).max(2);
+            self.push_block_rows(
+                start_row,
+                end_row,
+                height_estimate,
+                BlockRenderKind::Math {
+                    source: source.to_string(),
+                },
+            );
+            return;
+        }
+
+        self.inline.push(InlineMarker {
+            range: self.anchor_range(node.byte_range()),
+            kind: InlineKind::Math {
+                source: SharedString::from(source.to_string()),
+                style: if display {
+                    MathStyle::Display
+                } else {
+                    MathStyle::Inline
+                },
+            },
+        });
+    }
+
+    /// Whether only whitespace shares the node's first and last lines with it.
+    fn node_is_alone_on_its_lines(&self, node: tree_sitter::Node) -> bool {
+        let line_start = self.text[..node.start_byte()]
+            .rfind('\n')
+            .map_or(0, |index| index + 1);
+        let line_end = self.text[node.end_byte()..]
+            .find('\n')
+            .map_or(self.text.len(), |index| node.end_byte() + index);
+        let before = self.text.get(line_start..node.start_byte());
+        let after = self.text.get(node.end_byte()..line_end);
+        match (before, after) {
+            (Some(before), Some(after)) => {
+                before.chars().all(char::is_whitespace) && after.chars().all(char::is_whitespace)
+            }
+            _ => false,
         }
     }
 
@@ -2961,8 +3397,9 @@ impl Extraction<'_> {
                             let end_row = offsets.end.to_point(self.snapshot).row;
                             // One textual table can contain several table
                             // nodes; only the first one produces the block.
-                            let claimed =
-                                self.last_table_end_row.is_some_and(|last| start_row <= last);
+                            let claimed = self
+                                .last_table_end_row
+                                .is_some_and(|last| start_row <= last);
                             if !claimed {
                                 self.last_table_end_row = Some(end_row);
                                 self.push_block_rows(
@@ -3123,6 +3560,9 @@ impl Extraction<'_> {
                         }
                     }
                     push_children(node, &mut stack);
+                }
+                "latex_block" => {
+                    self.latex(node);
                 }
                 "code_span" => {
                     self.code_spans.push(node.byte_range());

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -986,6 +986,12 @@ impl gpui::Global for MathCache {}
 /// actual size.
 const MATH_RASTER_EM: f32 = 64.0;
 
+/// Formulas render at this multiple of the buffer font size. The KaTeX fonts
+/// have a visibly smaller x-height than code fonts, so at 1:1 math looks
+/// shrunken next to prose; this is the same ratio KaTeX's own stylesheet
+/// applies (`.katex { font-size: 1.21em }`).
+const MATH_FONT_SCALE: f32 = 1.21;
+
 /// Ensures a render for `key` is in flight or complete, and returns whether
 /// the cache already holds a finished image.
 ///
@@ -1101,6 +1107,17 @@ fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPl
                     style,
                     color: u32::from(gpui::Rgba::from(text_color)),
                 };
+                let line_height = font_size * theme_settings.line_height();
+                let text_system = cx.text_system().clone();
+                let font_id = text_system.resolve_font(&buffer_font);
+                let ascent = text_system.ascent(font_id, font_size);
+                // `TextSystem::descent` is negative on macOS (a signed offset
+                // below the baseline), while the painted baseline's formula
+                // (`gpui::paint_line`) works in magnitudes — feeding the
+                // signed value into `baseline_offset` lands 2×descent too
+                // low, so compute the baseline from magnitudes directly.
+                let descent = text_system.descent(font_id, font_size).abs();
+                let text_baseline = (line_height - ascent - descent) / 2.0 + ascent;
 
                 match cx.default_global::<MathCache>().entries.get(&key) {
                     Some(MathEntry::Ready {
@@ -1109,22 +1126,34 @@ fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPl
                         width_em,
                         height_em,
                     }) => {
-                        let height = font_size * *height_em;
-                        let width = font_size * *width_em;
-                        // Shift down by the part of the formula that hangs
-                        // below the baseline, so the typeset baseline lands on
-                        // the surrounding text's baseline instead of the
-                        // image floating mid-line.
-                        let descent = height * *baseline_fraction;
+                        let math_em = font_size * MATH_FONT_SCALE;
+                        let height = math_em * *height_em;
+                        let width = math_em * *width_em;
+                        // The editor centers inline elements in the line
+                        // (element top lands at `(line_height - height) / 2`),
+                        // while text baselines sit at `baseline_offset`. Shift
+                        // the image by the difference so the formula's
+                        // baseline lands exactly on the text's.
+                        let formula_ascent = height * (1.0 - *baseline_fraction);
+                        let shift = text_baseline - (line_height - height) / 2.0 - formula_ascent;
+                        // The centering offsets a padded element by half its
+                        // padding, so doubling the needed shift as one-sided
+                        // padding moves the image by exactly `shift` without
+                        // relying on inset positioning.
+                        let (pad_top, pad_bottom) = if shift >= gpui::px(0.) {
+                            (shift * 2.0, gpui::px(0.))
+                        } else {
+                            (gpui::px(0.), shift * -2.0)
+                        };
                         div()
-                            .h(height)
+                            .h(height + pad_top + pad_bottom)
                             .w(width)
+                            .pt(pad_top)
+                            .pb(pad_bottom)
                             .child(
                                 img(ImageSource::Render(image.clone()))
                                     .h(height)
-                                    .w(width)
-                                    .relative()
-                                    .top(descent),
+                                    .w(width),
                             )
                             .into_any_element()
                     }
@@ -3038,8 +3067,9 @@ fn render_math_block(
                 height_em,
                 ..
             }) => {
-                let height = font_size * *height_em;
-                let width = font_size * *width_em;
+                let math_em = font_size * MATH_FONT_SCALE;
+                let height = math_em * *height_em;
+                let width = math_em * *width_em;
                 img(ImageSource::Render(image.clone()))
                     .h(height)
                     .w(width)
@@ -3343,8 +3373,9 @@ impl Extraction<'_> {
     /// Following Obsidian, `$...$` requires a non-space immediately inside
     /// each delimiter — so prose like "cost $5 and $10" stays prose — while
     /// `$$...$$` tolerates padding. Display math that sits alone on its lines
-    /// becomes a centered block; mid-line `$$...$$` renders inline (in display
-    /// style) because a block replacement would swallow its neighbors.
+    /// becomes a centered block; mid-line `$$...$$` renders inline (in
+    /// compact text style) because a block replacement would swallow its
+    /// neighbors and display-style layout cannot fit within a line.
     fn latex(&mut self, node: tree_sitter::Node) {
         let mut delimiters = Vec::new();
         for index in 0..node.child_count() as u32 {
@@ -3397,11 +3428,10 @@ impl Extraction<'_> {
             range: self.anchor_range(node.byte_range()),
             kind: InlineKind::Math {
                 source: SharedString::from(source.to_string()),
-                style: if display {
-                    MathStyle::Display
-                } else {
-                    MathStyle::Inline
-                },
+                // Mid-line `$$...$$` also uses inline (text) style: display
+                // style stacks limits and full-size fractions, which cannot
+                // fit within a fixed-height editor line.
+                style: MathStyle::Inline,
             },
         });
     }

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -559,7 +559,6 @@ async fn test_linked_image_renders_as_block(cx: &mut TestAppContext) {
     }
 }
 
-
 #[gpui::test]
 async fn test_images_section_context(cx: &mut TestAppContext) {
     let mut cx = markdown_test_context(cx).await;
@@ -601,7 +600,10 @@ async fn test_images_section_context(cx: &mut TestAppContext) {
     // Inline image, reference image, and linked image; the heading is
     // revealed because the cursor sits on it.
     assert_eq!(blocks, 3, "applied block rows: {rows:?}");
-    assert!(rows.contains(&(12, 12)), "linked image row missing: {rows:?}");
+    assert!(
+        rows.contains(&(12, 12)),
+        "linked image row missing: {rows:?}"
+    );
 }
 
 #[gpui::test]
@@ -747,9 +749,18 @@ async fn test_wikilinks_conceal(cx: &mut TestAppContext) {
     "});
     cx.executor().run_until_parked();
     let display = cx.display_text();
-    assert!(display.contains("see CLAUDE and the plan here"), "{display}");
-    assert!(display.contains("embed stays raw: ![[image.png]]"), "{display}");
-    assert!(display.contains("code stays raw: [[not a link]]"), "{display}");
+    assert!(
+        display.contains("see CLAUDE and the plan here"),
+        "{display}"
+    );
+    assert!(
+        display.contains("embed stays raw: ![[image.png]]"),
+        "{display}"
+    );
+    assert!(
+        display.contains("code stays raw: [[not a link]]"),
+        "{display}"
+    );
 }
 
 #[gpui::test]
@@ -969,7 +980,11 @@ async fn test_table_structural_changes(cx: &mut TestAppContext) {
         apply_table_structural_change(editor, &range, TableStructuralChange::AddColumn, cx);
     });
     cx.executor().run_until_parked();
-    assert!(cx.buffer_text().contains("| A | B |   |"), "{}", cx.buffer_text());
+    assert!(
+        cx.buffer_text().contains("| A | B |   |"),
+        "{}",
+        cx.buffer_text()
+    );
 
     // Reuse the now-stale range on purpose: structural ops must re-resolve the
     // table from the live tree, since widget closures outlive edits.
@@ -981,12 +996,13 @@ async fn test_table_structural_changes(cx: &mut TestAppContext) {
     let table_lines: Vec<&str> = text.lines().filter(|line| line.starts_with('|')).collect();
     assert_eq!(table_lines.len(), 4, "{text}");
     assert!(
-        text.lines().filter(|line| line.starts_with('|')).all(|line| line.matches('|').count() == 4),
+        text.lines()
+            .filter(|line| line.starts_with('|'))
+            .all(|line| line.matches('|').count() == 4),
         "every table line should have 3 columns after the changes: {text}"
     );
     assert_eq!(table_lines.len(), 4, "{text}");
 }
-
 
 #[gpui::test]
 async fn test_add_row_no_outer_pipes(cx: &mut TestAppContext) {
@@ -1030,7 +1046,10 @@ async fn test_add_row_no_outer_pipes(cx: &mut TestAppContext) {
         ],
         "full text: {text:?}"
     );
-    assert!(text.contains("\n\nafter"), "must not eat the blank line: {text:?}");
+    assert!(
+        text.contains("\n\nafter"),
+        "must not eat the blank line: {text:?}"
+    );
 }
 
 #[gpui::test]
@@ -1189,7 +1208,10 @@ async fn test_table_reveals_only_via_button(cx: &mut TestAppContext) {
             .and_then(|addon| addon.source_revealed.clone())
             .is_none()
     });
-    assert!(cleared, "reveal must clear when the selection leaves the block");
+    assert!(
+        cleared,
+        "reveal must clear when the selection leaves the block"
+    );
 }
 
 #[gpui::test]
@@ -1254,7 +1276,10 @@ async fn test_move_and_delete_rows_columns(cx: &mut TestAppContext) {
     let text = cx.buffer_text();
     assert!(text.contains("| B | A |"), "{text}");
     assert!(text.contains("| y | x |"), "{text}");
-    assert!(!text.contains("| 1 |"), "deleted row should be gone: {text}");
+    assert!(
+        !text.contains("| 1 |"),
+        "deleted row should be gone: {text}"
+    );
 }
 
 #[gpui::test]
@@ -1304,8 +1329,15 @@ async fn test_drag_row_reorders_via_mouse(cx: &mut TestAppContext) {
             addon.drop_boundary.as_ref().map(|(_, boundary)| *boundary),
         )
     });
-    assert!(drag_active, "drag should be active after moving past threshold");
-    assert_eq!(source_set, Some(TableUnit::Row(0)), "source should be recorded");
+    assert!(
+        drag_active,
+        "drag should be active after moving past threshold"
+    );
+    assert_eq!(
+        source_set,
+        Some(TableUnit::Row(0)),
+        "source should be recorded"
+    );
     assert_eq!(
         boundary_set,
         Some(TableBoundary::Row(2)),
@@ -1370,8 +1402,8 @@ async fn test_drag_row_drop_anywhere_on_table(cx: &mut TestAppContext) {
         gpui::MouseButton::Left,
         gpui::Modifiers::none(),
     );
-    let handle_lower = target_handle.center()
-        + gpui::point(gpui::px(0.), target_handle.size.height * 0.3);
+    let handle_lower =
+        target_handle.center() + gpui::point(gpui::px(0.), target_handle.size.height * 0.3);
     cx.cx.simulate_mouse_move(
         handle_lower,
         gpui::MouseButton::Left,
@@ -1423,16 +1455,10 @@ async fn test_drag_column_release_on_handle_strip(cx: &mut TestAppContext) {
         gpui::Modifiers::none(),
     );
     let right_half = target.center() + gpui::point(target.size.width * 0.3, gpui::px(0.));
-    cx.cx.simulate_mouse_move(
-        right_half,
-        gpui::MouseButton::Left,
-        gpui::Modifiers::none(),
-    );
-    cx.cx.simulate_mouse_up(
-        right_half,
-        gpui::MouseButton::Left,
-        gpui::Modifiers::none(),
-    );
+    cx.cx
+        .simulate_mouse_move(right_half, gpui::MouseButton::Left, gpui::Modifiers::none());
+    cx.cx
+        .simulate_mouse_up(right_half, gpui::MouseButton::Left, gpui::Modifiers::none());
     cx.executor().run_until_parked();
 
     let text = cx.buffer_text();
@@ -1516,7 +1542,10 @@ async fn test_drag_column_between_others(cx: &mut TestAppContext) {
         .cx
         .debug_bounds("mdlp-column-handle-0")
         .expect("column handle rendered");
-    let target = cx.cx.debug_bounds("mdlp-cell-h-2").expect("header C rendered");
+    let target = cx
+        .cx
+        .debug_bounds("mdlp-cell-h-2")
+        .expect("header C rendered");
 
     let start = source.center();
     cx.cx
@@ -1528,11 +1557,8 @@ async fn test_drag_column_between_others(cx: &mut TestAppContext) {
     );
     // Left half of column C targets the boundary between B and C.
     let left_half = target.center() - gpui::point(target.size.width * 0.3, gpui::px(0.));
-    cx.cx.simulate_mouse_move(
-        left_half,
-        gpui::MouseButton::Left,
-        gpui::Modifiers::none(),
-    );
+    cx.cx
+        .simulate_mouse_move(left_half, gpui::MouseButton::Left, gpui::Modifiers::none());
     let boundary = cx.update_editor(|editor, _, _| {
         editor
             .addon::<LivePreviewAddon>()
@@ -1584,6 +1610,155 @@ async fn test_table_cell_wraps_long_content(cx: &mut TestAppContext) {
     );
 }
 
+#[gpui::test]
+async fn test_inline_math_conceals_and_reveals(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    // Off-cursor, the whole `$...$` construct is concealed behind one widget.
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        energy is $E = mc^2$ here
+    "});
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            energy is ⋯ here
+        "}
+    );
+
+    // Cursor inside the formula reveals the LaTeX for editing.
+    cx.set_state(indoc::indoc! {"
+        plain line
+        energy is $E = mˇc^2$ here
+    "});
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            energy is $E = mc^2$ here
+        "}
+    );
+
+    // Cursor elsewhere on the same line does not reveal it.
+    cx.set_state(indoc::indoc! {"
+        plain line
+        energy iˇs $E = mc^2$ here
+    "});
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            energy is ⋯ here
+        "}
+    );
+}
+
+#[gpui::test]
+async fn test_inline_math_requires_tight_delimiters(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    // Following Obsidian, `$` with whitespace immediately inside is not math,
+    // so dollar amounts in prose stay prose.
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        $ a = b $
+        it costs $5 and $10 today
+    "});
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            $ a = b $
+            it costs $5 and $10 today
+        "}
+    );
+}
+
+#[gpui::test]
+async fn test_display_math_renders_as_block(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        $$ a = b $$
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 1);
+
+    // The delimiters on their own lines — the common research-note format.
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        $$
+        a = b
+        $$
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 1);
+    assert!(
+        !cx.display_text().contains("a = b"),
+        "multi-line display math should be replaced by its widget: {}",
+        cx.display_text()
+    );
+
+    // Mid-line display math cannot replace its lines without swallowing the
+    // surrounding text, so it renders inline instead.
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        before $$ a = b $$ after
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 0);
+    pretty_assertions::assert_eq!(
+        cx.display_text(),
+        indoc::indoc! {"
+            plain line
+            before ⋯ after
+        "}
+    );
+}
+
+#[gpui::test]
+async fn test_display_math_keeps_rendering_while_editing(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    // Cursor inside the formula: the source is revealed, but the rendered
+    // widget stays as a block below it instead of disappearing, so the
+    // typeset result remains visible while editing (Obsidian behavior).
+    cx.set_state(indoc::indoc! {"
+        plain line
+
+        $$ a =ˇ b $$
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 1);
+    assert!(
+        cx.display_text().contains("$$ a = b $$"),
+        "revealed display math must show its source: {}",
+        cx.display_text()
+    );
+
+    // Cursor back outside: the block replaces the source lines again.
+    cx.set_state(indoc::indoc! {"
+        plainˇ line
+
+        $$ a = b $$
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(applied_block_count(&mut cx), 1);
+    assert!(
+        !cx.display_text().contains("$$ a = b $$"),
+        "unrevealed display math must not show its source: {}",
+        cx.display_text()
+    );
+}
+
 // --- Contract tests ---
 //
 // These pin behavior this crate relies on from `editor` and `gpui` rather than
@@ -1612,10 +1787,7 @@ async fn test_highlight_key_namespaces_are_independent(cx: &mut TestAppContext) 
     assert!(highlighted(&mut cx, ITALIC) > 0);
 
     cx.update_editor(|editor, _, cx| {
-        editor.clear_highlights(
-            HighlightKey::MarkdownLivePreview(BOLD),
-            cx,
-        );
+        editor.clear_highlights(HighlightKey::MarkdownLivePreview(BOLD), cx);
     });
 
     assert_eq!(highlighted(&mut cx, BOLD), 0);
@@ -1623,4 +1795,16 @@ async fn test_highlight_key_namespaces_are_independent(cx: &mut TestAppContext) 
         highlighted(&mut cx, ITALIC) > 0,
         "clearing one highlight key dropped another key's ranges"
     );
+}
+
+/// Math markers come from the `latex_block` node that tree-sitter-md's inline
+/// grammar only emits when it was generated with its latex extension enabled.
+/// An upstream bump to a build of the grammar without that extension would
+/// silently turn all math back into plain text; this fails instead.
+#[gpui::test]
+async fn test_markdown_inline_grammar_emits_latex_block(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state("ˇsome $E = mc^2$ math\n");
+    cx.executor().run_until_parked();
+    pretty_assertions::assert_eq!(cx.display_text(), "some ⋯ math\n");
 }

--- a/crates/math_render/Cargo.toml
+++ b/crates/math_render/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "math_render"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/math_render.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+gpui.workspace = true
+ratex-layout.workspace = true
+ratex-parser.workspace = true
+ratex-svg = { workspace = true, features = ["embed-fonts"] }
+ratex-types.workspace = true
+
+[dev-dependencies]
+usvg.workspace = true

--- a/crates/math_render/src/math_render.rs
+++ b/crates/math_render/src/math_render.rs
@@ -1,0 +1,237 @@
+//! Crate for rendering LaTeX math strings to SVG strings.
+//!
+//! The entrypoint to this crate is [`render_to_svg`]. It mirrors the shape of
+//! [`mermaid_render`](../../mermaid_render), the fork's other "embedded
+//! technical content" renderer, so both feed the same `usvg`/`resvg`
+//! rasterization path in `gpui`.
+//!
+//! Rendering goes through [RaTeX](https://github.com/erweixin/RaTeX), a
+//! KaTeX-compatible math engine written in Rust: `ratex-parser` parses the
+//! LaTeX, `ratex-layout` lays it out into a display list, and `ratex-svg`
+//! exports that list to SVG.
+//!
+//! Two properties of the emitted SVG matter to callers:
+//!
+//! 1. Glyphs are emitted as `<path>` outlines rather than `<text>` elements
+//!    (via [`ratex_svg::SvgOptions::embed_glyphs`] plus the `embed-fonts`
+//!    feature). `usvg` therefore needs no font database to rasterize the
+//!    result, and output does not shift with the user's installed fonts.
+//! 2. The returned [`RenderedMath`] carries `height_em`/`depth_em` alongside
+//!    the SVG. Inline math has to sit on the surrounding text's baseline, and
+//!    an SVG alone cannot say where within its box that baseline falls.
+//!    Callers offset by `depth_em` to align it.
+//!
+//! Keeping the engine behind this crate boundary is deliberate: `math_render`
+//! is the only place that names RaTeX, so swapping engines does not reach into
+//! the editor.
+
+use anyhow::{Context as _, Result};
+use gpui::{Hsla, Rgba};
+use ratex_layout::{LayoutOptions, layout, to_display_list};
+use ratex_svg::{SvgOptions, render_to_svg as ratex_render_to_svg};
+use ratex_types::math_style::MathStyle as RatexMathStyle;
+
+/// Whether a formula was written inline in a paragraph or as its own block.
+///
+/// This selects TeX's math style, which is not merely cosmetic: display style
+/// sets limits above and below large operators and uses full-size fractions,
+/// while text style tucks limits beside the operator and shrinks fractions so
+/// the formula fits within a line of prose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum MathStyle {
+    /// `$...$` — sized to sit within a line of prose.
+    #[default]
+    Inline,
+    /// `$$...$$` — sized to stand alone on its own lines.
+    Display,
+}
+
+impl From<MathStyle> for RatexMathStyle {
+    fn from(style: MathStyle) -> Self {
+        match style {
+            MathStyle::Inline => RatexMathStyle::Text,
+            MathStyle::Display => RatexMathStyle::Display,
+        }
+    }
+}
+
+/// Theme and sizing inputs for a single formula.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MathTheme {
+    /// Color of the rendered glyphs, normally the editor's foreground color.
+    pub text_color: Hsla,
+    /// Em size in SVG user units. The rasterized image is scaled to the
+    /// editor's font size, so this only sets the resolution of the outlines.
+    pub font_size: f32,
+}
+
+impl Default for MathTheme {
+    fn default() -> Self {
+        Self {
+            text_color: gpui::black(),
+            font_size: 40.0,
+        }
+    }
+}
+
+/// A rendered formula, plus the metrics needed to place it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RenderedMath {
+    /// A standalone SVG document with glyphs as `<path>` outlines.
+    pub svg: String,
+    /// Distance from the baseline to the top of the formula, in em.
+    pub height_em: f32,
+    /// Distance from the baseline to the bottom of the formula, in em.
+    ///
+    /// Zero for a formula that sits entirely on the baseline (`E = mc^2`);
+    /// positive when something descends below it (`\frac{a}{b}`).
+    pub depth_em: f32,
+}
+
+impl RenderedMath {
+    /// The fraction of the image's total height that sits below the baseline.
+    ///
+    /// Callers position inline math by shifting it down by this fraction of
+    /// the image height, which puts the formula's baseline on the text's.
+    pub fn baseline_fraction(&self) -> f32 {
+        let total = self.height_em + self.depth_em;
+        if total > 0.0 {
+            self.depth_em / total
+        } else {
+            0.0
+        }
+    }
+}
+
+/// Renders a LaTeX math string to SVG.
+///
+/// `source` is the formula body *without* its `$` delimiters. Errors are
+/// returned rather than panicking, because callers re-render on every
+/// keystroke and a half-typed formula is the common case, not the exception.
+pub fn render_to_svg(source: &str, style: MathStyle, theme: &MathTheme) -> Result<RenderedMath> {
+    let nodes = ratex_parser::parse(source)
+        .map_err(|error| anyhow::anyhow!("{}", error.message))
+        .context("parsing LaTeX math")?;
+
+    let options = LayoutOptions {
+        style: style.into(),
+        color: hsla_to_ratex_color(theme.text_color),
+        ..Default::default()
+    };
+
+    let display_list = to_display_list(&layout(&nodes, &options));
+
+    let svg = ratex_render_to_svg(
+        &display_list,
+        &SvgOptions {
+            font_size: theme.font_size as f64,
+            // Padding would be baked into the raster and offset the baseline;
+            // callers add spacing with layout instead.
+            padding: 0.0,
+            embed_glyphs: true,
+            ..Default::default()
+        },
+    );
+
+    Ok(RenderedMath {
+        svg,
+        height_em: display_list.height as f32,
+        depth_em: display_list.depth as f32,
+    })
+}
+
+fn hsla_to_ratex_color(color: Hsla) -> ratex_types::color::Color {
+    let Rgba { r, g, b, a } = Rgba::from(color);
+    ratex_types::color::Color { r, g, b, a }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The rasterizer is given no font database, so any `<text>` element would
+    /// silently render as nothing. Everything must be outlines.
+    #[test]
+    fn glyphs_are_outlines_not_text_elements() {
+        for source in [
+            r"E = mc^2",
+            r"\int_0^\infty e^{-x^2}\,dx",
+            r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}",
+            r"\sqrt{\frac{1}{1 + \sqrt{x}}}",
+        ] {
+            let rendered = render_to_svg(source, MathStyle::Display, &MathTheme::default())
+                .expect("formula should render");
+            assert!(
+                !rendered.svg.contains("<text"),
+                "{source:?} emitted a <text> element, which needs font resolution"
+            );
+            assert!(
+                rendered.svg.contains("<path"),
+                "{source:?} emitted no glyph outlines"
+            );
+        }
+    }
+
+    /// Pins the property the whole pipeline depends on: `usvg` can parse the
+    /// output with a default (empty) font database.
+    #[test]
+    fn output_parses_with_usvg_and_no_fontdb() {
+        let rendered = render_to_svg(
+            r"\sum_{i=1}^{n} i = \frac{n(n+1)}{2}",
+            MathStyle::Display,
+            &MathTheme::default(),
+        )
+        .expect("formula should render");
+
+        let tree = usvg::Tree::from_str(&rendered.svg, &usvg::Options::default())
+            .expect("usvg should parse the SVG without a font database");
+        assert!(tree.size().width() > 0.0 && tree.size().height() > 0.0);
+    }
+
+    #[test]
+    fn depth_distinguishes_descending_formulas() {
+        let flat = render_to_svg("E = mc^2", MathStyle::Inline, &MathTheme::default())
+            .expect("formula should render");
+        let descending = render_to_svg(r"\frac{a}{b}", MathStyle::Inline, &MathTheme::default())
+            .expect("formula should render");
+
+        assert_eq!(flat.depth_em, 0.0);
+        assert!(descending.depth_em > 0.0);
+        assert!(descending.baseline_fraction() > flat.baseline_fraction());
+    }
+
+    /// Inline style must be visibly more compact than display style, otherwise
+    /// formulas in prose blow up the line height.
+    #[test]
+    fn inline_style_is_more_compact_than_display() {
+        let source = r"\sum_{i=1}^{n} i";
+        let inline = render_to_svg(source, MathStyle::Inline, &MathTheme::default())
+            .expect("formula should render");
+        let display = render_to_svg(source, MathStyle::Display, &MathTheme::default())
+            .expect("formula should render");
+
+        let inline_total = inline.height_em + inline.depth_em;
+        let display_total = display.height_em + display.depth_em;
+        assert!(
+            inline_total < display_total,
+            "inline {inline_total} should be shorter than display {display_total}"
+        );
+    }
+
+    /// Live preview re-renders on every keystroke, so partial input arrives
+    /// constantly. It must produce an error, never a panic.
+    #[test]
+    fn malformed_input_errors_without_panicking() {
+        for source in [
+            r"\frac{a}{",
+            r"\begin{pmatrix} a",
+            r"\nosuchcommand{x}",
+            "",
+            "^",
+        ] {
+            let result = render_to_svg(source, MathStyle::Inline, &MathTheme::default());
+            // Either outcome is fine; not unwinding is the point.
+            drop(result);
+        }
+    }
+}


### PR DESCRIPTION
Adds Obsidian-style live math rendering to markdown buffers — the most-requested missing piece of the live preview. `$E = mc^2$` typesets inline on the text baseline; `$$...$$` alone on its lines becomes a centered block whose rendering stays visible below the source while the formula is edited, exactly matching Obsidian's Live Preview.

## Architecture

- **`crates/math_render/`** — a new fork-owned crate mirroring `mermaid_render`: LaTeX in, SVG out, feeding gpui's existing usvg rasterizer. The engine is [RaTeX](https://github.com/erweixin/RaTeX) (KaTeX-compatible, pure Rust); glyphs are emitted as `<path>` outlines so no font database or registration is needed. It is the only module that names the engine, so it stays swappable.
- **`crates/markdown_live_preview/`** — detection via the inline tree-sitter layer's `latex_block` node; inline math as a new `FoldPlaceholder` arm on the existing concealment mechanism (like the task checkbox); display math as a replace block (like headings) that moves to `BlockPlacement::Below` while its source is revealed.

**Zero lines in `crates/markdown` or `gpui`.** The four upstream attempts (zed#57339, zed#58593, zed#53150, zed#54668) each patched shared crates by 100–800 lines and all stalled without team review; this diff's only shared-file changes are the workspace `Cargo.toml` and a 3-line injection removal in the markdown-inline grammar queries.

## Behavior

- `$...$` needs a non-space immediately inside each delimiter (Obsidian's rule), so "costs $5 and $10" stays prose; the grammar's LaTeX language injection is removed so such spans aren't syntax-highlighted as math either
- Formulas render at 1.21× the buffer font size (KaTeX's own stylesheet ratio) — measured x-heights match the surrounding prose exactly
- Inline formulas sit precisely on the text baseline, via the painted-baseline formula computed from real font metrics; root-caused during dogfooding to gpui's `TextSystem::descent` returning a negative value on macOS, which `baseline_offset` mishandles — this is the bug open on zed#57339, solved here without touching gpui
- Mid-line `$$...$$` renders in compact text style (display layout can't fit a fixed-height line); full display layout is reserved for `$$` alone on its lines
- Renders are cached per (source, style, color) and shared across editors; pending or unparseable LaTeX falls back to showing the source, so buffer text never disappears

## Testing

- `math_render`: 5 tests — outline-only output, usvg parses with no fontdb, baseline metrics, inline vs display compactness, no panics on malformed input
- `markdown_live_preview`: full suite passes (43) including 6 new — conceal/reveal, delimiter strictness, single- and multi-line display blocks, render-while-editing, and a contract test pinning the grammar's latex extension
- Visually verified in the running app against `math-rendering-check.md` in the notes vault: size match and baseline alignment confirmed by pixel measurement of screenshots
- Merged with latest `main` (table-cell fixes); clippy and `cargo check -p zed` clean

## Suggested .rules additions

None — but one candidate for a future dedicated commit: "gpui's `TextSystem::descent` is negative on macOS; compute painted-baseline positions from metric magnitudes (`gpui::paint_line`'s formula), not `baseline_offset`."

Release Notes:

- Added Obsidian-style live rendering of inline (`$...$`) and display (`$$...$$`) LaTeX math in markdown buffers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)