### PR TITLE
markdown_live_preview: Let buttons inside block widgets keep their clicks

### DIFF
--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -20,8 +20,8 @@ use editor::{
 };
 use gpui::{
     App, AppContext as _, Context, Empty, Entity, Focusable as _, FontWeight, HighlightStyle, Hsla,
-    ImageSource, IntoElement, MouseButton, Resource, SharedString, SharedUri, StrikethroughStyle,
-    Subscription, TextStyleRefinement, WeakEntity, Window, actions, img, rems,
+    ImageSource, IntoElement, MouseButton, MouseDownEvent, Resource, SharedString, SharedUri,
+    StrikethroughStyle, Subscription, TextStyleRefinement, WeakEntity, Window, actions, img, rems,
 };
 use language::LanguageName;
 use markdown::{HeadingLevelStyles, Markdown, MarkdownElement, MarkdownFont, MarkdownStyle};
@@ -1229,6 +1229,35 @@ fn buffer_base_directory(editor: &Editor, cx: &App) -> Option<PathBuf> {
     Some(path)
 }
 
+/// Click-to-reveal for a block widget: puts the cursor at the block's first
+/// offset, which makes `recompute` drop the widget and show the raw markdown.
+///
+/// Clicks that a child button already claimed are skipped. `ButtonLike` calls
+/// `window.prevent_default()` on left mouse down for exactly this reason, and
+/// the editor's own `mouse_left_down` honors it — without the same check here,
+/// pressing a rendered code block's copy button tore the widget down before
+/// the mouse up could complete the click, so it revealed source instead of
+/// copying.
+fn reveal_source_on_mouse_down(
+    editor: WeakEntity<Editor>,
+    start: Anchor,
+) -> impl Fn(&MouseDownEvent, &mut Window, &mut App) + 'static {
+    move |_, window, cx| {
+        if window.default_prevented() {
+            return;
+        }
+        editor
+            .update(cx, |editor, cx| {
+                let snapshot = editor.buffer().read(cx).snapshot(cx);
+                let offset = start.to_offset(&snapshot);
+                editor.change_selections(Default::default(), window, cx, |selections| {
+                    selections.select_ranges([offset..offset]);
+                });
+            })
+            .log_err();
+    }
+}
+
 fn render_markdown_block(
     markdown: Entity<Markdown>,
     editor: WeakEntity<Editor>,
@@ -1248,17 +1277,10 @@ fn render_markdown_block(
             .pl(gutter_width)
             .w(max_width)
             .cursor_pointer()
-            .on_mouse_down(MouseButton::Left, move |_, window, cx| {
-                editor
-                    .update(cx, |editor, cx| {
-                        let snapshot = editor.buffer().read(cx).snapshot(cx);
-                        let offset = start.to_offset(&snapshot);
-                        editor.change_selections(Default::default(), window, cx, |selections| {
-                            selections.select_ranges([offset..offset]);
-                        });
-                    })
-                    .log_err();
-            })
+            .on_mouse_down(
+                MouseButton::Left,
+                reveal_source_on_mouse_down(editor, start),
+            )
             .child(
                 MarkdownElement::new(markdown.clone(), style).image_resolver(
                     move |destination, _cx| {
@@ -3017,17 +3039,10 @@ fn render_rule_block(
             .flex()
             .items_center()
             .cursor_pointer()
-            .on_mouse_down(MouseButton::Left, move |_, window, cx| {
-                editor
-                    .update(cx, |editor, cx| {
-                        let snapshot = editor.buffer().read(cx).snapshot(cx);
-                        let offset = start.to_offset(&snapshot);
-                        editor.change_selections(Default::default(), window, cx, |selections| {
-                            selections.select_ranges([offset..offset]);
-                        });
-                    })
-                    .log_err();
-            })
+            .on_mouse_down(
+                MouseButton::Left,
+                reveal_source_on_mouse_down(editor, start),
+            )
             .child(div().flex_1().h(gpui::px(2.)).bg(border_color))
             .into_any_element()
     })
@@ -3091,23 +3106,10 @@ fn render_math_block(
             .justify_center()
             .items_center()
             .when(!below, |this| {
-                this.cursor_pointer()
-                    .on_mouse_down(MouseButton::Left, move |_, window, cx| {
-                        editor
-                            .update(cx, |editor, cx| {
-                                let snapshot = editor.buffer().read(cx).snapshot(cx);
-                                let offset = start.to_offset(&snapshot);
-                                editor.change_selections(
-                                    Default::default(),
-                                    window,
-                                    cx,
-                                    |selections| {
-                                        selections.select_ranges([offset..offset]);
-                                    },
-                                );
-                            })
-                            .log_err();
-                    })
+                this.cursor_pointer().on_mouse_down(
+                    MouseButton::Left,
+                    reveal_source_on_mouse_down(editor, start),
+                )
             })
             .child(content)
             .into_any_element()
@@ -3144,17 +3146,10 @@ fn render_frontmatter_block(
             .w(block_cx.max_width)
             .py(gpui::px(2.))
             .cursor_pointer()
-            .on_mouse_down(MouseButton::Left, move |_, window, cx| {
-                editor
-                    .update(cx, |editor, cx| {
-                        let snapshot = editor.buffer().read(cx).snapshot(cx);
-                        let offset = start.to_offset(&snapshot);
-                        editor.change_selections(Default::default(), window, cx, |selections| {
-                            selections.select_ranges([offset..offset]);
-                        });
-                    })
-                    .log_err();
-            })
+            .on_mouse_down(
+                MouseButton::Left,
+                reveal_source_on_mouse_down(editor, start),
+            )
             .child(
                 v_flex()
                     .rounded_md()

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -1,9 +1,9 @@
 use super::*;
 use editor::test::editor_test_context::EditorTestContext;
-use gpui::TestAppContext;
+use gpui::{Modifiers, TestAppContext};
 use language::{Language, LanguageConfig};
 use settings::SettingsStore;
-use std::sync::Arc;
+use std::{cell::Cell, rc::Rc, sync::Arc};
 
 fn init_test(cx: &mut TestAppContext) {
     cx.update(|cx| {
@@ -1901,4 +1901,59 @@ async fn test_markdown_inline_grammar_emits_latex_block(cx: &mut TestAppContext)
     cx.set_state("ˇsome $E = mc^2$ math\n");
     cx.executor().run_until_parked();
     pretty_assertions::assert_eq!(cx.display_text(), "some ⋯ math\n");
+}
+
+/// A block widget's click-to-reveal defers to buttons rendered inside it by
+/// checking `window.default_prevented()`, which `ButtonLike` sets on left mouse
+/// down. If upstream stopped setting it, pressing a rendered code block's copy
+/// button would tear the widget down mid-click and reveal source instead of
+/// copying.
+#[gpui::test]
+fn test_buttons_prevent_default_on_mouse_down(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    struct ButtonInsideWidget(Rc<Cell<Option<bool>>>);
+
+    impl Render for ButtonInsideWidget {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let prevented = self.0.clone();
+            div()
+                .size_full()
+                .on_mouse_down(MouseButton::Left, move |_, window, _| {
+                    prevented.set(Some(window.default_prevented()));
+                })
+                .child(
+                    div().debug_selector(|| "BUTTON".into()).child(
+                        ui::Button::new("copy", "Copy")
+                            .full_width()
+                            .on_click(|_, _, _| {}),
+                    ),
+                )
+        }
+    }
+
+    let prevented = Rc::new(Cell::new(None));
+    let (_view, cx) = cx.add_window_view({
+        let prevented = prevented.clone();
+        move |_window, _cx| ButtonInsideWidget(prevented)
+    });
+    cx.run_until_parked();
+
+    let bounds = cx
+        .debug_bounds("BUTTON")
+        .expect("the button should have been laid out");
+    cx.simulate_event(MouseDownEvent {
+        position: bounds.center(),
+        button: MouseButton::Left,
+        modifiers: Modifiers::default(),
+        click_count: 1,
+        first_mouse: false,
+    });
+
+    pretty_assertions::assert_eq!(
+        prevented.get(),
+        Some(true),
+        "a button no longer prevents the default mouse-down action, so a block \
+         widget's click-to-reveal will fire on button presses"
+    );
 }


### PR DESCRIPTION
The copy button on a rendered code block never copied. Pressing it dropped the block into raw-source edit mode instead, so the clipboard was left untouched and the rendered view was lost — the one gesture guaranteed to fail was the button's own.

## Why it happened

Live preview replaces a fenced code block with a widget and wraps it in a div whose left mouse down places the cursor at the block's first offset. That is the click-to-reveal gesture, and it is correct for a click anywhere in the block — except on a button.

GPUI dispatches bubble-phase mouse listeners in reverse registration order, so a child's handlers run before its ancestors'. `ButtonLike` uses that: it calls `window.prevent_default()` on left mouse down, and `cx.stop_propagation()` on click. The second half is what most container/child pairs rely on, and it is useless here — by the time the click resolves on mouse up, the damage is done. The mouse down had already revealed the source, `recompute` had already dropped the replace block, and the button element no longer existed to receive the mouse up. `on_click` — the handler that writes the clipboard — was never reached.

The first half is the part that matters, and the editor already honors it: `EditorElement::mouse_left_down` opens with `if window.default_prevented() { return; }`, which is how buttons drawn over the editor avoid moving the cursor. Live preview's own block handlers never adopted the same check.

So the button was wired correctly the entire time. It was being destroyed mid-click.

## What changed

The four block kinds that reveal source on mouse down — markdown (which covers headings, code blocks, block quotes and HTML blocks), rule, frontmatter and math — each carried their own copy of the same handler. They now share one `reveal_source_on_mouse_down` helper that checks `window.default_prevented()` first.

Only the markdown block can currently contain a button, so that is where the behavior changes: the code block's copy and wrap buttons keep their clicks. Clicking anywhere else in a block still reveals source exactly as before. Folding the other three into the helper is deduplication, not a behavior change, and keeps the check from being the kind of thing a fifth call site forgets.

## Verification

- `cargo nextest run -p markdown_live_preview` — 44/44 pass. `cargo check -p markdown_live_preview --all-targets` clean.
- The new contract test is mutation-checked: swapping `ui::Button` for a plain `div` makes the parent observe `Some(false)` and the test fails, so it pins the button's behavior rather than passing vacuously.
- Exercised in a real build (`release-fast` binary in a copy of the installed bundle): the copy button copies and flips to its checkmark with the block staying rendered, and clicking elsewhere in the block, or on a heading, still reveals source.
- rustfmt and clippy add nothing. Both report only pre-existing drift in this crate — verified by stashing the change and re-running, which yields the identical 13 `unnecessary_cast` errors and the same single rustfmt hunk.

## Contract test

This crate now depends on an upstream behavior it did not before, so `test_buttons_prevent_default_on_mouse_down` joins the contract tests section: it renders a `ui::Button` inside a parent that records `window.default_prevented()` during mouse down and asserts it is set. If upstream ever stops setting it, that fails loudly instead of quietly returning us to a copy button that opens the editor.

## Suggested .rules additions

A GPUI container that mutates state on mouse down must check `window.default_prevented()` before acting, or it will destroy any button rendered inside it before that button's click can complete. `ButtonLike` sets the flag on left mouse down for exactly this reason and `EditorElement::mouse_left_down` honors it. Relying on the button's `cx.stop_propagation()` does not help: that fires on click, which is one event too late.

Meets the non-obvious bar — the button looks correctly wired, and the failure presents as "the button does nothing" rather than as an event-ordering problem. On the repeatedly-encountered bar it is one session, but four call sites in this crate had already been written with the same omission.

Release Notes:

- Fixed the copy button on a rendered code block putting the block into edit mode instead of copying
