### PR TITLE
suzuri_update: Notify when a newer Suzuri release is available

### DIFF
--- a/.github/workflows/suzuri-release.yml
+++ b/.github/workflows/suzuri-release.yml
@@ -21,7 +21,41 @@ permissions:
   contents: write
 
 jobs:
+  # The version a build reports at runtime is SUZURI_VERSION, compiled in, and
+  # it is what suzuri_update compares against the newest GitHub release. A tag
+  # that runs ahead of the constant ships a build that never learns it is out of
+  # date, so refuse to build one — in seconds, rather than after three hours of
+  # compilation.
+  #
+  # Note this is NOT crates/zed/Cargo.toml's version: that one is upstream Zed's,
+  # and every upstream merge moves it.
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare tag with SUZURI_VERSION
+        run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "Not a tag build; skipping the version check."
+            exit 0
+          fi
+          source_file=crates/suzuri_update/src/suzuri_update.rs
+          tag_version="${GITHUB_REF_NAME#suzuri-v}"
+          code_version=$(sed -n 's/^pub const SUZURI_VERSION: &str = "\(.*\)";$/\1/p' "$source_file")
+          if [ -z "${code_version}" ]; then
+            echo "::error::Could not read SUZURI_VERSION out of ${source_file}."
+            exit 1
+          fi
+          if [ "${tag_version}" != "${code_version}" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match SUZURI_VERSION ${code_version} in ${source_file}."
+            echo "Bump the constant (or retag) so the shipped build reports the version it was released as."
+            exit 1
+          fi
+          echo "Tag and SUZURI_VERSION agree: ${code_version}"
+
   build-mac:
+    needs: check-version
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +101,7 @@ jobs:
           path: target/${{ matrix.target }}/release/suzuri-*.dmg
 
   build-windows:
+    needs: check-version
     # windows-2022 specifically: it ships ISCC (Inno Setup) on PATH, which
     # bundle-windows.ps1 relies on; windows-2025 images currently do not.
     runs-on: windows-2022

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ The fork's own changes are small and additive:
 | Project panel header (file/sort/refresh/collapse) and typeset preview menu entry | `crates/project_panel/src/project_panel.rs` |
 | Built-in markdown-oxide language server | `crates/languages/src/markdown_oxide.rs`, `crates/languages/src/lib.rs` |
 | Preview button for `.typ`/`.tex` | `crates/zed/src/zed/quick_action_bar/preview.rs` |
+| Update notifications | `crates/suzuri_update/`, `crates/zed/src/zed/app_menus.rs` (the Check for Updates entry) |
 | Settings plumbing | `crates/settings_content/`, `assets/settings/default.json` |
 | Branding, CLI name, release infrastructure | `crates/zed/Cargo.toml` (bundle metadata), `crates/zed/resources/app-icon-suzuri*`, `crates/zed/resources/windows/app-icon-suzuri.ico`, `assets/images/suzuri_logo.svg`, `crates/install_cli/src/install_cli_binary.rs`, `script/bundle-mac`, `script/bundle-windows.ps1`, `.github/workflows/suzuri-release.yml` |
 
@@ -159,3 +160,33 @@ The chain is spread across crates and the compiler only catches part of it:
 4. `assets/settings/default.json` — the default value plus its user-facing comment.
 5. `crates/settings_ui/src/page_data.rs` if it should appear in the settings UI, and
    `docs/src/reference/all-settings.md` if it should be documented.
+
+## Cutting a release
+
+Suzuri ships on the **dev** release channel, which is what keeps Zed's auto-updater
+dormant (`ReleaseChannel::poll_for_updates` returns false for `Dev`) and what makes
+`[package.metadata.bundle]` — the block carrying Suzuri's branding — the one
+`script/bundle-mac` selects. Do not switch the channel casually: `bundle-stable` is
+still Zed's own metadata, so a stable build would install itself as `Zed.app`.
+
+To release:
+
+1. Bump `SUZURI_VERSION` in `crates/suzuri_update/src/suzuri_update.rs`.
+2. Tag `suzuri-v<that same version>` and push the tag.
+
+The two must agree: `SUZURI_VERSION` is what a running build compares against the
+newest GitHub release, so a tag ahead of the constant ships a build that never
+learns it is out of date. The `check-version` job in
+`.github/workflows/suzuri-release.yml` fails the release early rather than letting
+that happen.
+
+**Suzuri's version is not the `version` in `crates/zed/Cargo.toml`.** That one is
+upstream Zed's own (`Bump Zed to v1.17.0`), which upstream bumps on its own cadence
+and every merge brings along — it tracks the Zed base this fork is built on, not
+Suzuri's releases, and the two number lines are unrelated. `SUZURI_VERSION` lives in
+a fork-owned file precisely so no merge can move it.
+
+`suzuri_update` only *notifies*; it never installs. Zed's installer (`auto_update`)
+is not wired up, and adopting it would need, at minimum, its hardcoded `Zed` DMG
+mount path in `install_release_macos` reconciled with `bundle-mac`'s `-volname Suzuri`,
+plus signing secrets present on every release build.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18292,6 +18292,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "suzuri_update"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gpui",
+ "http_client",
+ "log",
+ "semver",
+ "settings",
+ "workspace",
+]
+
+[[package]]
 name = "sval"
 version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23835,6 +23848,7 @@ dependencies = [
  "smol",
  "snippet_provider",
  "snippets_ui",
+ "suzuri_update",
  "svg_preview",
  "sysinfo 0.37.2",
  "system_specs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,7 @@ members = [
     "crates/sqlez_macros",
     "crates/streaming_diff",
     "crates/sum_tree",
+    "crates/suzuri_update",
     "crates/svg_preview",
     "crates/syntax_theme",
     "crates/system_specs",
@@ -471,6 +472,7 @@ sqlez = { path = "crates/sqlez" }
 sqlez_macros = { path = "crates/sqlez_macros" }
 streaming_diff = { path = "crates/streaming_diff" }
 sum_tree = { path = "crates/sum_tree" }
+suzuri_update = { path = "crates/suzuri_update" }
 svg_preview = { path = "crates/svg_preview" }
 syntax_theme = { path = "crates/syntax_theme" }
 system_specs = { path = "crates/system_specs" }

--- a/crates/suzuri_update/Cargo.toml
+++ b/crates/suzuri_update/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "suzuri_update"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/suzuri_update.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+gpui.workspace = true
+http_client.workspace = true
+log.workspace = true
+semver.workspace = true
+settings.workspace = true
+workspace.workspace = true
+
+[dev-dependencies]
+http_client = { workspace = true, features = ["test-support"] }

--- a/crates/suzuri_update/src/suzuri_update.rs
+++ b/crates/suzuri_update/src/suzuri_update.rs
@@ -1,0 +1,632 @@
+//! Update checks for Suzuri.
+//!
+//! Suzuri ships on the `dev` release channel, where Zed's own auto-updater never
+//! polls (see `ReleaseChannel::poll_for_updates`) and whose release endpoints
+//! serve Zed's builds rather than this fork's. This crate is the fork's
+//! replacement: it asks GitHub for the newest `suzuri-v*` release and, when one
+//! is newer than the running build, shows a notification linking to the
+//! download.
+//!
+//! It deliberately stops at notifying. Installing an update means replacing a
+//! running `.app` in place, which needs signing and rollback guarantees this
+//! fork does not make yet; a broken installer would strand every user running
+//! the version that shipped it.
+//!
+//! The version being compared is [`SUZURI_VERSION`], not the crate version —
+//! see that constant for why.
+
+use anyhow::{Context as _, Result};
+use gpui::{
+    App, AppContext as _, AsyncApp, Context, DismissEvent, Entity, Global, Task, WeakEntity,
+    actions,
+};
+use http_client::{
+    HttpClient,
+    github::{GithubRelease, GithubReleaseAsset, latest_github_release},
+};
+use semver::Version;
+use settings::{RegisterSetting, Settings, SettingsStore};
+use std::{
+    env::{
+        self,
+        consts::{ARCH, OS},
+    },
+    sync::Arc,
+    time::Duration,
+};
+use workspace::{
+    Workspace,
+    notifications::{
+        NotificationId, show_app_notification, simple_message_notification::MessageNotification,
+    },
+};
+
+/// The version of Suzuri itself, and the only place it is written down.
+///
+/// Deliberately *not* `CARGO_PKG_VERSION`: `crates/zed/Cargo.toml` carries
+/// upstream Zed's version, which upstream bumps on its own release cadence and
+/// every merge brings along. Comparing a Suzuri release tag against that number
+/// would compare two unrelated sequences. This constant lives in a file
+/// upstream never touches, so a merge can never move it.
+///
+/// Bump it in the same commit that gets tagged `suzuri-v<this version>`; the
+/// `check-version` job in `.github/workflows/suzuri-release.yml` enforces that
+/// the two agree.
+pub const SUZURI_VERSION: &str = "0.2.0";
+
+/// The repository whose releases describe newer Suzuri builds.
+const RELEASE_REPOSITORY: &str = "harrywang/suzuri";
+/// `.github/workflows/suzuri-release.yml` publishes one release per `suzuri-v*` tag.
+const RELEASE_TAG_PREFIX: &str = "suzuri-v";
+
+/// Long enough that a launch never competes with the rest of startup for network.
+const INITIAL_POLL_DELAY: Duration = Duration::from_secs(5 * 60);
+const POLL_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// Set to any value to stop background polling, for working on the fork itself
+/// without the running debug build reporting itself out of date.
+const DISABLE_ENV_VAR: &str = "SUZURI_NO_UPDATE_CHECK";
+
+actions!(
+    suzuri,
+    [
+        /// Checks whether a newer Suzuri release is available.
+        CheckForUpdates
+    ]
+);
+
+/// Reuses Zed's `auto_update` setting: a user who turned update checks off
+/// means it for the app they are running, whichever updater implements them.
+#[derive(Clone, Copy, Debug, RegisterSetting)]
+struct UpdateCheckSetting(bool);
+
+impl Settings for UpdateCheckSetting {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        Self(content.auto_update.unwrap())
+    }
+}
+
+pub fn init(http_client: Arc<dyn HttpClient>, cx: &mut App) {
+    // `test_suzuri_version_is_valid_semver` keeps this from ever failing, so a
+    // typo costs a red build rather than a release nobody is told about.
+    let current_version = match SUZURI_VERSION.parse::<Version>() {
+        Ok(version) => version,
+        Err(error) => {
+            log::error!("SUZURI_VERSION {SUZURI_VERSION:?} is not valid semver: {error}");
+            return;
+        }
+    };
+
+    let checker = cx.new(|cx| UpdateChecker::new(http_client, current_version, cx));
+    cx.set_global(GlobalUpdateChecker(checker));
+
+    cx.observe_new(|workspace: &mut Workspace, _window, _cx| {
+        workspace.register_action(|_, _: &CheckForUpdates, _window, cx| {
+            check_for_updates(cx);
+        });
+    })
+    .detach();
+}
+
+/// Runs a check the user asked for: it reports its outcome either way, where a
+/// background check stays silent unless there is something to install.
+pub fn check_for_updates(cx: &mut App) {
+    let Some(checker) = UpdateChecker::global(cx) else {
+        return;
+    };
+    checker.update(cx, |checker, cx| checker.check(CheckKind::Manual, cx));
+}
+
+struct GlobalUpdateChecker(Entity<UpdateChecker>);
+
+impl Global for GlobalUpdateChecker {}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum CheckKind {
+    Manual,
+    Automatic,
+}
+
+struct UpdateChecker {
+    http_client: Arc<dyn HttpClient>,
+    current_version: Version,
+    /// The version a background check last raised, so that leaving Suzuri open
+    /// does not re-notify about the same release every `POLL_INTERVAL`.
+    last_notified_version: Option<Version>,
+    check_task: Option<Task<()>>,
+    poll_task: Option<Task<()>>,
+}
+
+impl UpdateChecker {
+    fn global(cx: &App) -> Option<Entity<Self>> {
+        cx.try_global::<GlobalUpdateChecker>()
+            .map(|checker| checker.0.clone())
+    }
+
+    fn new(
+        http_client: Arc<dyn HttpClient>,
+        current_version: Version,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let mut this = Self {
+            http_client,
+            current_version,
+            last_notified_version: None,
+            check_task: None,
+            poll_task: None,
+        };
+
+        cx.observe_global::<SettingsStore>(|this, cx| this.sync_polling(cx))
+            .detach();
+        this.sync_polling(cx);
+
+        this
+    }
+
+    fn sync_polling(&mut self, cx: &mut Context<Self>) {
+        if env::var(DISABLE_ENV_VAR).is_ok() || !UpdateCheckSetting::get_global(cx).0 {
+            self.poll_task = None;
+            return;
+        }
+
+        if self.poll_task.is_some() {
+            return;
+        }
+
+        self.poll_task = Some(cx.spawn(async move |this, cx| {
+            let mut delay = INITIAL_POLL_DELAY;
+            loop {
+                cx.background_executor().timer(delay).await;
+                delay = POLL_INTERVAL;
+
+                if this
+                    .update(cx, |this, cx| this.check(CheckKind::Automatic, cx))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        }));
+    }
+
+    fn check(&mut self, kind: CheckKind, cx: &mut Context<Self>) {
+        self.check_task = Some(cx.spawn(async move |this, cx| {
+            if let Err(error) = Self::perform_check(&this, kind, cx).await {
+                log::warn!("Suzuri update check failed: {error:#}");
+                if kind == CheckKind::Manual {
+                    cx.update(|cx| show_check_failed_notification(&error, cx));
+                }
+            }
+        }));
+    }
+
+    async fn perform_check(
+        this: &WeakEntity<Self>,
+        kind: CheckKind,
+        cx: &mut AsyncApp,
+    ) -> Result<()> {
+        let (http_client, current_version, last_notified_version) =
+            this.read_with(cx, |this, _| {
+                (
+                    this.http_client.clone(),
+                    this.current_version.clone(),
+                    this.last_notified_version.clone(),
+                )
+            })?;
+
+        match fetch_outcome(http_client, &current_version, OS, ARCH).await? {
+            CheckOutcome::UpToDate => {
+                if kind == CheckKind::Manual {
+                    cx.update(|cx| show_up_to_date_notification(&current_version, cx));
+                }
+            }
+            CheckOutcome::UpdateAvailable {
+                version,
+                download_url,
+                release_url,
+            } => {
+                if kind == CheckKind::Automatic && last_notified_version.as_ref() == Some(&version)
+                {
+                    return Ok(());
+                }
+
+                this.update(cx, |this, _| {
+                    this.last_notified_version = Some(version.clone());
+                })?;
+
+                cx.update(|cx| {
+                    show_update_available_notification(version, download_url, release_url, cx)
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum CheckOutcome {
+    UpToDate,
+    UpdateAvailable {
+        version: Version,
+        download_url: String,
+        release_url: String,
+    },
+}
+
+/// Everything a check decides before any of it reaches the screen, kept free of
+/// `App` so the decision can be tested against a fake GitHub.
+async fn fetch_outcome(
+    http_client: Arc<dyn HttpClient>,
+    current_version: &Version,
+    os: &str,
+    arch: &str,
+) -> Result<CheckOutcome> {
+    let release = latest_github_release(RELEASE_REPOSITORY, true, false, http_client)
+        .await
+        .context("could not reach GitHub to look for a newer Suzuri release")?;
+
+    let latest_version = parse_release_version(&release.tag_name).with_context(|| {
+        format!(
+            "the newest release of {RELEASE_REPOSITORY} is tagged {:?}, \
+             which is not a {RELEASE_TAG_PREFIX}<version> tag",
+            release.tag_name
+        )
+    })?;
+
+    if !is_newer(&latest_version, current_version) {
+        return Ok(CheckOutcome::UpToDate);
+    }
+
+    let release_url = release_page_url(&release.tag_name);
+    let download_url = download_url_for_host(&release, os, arch)
+        .map(str::to_owned)
+        .unwrap_or_else(|| release_url.clone());
+
+    Ok(CheckOutcome::UpdateAvailable {
+        version: latest_version,
+        download_url,
+        release_url,
+    })
+}
+
+/// Turns `suzuri-v1.18.0` into `1.18.0`.
+fn parse_release_version(tag_name: &str) -> Option<Version> {
+    tag_name.strip_prefix(RELEASE_TAG_PREFIX)?.parse().ok()
+}
+
+/// Compares release numbers only, so that a `0.3.0-rc1` build is not told that
+/// `0.3.0` — the release it is a candidate for — is an update, which is what
+/// plain semver ordering would claim.
+fn is_newer(latest: &Version, current: &Version) -> bool {
+    (latest.major, latest.minor, latest.patch) > (current.major, current.minor, current.patch)
+}
+
+fn release_page_url(tag_name: &str) -> String {
+    format!("https://github.com/{RELEASE_REPOSITORY}/releases/tag/{tag_name}")
+}
+
+/// Picks the asset a user on this OS and CPU should download, matching on shape
+/// rather than exact filenames so that renaming an artifact in the release
+/// workflow degrades to the release page instead of linking to a 404.
+fn download_url_for_host<'a>(release: &'a GithubRelease, os: &str, arch: &str) -> Option<&'a str> {
+    let matches = |asset: &GithubReleaseAsset| match os {
+        "macos" => asset.name.ends_with(".dmg") && asset.name.contains(arch),
+        "windows" => asset.name.ends_with(".exe") && asset.name.contains("windows"),
+        _ => false,
+    };
+
+    release
+        .assets
+        .iter()
+        .find(|asset| matches(asset))
+        .map(|asset| asset.browser_download_url.as_str())
+}
+
+fn show_update_available_notification(
+    version: Version,
+    download_url: String,
+    release_url: String,
+    cx: &mut App,
+) {
+    struct UpdateAvailable;
+
+    show_app_notification(NotificationId::unique::<UpdateAvailable>(), cx, move |cx| {
+        let download_url = download_url.clone();
+        let release_url = release_url.clone();
+        cx.new(|cx| {
+            MessageNotification::new(format!("Suzuri {version} is available"), cx)
+                .primary_message("Download")
+                .primary_on_click(move |_, cx| {
+                    cx.open_url(&download_url);
+                    cx.emit(DismissEvent);
+                })
+                .secondary_message("Release Notes")
+                .secondary_on_click(move |_, cx| {
+                    cx.open_url(&release_url);
+                    cx.emit(DismissEvent);
+                })
+                .show_suppress_button(false)
+        })
+    });
+}
+
+fn show_up_to_date_notification(current_version: &Version, cx: &mut App) {
+    struct UpToDate;
+
+    let message = format!("Suzuri {current_version} is up to date");
+    show_app_notification(NotificationId::unique::<UpToDate>(), cx, move |cx| {
+        let message = message.clone();
+        cx.new(|cx| MessageNotification::new(message, cx).show_suppress_button(false))
+    });
+}
+
+fn show_check_failed_notification(error: &anyhow::Error, cx: &mut App) {
+    struct CheckFailed;
+
+    let message = format!("Couldn't check for Suzuri updates: {error}");
+    let release_url = format!("https://github.com/{RELEASE_REPOSITORY}/releases/latest");
+    show_app_notification(NotificationId::unique::<CheckFailed>(), cx, move |cx| {
+        let message = message.clone();
+        let release_url = release_url.clone();
+        cx.new(|cx| {
+            MessageNotification::new(message, cx)
+                .primary_message("View Releases")
+                .primary_on_click(move |_, cx| {
+                    cx.open_url(&release_url);
+                    cx.emit(DismissEvent);
+                })
+                .show_suppress_button(false)
+        })
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_client::{AsyncBody, FakeHttpClient, Response};
+
+    /// Shaped like a real response from `/repos/{owner}/{repo}/releases`, so
+    /// that a change to the fields `GithubRelease` requires — an upstream merge
+    /// narrowing them, or GitHub dropping one — fails here rather than in the
+    /// hands of users who then never hear about a release.
+    const RELEASES_JSON: &str = r#"[
+      {
+        "tag_name": "suzuri-v0.3.0",
+        "prerelease": false,
+        "tarball_url": "https://api.github.test/repos/harrywang/suzuri/tarball/suzuri-v0.3.0",
+        "zipball_url": "https://api.github.test/repos/harrywang/suzuri/zipball/suzuri-v0.3.0",
+        "assets": [
+          {
+            "name": "suzuri-aarch64.dmg",
+            "browser_download_url": "https://github.test/suzuri-aarch64.dmg",
+            "digest": "sha256:0123456789abcdef"
+          },
+          {
+            "name": "suzuri-x86_64.dmg",
+            "browser_download_url": "https://github.test/suzuri-x86_64.dmg",
+            "digest": null
+          },
+          {
+            "name": "suzuri-windows-x86_64.exe",
+            "browser_download_url": "https://github.test/suzuri-windows-x86_64.exe",
+            "digest": null
+          }
+        ]
+      }
+    ]"#;
+
+    fn fake_github(body: &'static str) -> Arc<dyn HttpClient> {
+        FakeHttpClient::create(move |_| async move {
+            Ok(Response::builder()
+                .status(200)
+                .body(AsyncBody::from(body))?)
+        })
+    }
+
+    fn version(text: &str) -> Version {
+        text.parse().expect("test version should be valid semver")
+    }
+
+    fn asset(name: &str) -> GithubReleaseAsset {
+        GithubReleaseAsset {
+            name: name.to_string(),
+            browser_download_url: format!("https://example.test/{name}"),
+            digest: None,
+        }
+    }
+
+    fn release(tag_name: &str, asset_names: &[&str]) -> GithubRelease {
+        GithubRelease {
+            tag_name: tag_name.to_string(),
+            pre_release: false,
+            assets: asset_names.iter().copied().map(asset).collect(),
+            tarball_url: String::new(),
+            zipball_url: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_parse_release_version() {
+        assert_eq!(
+            parse_release_version("suzuri-v1.18.0"),
+            Some(Version::new(1, 18, 0))
+        );
+        // Zed's own tags share this repository's history but not its releases;
+        // reading one as a Suzuri version would advertise the wrong download.
+        assert_eq!(parse_release_version("v0.180.0"), None);
+        assert_eq!(parse_release_version("suzuri-v"), None);
+        assert_eq!(parse_release_version("suzuri-vnightly"), None);
+    }
+
+    #[test]
+    fn test_suzuri_version_is_valid_semver() {
+        // `init` gives up on an unparseable version, which would silently leave
+        // every user of that build with no update checks at all.
+        assert!(SUZURI_VERSION.parse::<Version>().is_ok());
+    }
+
+    #[test]
+    fn test_is_newer_ignores_pre_release_and_build_metadata() {
+        let current: Version = "0.2.0-rc1+abc123".parse().unwrap();
+
+        assert!(is_newer(&Version::new(0, 3, 0), &current));
+        assert!(is_newer(&Version::new(1, 0, 0), &current));
+        // The release this build is a candidate for is not an update to it,
+        // though plain semver ordering would say otherwise.
+        assert!(!is_newer(&Version::new(0, 2, 0), &current));
+        assert!(!is_newer(&Version::new(0, 1, 9), &current));
+    }
+
+    #[test]
+    fn test_download_url_matches_host_asset() {
+        let release = release(
+            "suzuri-v1.18.0",
+            &[
+                "suzuri-aarch64.dmg",
+                "suzuri-x86_64.dmg",
+                "suzuri-windows-x86_64.exe",
+            ],
+        );
+
+        assert_eq!(
+            download_url_for_host(&release, "macos", "aarch64"),
+            Some("https://example.test/suzuri-aarch64.dmg")
+        );
+        assert_eq!(
+            download_url_for_host(&release, "macos", "x86_64"),
+            Some("https://example.test/suzuri-x86_64.dmg")
+        );
+        assert_eq!(
+            download_url_for_host(&release, "windows", "x86_64"),
+            Some("https://example.test/suzuri-windows-x86_64.exe")
+        );
+        // Linux has no artifact in the release workflow; callers fall back to
+        // the release page rather than offering a macOS disk image.
+        assert_eq!(download_url_for_host(&release, "linux", "x86_64"), None);
+    }
+
+    #[test]
+    fn test_download_url_is_absent_when_assets_do_not_match() {
+        let release = release("suzuri-v1.18.0", &["suzuri-x86_64.dmg"]);
+
+        assert_eq!(download_url_for_host(&release, "macos", "aarch64"), None);
+    }
+
+    #[test]
+    fn test_release_page_url() {
+        assert_eq!(
+            release_page_url("suzuri-v1.18.0"),
+            "https://github.com/harrywang/suzuri/releases/tag/suzuri-v1.18.0"
+        );
+    }
+
+    #[test]
+    fn test_fetch_outcome_offers_the_host_download_for_a_newer_release() {
+        let outcome = gpui::block_on(fetch_outcome(
+            fake_github(RELEASES_JSON),
+            &version("0.2.0"),
+            "macos",
+            "aarch64",
+        ))
+        .expect("a well-formed release listing should be understood");
+
+        assert_eq!(
+            outcome,
+            CheckOutcome::UpdateAvailable {
+                version: version("0.3.0"),
+                download_url: "https://github.test/suzuri-aarch64.dmg".to_string(),
+                release_url: "https://github.com/harrywang/suzuri/releases/tag/suzuri-v0.3.0"
+                    .to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_fetch_outcome_is_up_to_date_on_the_newest_release() {
+        for current in ["0.3.0", "0.4.0"] {
+            let outcome = gpui::block_on(fetch_outcome(
+                fake_github(RELEASES_JSON),
+                &version(current),
+                "macos",
+                "aarch64",
+            ))
+            .expect("a well-formed release listing should be understood");
+
+            assert_eq!(outcome, CheckOutcome::UpToDate, "running {current}");
+        }
+    }
+
+    #[test]
+    fn test_fetch_outcome_falls_back_to_the_release_page_without_a_host_asset() {
+        let outcome = gpui::block_on(fetch_outcome(
+            fake_github(RELEASES_JSON),
+            &version("0.2.0"),
+            "linux",
+            "x86_64",
+        ))
+        .expect("a well-formed release listing should be understood");
+
+        // Sending a Linux user to the release page beats sending them a .dmg.
+        assert_eq!(
+            outcome,
+            CheckOutcome::UpdateAvailable {
+                version: version("0.3.0"),
+                download_url: "https://github.com/harrywang/suzuri/releases/tag/suzuri-v0.3.0"
+                    .to_string(),
+                release_url: "https://github.com/harrywang/suzuri/releases/tag/suzuri-v0.3.0"
+                    .to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_fetch_outcome_rejects_a_release_that_is_not_suzuris() {
+        const ZED_RELEASE_JSON: &str = r#"[
+          {
+            "tag_name": "v0.180.0",
+            "prerelease": false,
+            "tarball_url": "https://api.github.test/tarball/v0.180.0",
+            "zipball_url": "https://api.github.test/zipball/v0.180.0",
+            "assets": [
+              {
+                "name": "Zed.dmg",
+                "browser_download_url": "https://github.test/Zed.dmg",
+                "digest": null
+              }
+            ]
+          }
+        ]"#;
+
+        let error = gpui::block_on(fetch_outcome(
+            fake_github(ZED_RELEASE_JSON),
+            &version("0.2.0"),
+            "macos",
+            "aarch64",
+        ))
+        .expect_err("a tag that is not a Suzuri release must not become an update");
+
+        assert!(
+            format!("{error:#}").contains("v0.180.0"),
+            "the error should name the tag it could not read: {error:#}"
+        );
+    }
+
+    #[test]
+    fn test_fetch_outcome_surfaces_an_unreachable_github() {
+        let unreachable = FakeHttpClient::with_404_response();
+
+        let error = gpui::block_on(fetch_outcome(
+            unreachable,
+            &version("0.2.0"),
+            "macos",
+            "aarch64",
+        ))
+        .expect_err("a failed request must not be reported as being up to date");
+
+        assert!(
+            format!("{error:#}").contains("GitHub"),
+            "the error should say what could not be reached: {error:#}"
+        );
+    }
+}

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -196,6 +196,7 @@ sidebar.workspace = true
 smol.workspace = true
 snippet_provider.workspace = true
 snippets_ui.workspace = true
+suzuri_update.workspace = true
 svg_preview.workspace = true
 sysinfo.workspace = true
 tab_switcher.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -663,6 +663,7 @@ fn main() {
         auto_update::init(client.clone(), cx);
         dap_adapters::init(cx);
         auto_update_ui::init(cx);
+        suzuri_update::init(client.http_client(), cx);
         reliability::init(client.clone(), app_state.workspace_store.clone(), cx);
         extension_host::init(
             extension_host_proxy.clone(),

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -64,7 +64,9 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
             disabled: false,
             items: vec![
                 MenuItem::action("About Zed", zed_actions::About),
-                MenuItem::action("Check for Updates", auto_update::Check),
+                // Not `auto_update::Check`: that asks Zed's release server about
+                // Zed's builds, which would offer to install Zed over Suzuri.
+                MenuItem::action("Check for Updates", suzuri_update::CheckForUpdates),
                 MenuItem::separator(),
                 MenuItem::submenu(Menu::new("Settings").items([
                     MenuItem::action("Open Settings", zed_actions::OpenSettings),


### PR DESCRIPTION
Suzuri ships on the **dev** release channel, where `ReleaseChannel::poll_for_updates` returns false, so Zed's auto-updater never polls and an installed build has no way to learn a newer one exists. Separately, the App menu's "Check for Updates" dispatched `auto_update::Check`, which queries Zed's release server about *Zed's* builds — harmless today only because the dev endpoint 404s.

This adds `crates/suzuri_update/`, a fork-owned crate that asks GitHub for the newest `suzuri-v*` release and, when it is newer than the running build, shows a notification with **Download** (linking to the `.dmg`/`.exe` matching the user's OS and CPU) and **Release Notes**. The App menu entry now dispatches `suzuri::CheckForUpdates`, which also reports "up to date" and surfaces failures, where the background check stays silent unless there is something to install.

It notifies only — it never installs. Replacing a running `.app` in place needs signing and rollback guarantees this fork does not make yet, and a broken installer strands every user running the version that shipped it, since the code that would deliver the fix is the code that is broken. Adopting Zed's installer later would additionally need its hardcoded `Zed` DMG mount path in `install_release_macos` reconciled with `bundle-mac`'s `-volname Suzuri`.

### Versioning

The compared version is a new `SUZURI_VERSION` constant rather than `CARGO_PKG_VERSION`. `crates/zed/Cargo.toml` carries **upstream Zed's** version — `1.17.0`, from `Bump Zed to v1.17.0 (#62530)` — which upstream bumps on its own cadence and every merge brings along. It is unrelated to Suzuri's `suzuri-v0.1.0`/`0.1.1`/`0.2.0` tags, so comparing a tag against it compares two unrelated sequences. The constant lives in a file upstream never touches, so no merge can move it.

A new `check-version` job fails a release whose tag and constant disagree in seconds, rather than after three hours of compilation.

To release: bump `SUZURI_VERSION`, tag `suzuri-v<that version>`, push.

### Scope of the fix

Existing 0.2.0 installs cannot be reached by code they do not contain — this starts working for whoever installs the next release. Reaching the current installed base needs a one-time manual nudge.

### Upstream surface

Four shared files, minimally: `crates/zed/src/main.rs` (+1 init call), `crates/zed/src/zed/app_menus.rs` (the menu entry), `crates/zed/Cargo.toml` and the workspace `Cargo.toml` (dependency registration). All are registration points `CLAUDE.md` already lists as recurring merge-conflict sites.

### Testing

- `cargo nextest run -p suzuri_update` — 11 tests, including the decision path end to end against a `FakeHttpClient` serving a realistic `/releases` payload (update available / up to date / no host asset / a non-Suzuri tag / unreachable GitHub).
- `cargo check -p zed` and `cargo clippy -p suzuri_update --all-targets -- --deny warnings` clean.
- Verified against the live API that `harrywang/suzuri`'s newest non-prerelease is `suzuri-v0.2.0` and that its assets are exactly `suzuri-aarch64.dmg`, `suzuri-x86_64.dmg`, `suzuri-windows-x86_64.exe`, which the asset matcher and its tests pin.
- **Not** smoke-tested in a running app; the notification is built with the same `show_app_notification` + `MessageNotification` pattern `auto_update_ui` uses. Worth one `cargo run --profile release-fast` with `SUZURI_VERSION` temporarily lowered before tagging.

### Suggested .rules additions

None.

Release Notes:

- Added a notification when a newer Suzuri release is available, with a direct download link for your platform.
