### PR TITLE
repl: Stop dropping notebook outputs on save

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,21 @@ deliberate fork behavior. Note it under a "pending upstream" heading with its PR
 a later merge knows to drop the local copy instead of preserving it. If review reshapes
 the patch, the merge conflicts against your local copy — resolve by taking upstream's.
 
+### Pending upstream
+
+Fixes carried locally while their pull request is in review. These are **not** fork
+behavior — do not tag them `SUZURI:`, and drop the local copy once the merge brings the
+patch back as vendor code. If review reshapes a patch, the merge conflicts against the
+local copy; resolve by taking upstream's.
+
+| Fix | Files | PR |
+| --- | --- | --- |
+| Notebook save destroyed rich outputs (`display_data` images, HTML tables, JSON) and rewrote `execute_result` as `display_data`; cell source also gained a trailing newline, churning every cell | `crates/repl/src/notebook/cell.rs`, `crates/repl/src/outputs.rs` | [zed#63064](https://github.com/zed-industries/zed/pull/63064) |
+
+Carried because it is silent data loss: a notebook with plots or tables lost them on
+save with no error, which is exactly the case the "carry it locally" rule above exists
+for.
+
 ## Jupyter notebooks (temporary fork delta)
 
 Upstream builds the `.ipynb` notebook editor but gates it behind the unreleased

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,27 +179,32 @@ near-full rebuilds per fix. A worktree gets its own target dir. Reuse **one** lo
 upstream worktree across fixes, resetting it to a fresh `upstream/main` each time, rather
 than spawning one per bug: the disk cost is per-worktree and it adds up fast.
 
-Carry a fix locally only when waiting for review actually hurts — data loss, or an error
-message so misleading it costs debugging time. Cosmetic fixes should just come back
-through the merge. When carrying one, do **not** tag it `SUZURI:`; that marker means
-deliberate fork behavior. Note it under a "pending upstream" heading with its PR link, so
-a later merge knows to drop the local copy instead of preserving it. If review reshapes
-the patch, the merge conflicts against your local copy — resolve by taking upstream's.
+**Carrying a fix locally.** An upstream PR can sit in review for weeks, so you may also
+cherry-pick it onto Suzuri's `main` to get the fix now. That is not free: the local copy
+is a delta on a vendor file, and when upstream merges the same patch, the next weekly
+merge collides with it. So carry only when waiting actually hurts — data loss, or an
+error message so misleading it costs debugging time. Cosmetic fixes should just come back
+through the merge.
+
+When carrying one:
+
+- Cherry-pick the upstream commit **unchanged**, so a later merge can recognize it.
+- Do **not** tag it `SUZURI:`. That marker means deliberate fork behavior and tells a
+  future merge to *preserve* the hunk — the opposite of what you want. A carried fix is
+  meant to be deleted the moment upstream's version lands.
+- Add a row to the "Pending upstream" table below, with the PR link, so a later merge
+  knows to drop the local copy instead of keeping it.
+- If review reshapes the patch, the merge conflicts against your local copy — resolve by
+  taking upstream's.
 
 ### Pending upstream
 
-Fixes carried locally while their pull request is in review. These are **not** fork
-behavior — do not tag them `SUZURI:`, and drop the local copy once the merge brings the
-patch back as vendor code. If review reshapes a patch, the merge conflicts against the
-local copy; resolve by taking upstream's.
+Fixes carried locally while their pull request is in review, per the rule above. Drop
+the local copy once a merge brings the patch back as vendor code, and clear the row.
 
 | Fix | Files | PR |
 | --- | --- | --- |
 | Notebook save destroyed rich outputs (`display_data` images, HTML tables, JSON) and rewrote `execute_result` as `display_data`; cell source also gained a trailing newline, churning every cell | `crates/repl/src/notebook/cell.rs`, `crates/repl/src/outputs.rs` | [zed#63064](https://github.com/zed-industries/zed/pull/63064) |
-
-Carried because it is silent data loss: a notebook with plots or tables lost them on
-save with no error, which is exactly the case the "carry it locally" rule above exists
-for.
 
 ## Jupyter notebooks (temporary fork delta)
 

--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -7,6 +7,7 @@ use gpui::{
     App, Entity, EventEmitter, Focusable, Hsla, InteractiveElement, RetainAllImageCache,
     StatefulInteractiveElement, Task, prelude::*,
 };
+use jupyter_protocol::Stdio;
 use language::{Buffer, Language, LanguageRegistry};
 use markdown::{Markdown, MarkdownElement, MarkdownFont, MarkdownStyle};
 use nbformat::v4::{CellId, CellMetadata, CellType};
@@ -116,14 +117,24 @@ pub(crate) enum MovementDirection {
     End,
 }
 
-fn convert_outputs(
-    outputs: &Vec<nbformat::v4::Output>,
-    window: &mut Window,
-    cx: &mut App,
-) -> Vec<Output> {
-    outputs
-        .iter()
-        .map(|output| match output {
+const KERNEL_ERROR_NAME: &str = "Kernel Error";
+const KERNEL_ERROR_VALUE: &str = "cell could not be executed";
+
+/// A rendered output paired with the notebook representation it was built from.
+///
+/// [`Output`] renders only the richest mime type in a bundle and drops the rest,
+/// and images, tables and HTML have no path back to nbformat at all, so saving
+/// has to write this retained copy rather than re-derive one from what is on
+/// screen. Keeping the two together means an output cannot be rendered without
+/// also being saveable.
+pub(super) struct CellOutput {
+    view: Output,
+    serialized: nbformat::v4::Output,
+}
+
+impl CellOutput {
+    fn from_nbformat(output: &nbformat::v4::Output, window: &mut Window, cx: &mut App) -> Self {
+        let view = match output {
             nbformat::v4::Output::Stream { text, .. } => Output::Stream {
                 content: cx.new(|cx| TerminalOutput::from(&text.0, window, cx)),
             },
@@ -139,7 +150,34 @@ fn convert_outputs(
                 traceback: cx
                     .new(|cx| TerminalOutput::from(&error.traceback.join("\n"), window, cx)),
             }),
-        })
+        };
+
+        Self {
+            view,
+            serialized: output.clone(),
+        }
+    }
+}
+
+/// Splits cell source the way the notebook format stores it: one entry per line,
+/// each keeping its trailing newline, with no newline added to the last line.
+/// Appending one unconditionally rewrites every cell the first time a notebook is
+/// saved.
+fn split_source_lines(source: &str) -> Vec<String> {
+    source
+        .split_inclusive('\n')
+        .map(|line| line.to_string())
+        .collect()
+}
+
+fn convert_outputs(
+    outputs: &Vec<nbformat::v4::Output>,
+    window: &mut Window,
+    cx: &mut App,
+) -> Vec<CellOutput> {
+    outputs
+        .iter()
+        .map(|output| CellOutput::from_nbformat(output, window, cx))
         .collect()
 }
 
@@ -487,7 +525,7 @@ impl MarkdownCell {
 
     pub fn to_nbformat_cell(&self, cx: &App) -> nbformat::v4::Cell {
         let source = self.current_source(cx);
-        let source_lines: Vec<String> = source.lines().map(|l| format!("{}\n", l)).collect();
+        let source_lines: Vec<String> = split_source_lines(&source);
 
         nbformat::v4::Cell::Markdown {
             id: self.id.clone(),
@@ -651,7 +689,7 @@ pub struct CodeCell {
     execution_count: Option<i32>,
     source: String,
     editor: Entity<editor::Editor>,
-    outputs: Vec<Output>,
+    outputs: Vec<CellOutput>,
     selected: bool,
     cell_position: Option<CellPosition>,
     _language_task: Task<()>,
@@ -668,12 +706,12 @@ pub(super) enum CellSource {
     /// Backed by an existing notebook cell
     Existing {
         execution_count: Option<i32>,
-        outputs: Vec<Output>,
+        outputs: Vec<CellOutput>,
     },
 }
 
 impl CellSource {
-    fn into_outputs(self) -> (Option<i32>, Vec<Output>) {
+    fn into_outputs(self) -> (Option<i32>, Vec<CellOutput>) {
         match self {
             CellSource::Existing {
                 execution_count,
@@ -774,9 +812,9 @@ impl CodeCell {
 
     pub fn to_nbformat_cell(&self, cx: &App) -> nbformat::v4::Cell {
         let source = self.current_source(cx);
-        let source_lines: Vec<String> = source.lines().map(|l| format!("{}\n", l)).collect();
+        let source_lines: Vec<String> = split_source_lines(&source);
 
-        let outputs = self.outputs_to_nbformat(cx);
+        let outputs = self.outputs_to_nbformat();
 
         nbformat::v4::Cell::Code {
             id: self.id.clone(),
@@ -787,10 +825,10 @@ impl CodeCell {
         }
     }
 
-    fn outputs_to_nbformat(&self, cx: &App) -> Vec<nbformat::v4::Output> {
+    fn outputs_to_nbformat(&self) -> Vec<nbformat::v4::Output> {
         self.outputs
             .iter()
-            .filter_map(|output| output.to_nbformat(cx))
+            .map(|output| output.serialized.clone())
             .collect()
     }
 
@@ -829,11 +867,18 @@ impl CodeCell {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.outputs.push(Output::ErrorOutput(ErrorView {
-            ename: "Kernel Error".to_string(),
-            evalue: "cell could not be executed".to_string(),
-            traceback: cx.new(|cx| TerminalOutput::from(error_message, window, cx)),
-        }));
+        self.outputs.push(CellOutput {
+            view: Output::ErrorOutput(ErrorView {
+                ename: KERNEL_ERROR_NAME.to_string(),
+                evalue: KERNEL_ERROR_VALUE.to_string(),
+                traceback: cx.new(|cx| TerminalOutput::from(error_message, window, cx)),
+            }),
+            serialized: nbformat::v4::Output::Error(nbformat::v4::ErrorOutput {
+                ename: KERNEL_ERROR_NAME.to_string(),
+                evalue: KERNEL_ERROR_VALUE.to_string(),
+                traceback: error_message.lines().map(|line| line.to_string()).collect(),
+            }),
+        });
         self.execution_start_time = None;
         self.is_executing = false;
         cx.notify();
@@ -864,17 +909,37 @@ impl CodeCell {
     ) {
         match &message.content {
             JupyterMessageContent::StreamContent(stream) => {
-                self.outputs.push(Output::Stream {
-                    content: cx.new(|cx| TerminalOutput::from(&stream.text, window, cx)),
+                self.outputs.push(CellOutput {
+                    view: Output::Stream {
+                        content: cx.new(|cx| TerminalOutput::from(&stream.text, window, cx)),
+                    },
+                    serialized: nbformat::v4::Output::Stream {
+                        name: match stream.name {
+                            Stdio::Stdout => "stdout".to_string(),
+                            Stdio::Stderr => "stderr".to_string(),
+                        },
+                        text: nbformat::v4::MultilineString(stream.text.clone()),
+                    },
                 });
             }
             JupyterMessageContent::DisplayData(display_data) => {
-                self.outputs
-                    .push(Output::new(&display_data.data, None, window, cx));
+                self.outputs.push(CellOutput {
+                    view: Output::new(&display_data.data, None, window, cx),
+                    serialized: nbformat::v4::Output::DisplayData(nbformat::v4::DisplayData {
+                        data: display_data.data.clone(),
+                        metadata: display_data.metadata.clone(),
+                    }),
+                });
             }
             JupyterMessageContent::ExecuteResult(execute_result) => {
-                self.outputs
-                    .push(Output::new(&execute_result.data, None, window, cx));
+                self.outputs.push(CellOutput {
+                    view: Output::new(&execute_result.data, None, window, cx),
+                    serialized: nbformat::v4::Output::ExecuteResult(nbformat::v4::ExecuteResult {
+                        execution_count: execute_result.execution_count,
+                        data: execute_result.data.clone(),
+                        metadata: execute_result.metadata.clone(),
+                    }),
+                });
             }
             JupyterMessageContent::ExecuteInput(input) => {
                 self.execution_count = serde_json::to_value(&input.execution_count)
@@ -886,12 +951,20 @@ impl CodeCell {
                 self.finish_execution();
             }
             JupyterMessageContent::ErrorOutput(error) => {
-                self.outputs.push(Output::ErrorOutput(ErrorView {
-                    ename: error.ename.clone(),
-                    evalue: error.evalue.clone(),
-                    traceback: cx
-                        .new(|cx| TerminalOutput::from(&error.traceback.join("\n"), window, cx)),
-                }));
+                self.outputs.push(CellOutput {
+                    view: Output::ErrorOutput(ErrorView {
+                        ename: error.ename.clone(),
+                        evalue: error.evalue.clone(),
+                        traceback: cx.new(|cx| {
+                            TerminalOutput::from(&error.traceback.join("\n"), window, cx)
+                        }),
+                    }),
+                    serialized: nbformat::v4::Output::Error(nbformat::v4::ErrorOutput {
+                        ename: error.ename.clone(),
+                        evalue: error.evalue.clone(),
+                        traceback: error.traceback.clone(),
+                    }),
+                });
             }
             _ => {}
         }
@@ -1220,7 +1293,7 @@ impl Render for CodeCell {
                                                     div.max_h(max_height).overflow_y_scroll()
                                                 })
                                                 .children(self.outputs.iter().map(|output| {
-                                                    div().children(output.content(window, cx))
+                                                    div().children(output.view.content(window, cx))
                                                 })),
                                         ),
                                 ),
@@ -1243,7 +1316,7 @@ pub struct RawCell {
 
 impl RawCell {
     pub fn to_nbformat_cell(&self) -> nbformat::v4::Cell {
-        let source_lines: Vec<String> = self.source.lines().map(|l| format!("{}\n", l)).collect();
+        let source_lines: Vec<String> = split_source_lines(&self.source);
 
         nbformat::v4::Cell::Raw {
             id: self.id.clone(),
@@ -1319,5 +1392,176 @@ impl Render for RawCell {
             )
             // TODO: Move base cell render into trait impl so we don't have to repeat this
             .children(self.cell_position_spacer(false, window, cx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::FutureExt as _;
+    use gpui::TestAppContext;
+    use jupyter_protocol::{ExecutionCount, Media, MediaType};
+
+    /// A 1x1 transparent PNG, the smallest thing `ImageView` will accept.
+    const PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            settings::init(cx);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            editor::init(cx);
+        });
+    }
+
+    fn empty_metadata() -> CellMetadata {
+        serde_json::from_value(serde_json::json!({})).unwrap()
+    }
+
+    fn code_cell(outputs: Vec<nbformat::v4::Output>) -> nbformat::v4::Cell {
+        nbformat::v4::Cell::Code {
+            id: "cell-1".to_string().try_into().unwrap(),
+            metadata: empty_metadata(),
+            execution_count: Some(1),
+            source: vec!["print('hi')".to_string()],
+            outputs,
+        }
+    }
+
+    fn round_trip(
+        cell: &nbformat::v4::Cell,
+        cx: &mut TestAppContext,
+    ) -> (Vec<nbformat::v4::Output>, Vec<String>) {
+        let languages = Arc::new(LanguageRegistry::test(cx.executor()));
+        let cx = cx.add_empty_window();
+        let loaded = cx.update(|window, cx| {
+            let language = Task::ready(None).shared();
+            Cell::load(cell, &languages, language, window, cx)
+        });
+
+        cx.update(|_, cx| match loaded.to_nbformat_cell(cx) {
+            nbformat::v4::Cell::Code {
+                outputs, source, ..
+            } => (outputs, source),
+            _ => panic!("expected a code cell"),
+        })
+    }
+
+    /// Rich outputs used to be dropped on save: `Output` renders only the richest
+    /// mime type in a bundle, and images, tables and HTML had no path back to
+    /// nbformat at all, so `filter_map` silently discarded them.
+    #[gpui::test]
+    async fn test_rich_outputs_survive_a_round_trip(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let mut image_data = Media::default();
+        image_data
+            .content
+            .push(MediaType::Png(PNG_BASE64.to_string()));
+        let mut html_data = Media::default();
+        html_data.content.push(MediaType::Html(
+            "<table><tr><td>1</td></tr></table>".to_string(),
+        ));
+        html_data.content.push(MediaType::Plain("   1".to_string()));
+
+        let original = vec![
+            nbformat::v4::Output::DisplayData(nbformat::v4::DisplayData {
+                data: image_data,
+                metadata: serde_json::Map::new(),
+            }),
+            nbformat::v4::Output::ExecuteResult(nbformat::v4::ExecuteResult {
+                execution_count: ExecutionCount::new(1),
+                data: html_data,
+                metadata: serde_json::Map::new(),
+            }),
+        ];
+
+        let (saved, _) = round_trip(&code_cell(original.clone()), cx);
+
+        assert_eq!(
+            saved.len(),
+            original.len(),
+            "no output may be dropped on save"
+        );
+        assert_eq!(
+            serde_json::to_value(&saved).unwrap(),
+            serde_json::to_value(&original).unwrap(),
+            "outputs must be written back unchanged"
+        );
+    }
+
+    /// An `execute_result` used to be rewritten as `display_data`, losing its
+    /// `execution_count`, because the saved form was re-derived from the view.
+    #[gpui::test]
+    async fn test_execute_result_keeps_its_output_type(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let mut data = Media::default();
+        data.content.push(MediaType::Plain("42".to_string()));
+        let original = vec![nbformat::v4::Output::ExecuteResult(
+            nbformat::v4::ExecuteResult {
+                execution_count: ExecutionCount::new(7),
+                data,
+                metadata: serde_json::Map::new(),
+            },
+        )];
+
+        let (saved, _) = round_trip(&code_cell(original), cx);
+
+        match saved.as_slice() {
+            [nbformat::v4::Output::ExecuteResult(result)] => {
+                assert_eq!(result.execution_count, ExecutionCount::new(7));
+            }
+            other => panic!("expected one execute_result, got {other:?}"),
+        }
+    }
+
+    /// A `stderr` stream used to be relabelled `stdout` on save.
+    #[gpui::test]
+    async fn test_stream_keeps_its_name(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let original = vec![nbformat::v4::Output::Stream {
+            name: "stderr".to_string(),
+            text: nbformat::v4::MultilineString("a warning\n".to_string()),
+        }];
+
+        let (saved, _) = round_trip(&code_cell(original), cx);
+
+        match saved.as_slice() {
+            [nbformat::v4::Output::Stream { name, .. }] => assert_eq!(name, "stderr"),
+            other => panic!("expected one stream output, got {other:?}"),
+        }
+    }
+
+    /// Saving used to append a newline to every line of every cell, rewriting the
+    /// whole file the first time a notebook was saved.
+    #[gpui::test]
+    async fn test_source_lines_do_not_gain_a_trailing_newline(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let cell = nbformat::v4::Cell::Code {
+            id: "cell-1".to_string().try_into().unwrap(),
+            metadata: empty_metadata(),
+            execution_count: Some(1),
+            source: vec!["import os\n".to_string(), "print(os.name)".to_string()],
+            outputs: Vec::new(),
+        };
+
+        let (_, source) = round_trip(&cell, cx);
+
+        assert_eq!(source, vec!["import os\n", "print(os.name)"]);
+    }
+
+    #[test]
+    fn test_split_source_lines() {
+        assert_eq!(split_source_lines(""), Vec::<String>::new());
+        assert_eq!(split_source_lines("one"), vec!["one"]);
+        assert_eq!(split_source_lines("one\n"), vec!["one\n"]);
+        assert_eq!(split_source_lines("one\ntwo"), vec!["one\n", "two"]);
+        assert_eq!(
+            split_source_lines("one\ntwo\n"),
+            vec!["one\n", "two\n"],
+            "a trailing newline belongs to the last line, not a new empty one"
+        );
     }
 }

--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -140,47 +140,6 @@ pub enum Output {
 }
 
 impl Output {
-    pub fn to_nbformat(&self, cx: &App) -> Option<nbformat::v4::Output> {
-        match self {
-            Output::Stream { content } => {
-                let text = content.read(cx).full_text(cx);
-                Some(nbformat::v4::Output::Stream {
-                    name: "stdout".to_string(),
-                    text: nbformat::v4::MultilineString(text),
-                })
-            }
-            Output::Plain { content, .. } => {
-                let text = content.read(cx).full_text(cx);
-                let mut data = jupyter_protocol::media::Media::default();
-                data.content.push(jupyter_protocol::MediaType::Plain(text));
-                Some(nbformat::v4::Output::DisplayData(
-                    nbformat::v4::DisplayData {
-                        data,
-                        metadata: serde_json::Map::new(),
-                    },
-                ))
-            }
-            Output::ErrorOutput(error_view) => {
-                let traceback_text = error_view.traceback.read(cx).full_text(cx);
-                let traceback_lines: Vec<String> =
-                    traceback_text.lines().map(|s| s.to_string()).collect();
-                Some(nbformat::v4::Output::Error(nbformat::v4::ErrorOutput {
-                    ename: error_view.ename.clone(),
-                    evalue: error_view.evalue.clone(),
-                    traceback: traceback_lines,
-                }))
-            }
-            Output::Image { .. }
-            | Output::Markdown { .. }
-            | Output::Table { .. }
-            | Output::Json { .. } => None,
-            Output::Message(_) => None,
-            Output::ClearOutputWaitMarker => None,
-        }
-    }
-}
-
-impl Output {
     fn render_output_controls<V: OutputContent + 'static>(
         v: Entity<V>,
         workspace: WeakEntity<Workspace>,


### PR DESCRIPTION
Carries [zed#63064](https://github.com/zed-industries/zed/pull/63064) locally while it is in review.

Saving a notebook silently destroyed every rich output: `display_data` images, HTML tables, JSON and markdown outputs vanished from the file with no error, and `execute_result` outputs came back as `display_data` with their `execution_count` gone. `stderr` streams were relabelled `stdout`, output metadata was blanked, and every cell's source gained a trailing newline — which rewrote the whole file on the first save and buried the loss in the diff.

The cause: `CodeCell::outputs_to_nbformat` re-derived the saved notebook from the *rendered views*. `Output::new` keeps only the richest mime type in a bundle, and `Output::to_nbformat` had no case at all for `Image`, `Table`, `Markdown` or `Json` — it returned `None` for each and `filter_map` dropped them.

A cell now retains the nbformat output it was built from alongside the view that renders it, so saving writes back what was loaded or what the kernel sent.

## Why carry it instead of waiting for the merge

Per `CLAUDE.md`, a fix is carried locally only when waiting for review actually hurts — data loss being the named case. This is silent data loss: a notebook with plots or tables loses them on save with no warning. Suzuri ships notebooks on by default, so this is reachable here today in a way it is not upstream, where the feature is still flag-gated.

The commit is cherry-picked byte-identically from the upstream PR branch and is **not** tagged `SUZURI:`, per the convention for carried fixes. `CLAUDE.md` gains a "Pending upstream" section recording it with the PR link, so a later merge drops the local copy rather than preserving it as fork behavior. If review reshapes the patch, resolve the merge conflict by taking upstream's.

## Verification

- `cargo nextest run -p repl` — all tests pass, including four new round-trip regression tests and one unit test.
- The regression tests were mutation-checked: reverting the fix makes all five fail.
- Exercised in a real build against a notebook holding a PNG `display_data`, an HTML-table `execute_result`, a `stderr` stream and an `execute_result` with `execution_count: 7`. All four survived a real Cmd+S; before the fix the first two were deleted outright.
- Applies cleanly: `crates/repl/src/notebook/cell.rs` and `crates/repl/src/outputs.rs` are byte-identical between `upstream/main` and Suzuri's `main`, and Suzuri's own `repl` deltas only call `to_nbformat_cell`, whose signature is unchanged.

Release Notes:

- Fixed image, table, JSON and markdown outputs being silently dropped when saving a notebook
