### PR TITLE
repl: Open .ipynb as notebooks by default and offer ipykernel install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,44 @@ Conflicts recur in the same handful of registration points (`Cargo.toml` members
 replays itself. `README.md` carries `merge=ours` in `.gitattributes` and never conflicts —
 that driver needs `git config merge.ours.driver true` once per clone.
 
+## Contributing fixes upstream
+
+Bugs found while working here are usually *upstream Zed* bugs in vendor files, not
+Suzuri bugs. Fixing them in the fork converts someone else's bug into a permanent merge
+conflict surface; fixing them upstream means the patch returns as ordinary vendor code on
+the next weekly merge, at zero fork delta. So fix them upstream — but do the work in this
+repo, which already has `upstream` wired, rather than a second clone. Add the PR remote
+once:
+
+```sh
+git remote add zed-fork https://github.com/harrywang/zed.git
+```
+
+Two guardrails matter, and both are easy to get wrong.
+
+**1. Always branch from `upstream/main`, never from Suzuri's `main`.** This is the single
+way the workflow goes wrong: branching off `main` drags the fork's entire history into the
+pull request.
+
+```sh
+git fetch upstream
+git worktree add ../suzuri-upstream <branch-name> upstream/main
+```
+
+**2. Use a separate worktree; never switch branches in place.** Suzuri's target dir is
+~63G and a feature worktree's is ~68G. Checking out an upstream branch in the main
+checkout invalidates that incremental build, and checking back invalidates it again — two
+near-full rebuilds per fix. A worktree gets its own target dir. Reuse **one** long-lived
+upstream worktree across fixes, resetting it to a fresh `upstream/main` each time, rather
+than spawning one per bug: the disk cost is per-worktree and it adds up fast.
+
+Carry a fix locally only when waiting for review actually hurts — data loss, or an error
+message so misleading it costs debugging time. Cosmetic fixes should just come back
+through the merge. When carrying one, do **not** tag it `SUZURI:`; that marker means
+deliberate fork behavior. Note it under a "pending upstream" heading with its PR link, so
+a later merge knows to drop the local copy instead of preserving it. If review reshapes
+the patch, the merge conflicts against your local copy — resolve by taking upstream's.
+
 ## Jupyter notebooks (temporary fork delta)
 
 Upstream builds the `.ipynb` notebook editor but gates it behind the unreleased

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ The fork's own changes are small and additive:
 | Project panel header (file/sort/refresh/collapse) and typeset preview menu entry | `crates/project_panel/src/project_panel.rs` |
 | Built-in markdown-oxide language server | `crates/languages/src/markdown_oxide.rs`, `crates/languages/src/lib.rs` |
 | Preview button for `.typ`/`.tex` | `crates/zed/src/zed/quick_action_bar/preview.rs` |
+| Jupyter notebooks enabled by default (temporary; see below) | `crates/feature_flags/src/flags.rs`, `crates/repl/src/notebook/notebook_ui.rs`, `crates/repl/src/repl_editor.rs` |
 | Settings plumbing | `crates/settings_content/`, `assets/settings/default.json` |
 | Branding, CLI name, release infrastructure | `crates/zed/Cargo.toml` (bundle metadata), `crates/zed/resources/app-icon-suzuri*`, `crates/zed/resources/windows/app-icon-suzuri.ico`, `assets/images/suzuri_logo.svg`, `crates/install_cli/src/install_cli_binary.rs`, `script/bundle-mac`, `script/bundle-windows.ps1`, `.github/workflows/suzuri-release.yml` |
 
@@ -145,6 +146,37 @@ Conflicts recur in the same handful of registration points (`Cargo.toml` members
 `quick_action_bar/preview.rs`). `git rerere` is enabled, so a resolution once recorded
 replays itself. `README.md` carries `merge=ours` in `.gitattributes` and never conflicts —
 that driver needs `git config merge.ours.driver true` once per clone.
+
+## Jupyter notebooks (temporary fork delta)
+
+Upstream builds the `.ipynb` notebook editor but gates it behind the unreleased
+`notebooks` feature flag. That flag cannot be turned on in a shipped build — staff rules
+do not apply and `settings.json` overrides are themselves staff-gated
+(`FeatureFlagStore::overrides_enabled`) — so `.ipynb` opens as a language-less JSON
+buffer. **The whole fork delta exists only to bridge the gap until upstream ships this,
+and is designed to be deleted, not maintained.** All three hunks are tagged `SUZURI:`.
+
+1. `crates/feature_flags/src/flags.rs` — `NotebookFeatureFlag::enabled_for_all() -> true`.
+   This is deliberately the only lever used to turn the feature on, so registration still
+   flows through upstream's own `notebook::init`. Do **not** call
+   `register_project_item::<NotebookEditor>` from Suzuri code instead:
+   `ProjectItemRegistry::register` *pushes* onto `build_project_item_for_path_fns`, so
+   that would leave a duplicate opener the moment upstream flips the flag.
+2. `crates/repl/src/repl_editor.rs` — `install_ipykernel_and_assign` split into a
+   reusable `install_ipykernel_with(.., on_ready)`. Pure refactor, no behavior change.
+3. `crates/repl/src/notebook/notebook_ui.rs` — the notebook's kernel picker now installs
+   `ipykernel` when the chosen environment lacks it, matching the toolbar REPL menu.
+   Needed because that toolbar menu is hidden for `.ipynb` (no language on the buffer
+   means `SessionSupport::Unsupported`), leaving notebooks with no way to recover.
+
+`suzuri_notebooks_are_enabled_without_a_feature_flag` in `notebook_ui.rs` pins item 1, so
+a merge that drops the override fails loudly instead of silently reverting to raw JSON.
+
+**When upstream enables notebooks by default**, delete item 1 and its contract test and
+take upstream's `flags.rs` wholesale — nothing else is required, because the notebook
+editor itself was never forked. Items 2 and 3 are worth upstreaming as a PR; until they
+land, they are the only part of this that needs conflict resolution, and
+`notebook_ui.rs` is actively developed upstream, so expect to redo hunk 3 occasionally.
 
 ## Adding a setting
 

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -5,6 +5,21 @@ pub struct NotebookFeatureFlag;
 impl FeatureFlag for NotebookFeatureFlag {
     const NAME: &'static str = "notebooks";
     type Value = PresenceFlag;
+
+    // SUZURI: notebooks are a first-class document type in a research writing
+    // environment, so `.ipynb` must open as a notebook in release builds. Upstream
+    // still gates this, and its overrides are themselves staff-gated, so forcing the
+    // flag here is the only lever that works in a shipped build.
+    //
+    // Deliberately the *only* fork change needed to turn the feature on: it flows
+    // through upstream's own `register_project_item` call, so there is exactly one
+    // registration. Registering from Suzuri's `main.rs` instead would push a second
+    // opener onto `build_project_item_for_path_fns` once upstream flips the flag.
+    //
+    // Delete this method when upstream enables notebooks by default.
+    fn enabled_for_all() -> bool {
+        true
+    }
 }
 register_feature_flag!(NotebookFeatureFlag);
 

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -1310,11 +1310,35 @@ impl NotebookEditor {
             .child(
                 KernelSelector::new(
                     Box::new(move |spec: KernelSpecification, window, cx| {
-                        if let Some(view) = view.upgrade() {
-                            view.update(cx, |this, cx| {
-                                this.change_kernel(spec, window, cx);
-                            });
+                        // SUZURI: mirror the toolbar REPL menu, which installs
+                        // `ipykernel` when the chosen environment lacks it. Without this
+                        // the picker lists such environments (dimmed, labelled
+                        // "ipykernel not installed") but selecting one just fails to
+                        // launch, and the notebook offers no way to fix it — the toolbar
+                        // menu that normally does is hidden for `.ipynb`, whose buffer has
+                        // no language.
+                        if spec.has_ipykernel() {
+                            if let Some(view) = view.upgrade() {
+                                view.update(cx, |this, cx| {
+                                    this.change_kernel(spec, window, cx);
+                                });
+                            }
+                            return;
                         }
+
+                        let view = view.clone();
+                        crate::repl_editor::install_ipykernel_with(
+                            spec,
+                            window,
+                            cx,
+                            move |spec, window, cx| {
+                                if let Some(view) = view.upgrade() {
+                                    view.update(cx, |this, cx| {
+                                        this.change_kernel(spec, window, cx);
+                                    });
+                                }
+                            },
+                        );
                     }),
                     worktree_id,
                     Button::new("kernel-selector", kernel_name.clone())
@@ -2054,7 +2078,26 @@ impl KernelSession for NotebookEditor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use feature_flags::FeatureFlag as _;
     use gpui::TestAppContext;
+
+    // SUZURI: contract test. `init` only registers `NotebookEditor` as the handler for
+    // `.ipynb` when this resolves true, and in a release build `enabled_for_all` is the
+    // only input that can make it so — staff rules do not apply and settings overrides
+    // are themselves staff-gated. If an upstream merge drops the fork's
+    // `enabled_for_all` override, notebooks silently fall back to opening as raw JSON
+    // with no error anywhere. Fail loudly here instead.
+    //
+    // When upstream enables notebooks by default, delete this along with the override.
+    #[test]
+    fn suzuri_notebooks_are_enabled_without_a_feature_flag() {
+        assert!(
+            NotebookFeatureFlag::enabled_for_all(),
+            "Suzuri opens .ipynb as notebooks in release builds; \
+             restore `enabled_for_all` on NotebookFeatureFlag in crates/feature_flags/src/flags.rs"
+        );
+    }
+
     use project::{FakeFs, Project, ProjectItem as _};
     use serde_json::json;
     use settings::SettingsStore;

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -2089,6 +2089,25 @@ mod tests {
     // with no error anywhere. Fail loudly here instead.
     //
     // When upstream enables notebooks by default, delete this along with the override.
+    // SUZURI: `init` runs during app startup, which may be before `FeatureFlagStore`
+    // is installed as a global. `has_flag` must still resolve true then, via the
+    // `has_flag_default` fallback — otherwise registration is skipped for the whole
+    // process lifetime and `.ipynb` silently opens as a language-less JSON buffer,
+    // because the `observe_flag` path in `init` never fires without a store either.
+    #[gpui::test]
+    fn suzuri_notebook_flag_resolves_before_the_store_exists(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            assert!(
+                cx.try_global::<feature_flags::FeatureFlagStore>().is_none(),
+                "precondition: this test is about the no-store path"
+            );
+            assert!(
+                cx.has_flag::<NotebookFeatureFlag>(),
+                "notebooks must resolve on before the feature flag store exists"
+            );
+        });
+    }
+
     #[test]
     fn suzuri_notebooks_are_enabled_without_a_feature_flag() {
         assert!(

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -8,6 +8,7 @@ use editor::{Editor, MultiBufferOffset};
 use gpui::{App, Entity, WeakEntity, Window, prelude::*};
 use language::{BufferSnapshot, Language, LanguageName, Point};
 use project::{ProjectItem as _, WorktreeId};
+use util::ResultExt as _;
 use workspace::{Workspace, notifications::NotificationId};
 
 use crate::kernels::PythonEnvKernelSpecification;
@@ -81,8 +82,30 @@ pub fn install_ipykernel_and_assign(
     window: &mut Window,
     cx: &mut App,
 ) -> Result<()> {
+    install_ipykernel_with(kernel_specification, window, cx, move |spec, window, cx| {
+        assign_kernelspec(spec, weak_editor, window, cx).log_err();
+    });
+    Ok(())
+}
+
+/// Installs `ipykernel` into the Python environment backing `kernel_specification`,
+/// then hands the updated spec to `on_ready`.
+///
+/// Specs that cannot be missing `ipykernel` (Jupyter, remote) are passed through
+/// untouched. Progress and failure are reported as workspace toasts.
+///
+/// Callers that own an [`Editor`] want [`install_ipykernel_and_assign`]; this exists
+/// so the notebook editor, which assigns kernels through its own path rather than
+/// through `assign_kernelspec`, can reuse the same install.
+pub fn install_ipykernel_with(
+    kernel_specification: KernelSpecification,
+    window: &mut Window,
+    cx: &mut App,
+    on_ready: impl FnOnce(KernelSpecification, &mut Window, &mut App) + 'static,
+) {
     let KernelSpecification::PythonEnv(ref env_spec) = kernel_specification else {
-        return assign_kernelspec(kernel_specification, weak_editor, window, cx);
+        on_ready(kernel_specification, window, cx);
+        return;
     };
 
     let python_path = env_spec.path.clone();
@@ -171,7 +194,7 @@ pub fn install_ipykernel_and_assign(
                                 has_ipykernel: true,
                                 ..env_spec
                             });
-                        assign_kernelspec(updated_spec, weak_editor, window, cx).ok();
+                        on_ready(updated_spec, window, cx);
                     })
                     .ok();
             }
@@ -197,8 +220,6 @@ pub fn install_ipykernel_and_assign(
         }
     })
     .detach();
-
-    Ok(())
 }
 
 pub fn run(


### PR DESCRIPTION
Upstream builds a full `.ipynb` notebook editor but gates it behind the unreleased
`notebooks` feature flag, which cannot be enabled in a shipped build: staff rules do not
apply and settings overrides are themselves staff-gated. Nothing else claims the `.ipynb`
extension, so notebooks opened as language-less JSON buffers — no highlighting, no kernel,
and no REPL toolbar, since `SessionSupport::Unsupported` hides it for a buffer with no
language.

## What changed

- `feature_flags`: force `NotebookFeatureFlag::enabled_for_all`. This is deliberately the
  only lever used, so registration still flows through upstream's own `notebook::init`.
  Registering `NotebookEditor` from Suzuri code instead would push a second opener onto
  `build_project_item_for_path_fns` the moment upstream flips the flag.
- `repl_editor`: split `install_ipykernel_and_assign` into a reusable
  `install_ipykernel_with(.., on_ready)`. Pure refactor, no behavior change.
- `notebook_ui`: the notebook kernel picker now installs `ipykernel` when the chosen
  environment lacks it, matching the toolbar REPL menu. The notebook previously listed
  such environments (dimmed, labelled) but selecting one just failed, with no way to
  recover — the toolbar menu that normally offers the install is hidden for `.ipynb`.
- `CLAUDE.md`: document this as a temporary fork delta with its removal recipe, plus the
  workflow and guardrails for upstreaming fixes found while working in the fork.

## Designed to be deleted

The notebook editor itself is not forked. When upstream enables notebooks by default,
delete the `enabled_for_all` override and its contract test and take upstream's
`flags.rs` wholesale. The `install_ipykernel_with` refactor and the picker wiring are
worth upstreaming; until they land they are the only hunks needing conflict resolution.

## Verification

- 41/41 `repl` tests pass; `cargo check -p repl -p feature_flags -p zed` clean; clippy and
  rustfmt clean on the changed files.
- Two contract tests pin the fork behavior: that notebooks resolve on without a flag, and
  that they resolve on before `FeatureFlagStore` exists as a global — the path that would
  otherwise skip registration for the whole process lifetime. Upstream's notebook tests
  call `NotebookItem::try_open` directly, so registration was untested.
- Verified in a real release bundle: notebook renders, cells execute against a uv venv
  kernel, and selecting an environment without `ipykernel` installs it (confirmed
  `ipykernel` 7.3.0 written into a deliberately bare venv by the app).

## Known upstream bugs found while testing

Not addressed here; they are upstream defects in vendor files.

1. The kernel picker offers an `ipykernel` install on externally-managed interpreters
   where it provably cannot succeed, and badges one "Recommended". The failure toast also
   shows uv's `hint:` line with raw ANSI instead of its `error:` line.
2. The toolchain status item goes stale and inert when a non-`Editor` item is focused.
3. Saving a notebook drops rich outputs — a `display_data` PNG and an `execute_result`
   table were lost, and `execute_result` was rewritten to `display_data`.

## Suggested .rules additions

After rebuilding and installing the app, verify the running process actually is the new
binary by comparing its start time against the binary's mtime. `open` and
`script/bundle-mac -o` silently refocus an already-running instance rather than launching
the new build, so a change looks like it failed when it was never loaded. Hit twice in one
session.

Release Notes:

- Added `.ipynb` notebook rendering and execution, with kernel selection and one-click `ipykernel` install