### PR TITLE
PDF atlas leak

### DIFF
--- a/crates/pdf_viewer/src/pdf_viewer.rs
+++ b/crates/pdf_viewer/src/pdf_viewer.rs
@@ -91,7 +91,9 @@ pub struct PdfViewer {
     focus_handle: FocusHandle,
     scroll_handle: ScrollHandle,
     metadata: Option<PdfMetadata>,
-    rendered_pages: HashMap<usize, (f32, Arc<RenderImage>)>,
+    /// Only ever mutated through `place_rendered_page` and
+    /// `take_rendered_pages`, so no page's atlas tile can be orphaned.
+    rendered_pages: RenderedPages,
     pages_in_flight: HashSet<usize>,
     cancel_token: Arc<AtomicBool>,
     render_task: Task<()>,
@@ -109,22 +111,87 @@ pub struct PdfViewer {
     is_selecting: bool,
 }
 
+/// The rendered page cache, keyed by page index, holding the scale each page
+/// was rasterised at alongside its image.
+type RenderedPages = HashMap<usize, (f32, Arc<RenderImage>)>;
+
+/// Places a freshly rendered page, returning the image it displaced so the
+/// caller can free that image's sprite-atlas tile with `App::drop_image`.
+///
+/// A `RenderImage`'s GPU tile is keyed by a process-unique id and lives until an
+/// explicit `drop_image`; dropping the `Arc` frees only the CPU bitmap, and the
+/// Metal atlas has no eviction. A page tile fills a whole atlas texture, so a
+/// page left behind holds that texture for the window's lifetime: about 10.5 MiB
+/// for a Letter page in a 730 px split on a Retina display, and about 28 MiB at
+/// a 1200 px pane, because `render_scale` grows with the pane.
+fn place_rendered_page(
+    rendered_pages: &mut RenderedPages,
+    page_index: usize,
+    scale: f32,
+    image: Arc<RenderImage>,
+) -> Option<Arc<RenderImage>> {
+    rendered_pages
+        .insert(page_index, (scale, image))
+        .map(|(_scale, displaced)| displaced)
+}
+
+/// Empties the rendered page cache, handing back every image so the caller can
+/// free the tiles. Used when the document is replaced on disk and when the tab
+/// is released.
+fn take_rendered_pages(rendered_pages: &mut RenderedPages) -> Vec<Arc<RenderImage>> {
+    rendered_pages
+        .drain()
+        .map(|(_index, (_scale, image))| image)
+        .collect()
+}
+
 impl PdfViewer {
+    /// Registers the two things every `PdfViewer` needs, wherever it is built.
+    ///
+    /// `clone_on_split` builds its view from a struct literal rather than going
+    /// through `new`, so anything registered only in `new` silently misses the
+    /// split: before this was factored out, a split pane never reloaded when the
+    /// file changed and never freed a tile when it closed.
+    fn register_subscriptions(pdf_item: &Entity<PdfItem>, cx: &mut Context<Self>) {
+        // Live-preview loop: the item reloads itself when the file changes
+        // on disk (e.g. a Typst/LaTeX recompile); rebuild rendering state
+        // but keep zoom and scroll so the document doesn't jump.
+        cx.subscribe(pdf_item, |this, _, event: &pdf_item::PdfItemEvent, cx| {
+            match event {
+                pdf_item::PdfItemEvent::Reloaded => this.reload_document(cx),
+            }
+        })
+        .detach();
+        // Free the sprite-atlas tiles of every page still displayed when the
+        // tab closes. Dropping the view frees the CPU bitmaps, but a
+        // RenderImage's GPU tile lives until drop_image, so without this every
+        // page ever shown leaks for the window's lifetime.
+        //
+        // `on_release`, not `on_release_in`: release callbacks run from
+        // `release_dropped_entities` with an `&mut App` and no window in hand,
+        // so the window is still in `App.windows` and `None` reaches it.
+        // `on_release_in` would run inside `update_window_id`, which takes the
+        // window out of the map, and `None` would then free nothing.
+        cx.on_release(|this, cx| {
+            // The render thread is detached (its JoinHandle is discarded) and
+            // holds the whole document as an Arc<[u8]>, so without this a closed
+            // tab leaves it rasterising a page nobody will see. It notices when
+            // the token flips or when its send fails, whichever comes first.
+            this.cancel_token.store(true, Ordering::Relaxed);
+            for image in take_rendered_pages(&mut this.rendered_pages) {
+                cx.drop_image(image, None);
+            }
+        })
+        .detach();
+    }
+
     pub fn new(
         pdf_item: Entity<PdfItem>,
         project: Entity<Project>,
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        // Live-preview loop: the item reloads itself when the file changes
-        // on disk (e.g. a Typst/LaTeX recompile); rebuild rendering state
-        // but keep zoom and scroll so the document doesn't jump.
-        cx.subscribe(&pdf_item, |this, _, event: &pdf_item::PdfItemEvent, cx| {
-            match event {
-                pdf_item::PdfItemEvent::Reloaded => this.reload_document(cx),
-            }
-        })
-        .detach();
+        Self::register_subscriptions(&pdf_item, cx);
         let mut this = Self {
             pdf_item,
             project,
@@ -155,7 +222,14 @@ impl PdfViewer {
         self.cancel_token.store(true, Ordering::Relaxed);
         self.cancel_token = Arc::new(AtomicBool::new(false));
         self.pages_in_flight.clear();
-        self.rendered_pages.clear();
+        // Every page is about to be re-rendered into a new RenderImage, so the
+        // outgoing ones must give their atlas tiles back. A typeset preview
+        // recompiles on each pause in typing and rewrites the same PDF, so this
+        // path runs constantly and dropping the images alone would orphan a
+        // texture per page per recompile.
+        for image in take_rendered_pages(&mut self.rendered_pages) {
+            cx.drop_image(image, None);
+        }
         self.text_layouts.clear();
         self.selection_start = None;
         self.selection_end = None;
@@ -177,7 +251,24 @@ impl PdfViewer {
                         "pdf_viewer: loaded metadata — {} pages",
                         metadata.page_count
                     );
+                    // Read the count before the move: PdfMetadata owns a Vec of
+                    // page dimensions, so it is not Copy.
+                    let page_count = metadata.page_count;
                     this.metadata = Some(metadata);
+                    // A recompile can shorten the document. Pages past the new
+                    // end would otherwise sit in the cache forever, holding a
+                    // texture each, because nothing re-renders or clears them.
+                    let dropped: Vec<_> = this
+                        .rendered_pages
+                        .keys()
+                        .copied()
+                        .filter(|index| *index >= page_count)
+                        .collect();
+                    for index in dropped {
+                        if let Some((_scale, image)) = this.rendered_pages.remove(&index) {
+                            cx.drop_image(image, None);
+                        }
+                    }
                     this.render_error = None;
                     log::debug!("pdf_viewer: kicking off text extraction");
                     this.extract_all_text(cx);
@@ -450,7 +541,13 @@ impl PdfViewer {
                 let scale = render_scale;
                 this.update(cx, |this, cx| {
                     this.pages_in_flight.remove(&page_index);
-                    this.rendered_pages.insert(page_index, (scale, image));
+                    // Re-rendering a page at a new scale displaces the previous
+                    // image, whose atlas tile is only freed explicitly.
+                    if let Some(displaced) =
+                        place_rendered_page(&mut this.rendered_pages, page_index, scale, image)
+                    {
+                        cx.drop_image(displaced, None);
+                    }
                     cx.notify();
                 })
                 .ok();
@@ -844,27 +941,44 @@ impl Item for PdfViewer {
     where
         Self: Sized,
     {
-        Task::ready(Some(cx.new(|cx| Self {
-            pdf_item: self.pdf_item.clone(),
-            project: self.project.clone(),
-            focus_handle: cx.focus_handle(),
-            scroll_handle: ScrollHandle::new(),
-            metadata: self.metadata.clone(),
-            rendered_pages: self.rendered_pages.clone(),
-            pages_in_flight: HashSet::new(),
-            cancel_token: Arc::new(AtomicBool::new(false)),
-            render_task: Task::ready(()),
-            render_debounce: Task::ready(()),
-            render_error: self.render_error.clone(),
-            zoom_level: self.zoom_level,
-            render_scale: self.render_scale,
-            display_scale: self.display_scale,
-            pan_x: self.pan_x,
-            text_layouts: self.text_layouts.clone(),
-            text_extraction_task: Task::ready(()),
-            selection_start: None,
-            selection_end: None,
-            is_selecting: false,
+        Task::ready(Some(cx.new(|cx| {
+            let pdf_item = self.pdf_item.clone();
+            Self::register_subscriptions(&pdf_item, cx);
+            Self {
+                pdf_item,
+                project: self.project.clone(),
+                focus_handle: cx.focus_handle(),
+                scroll_handle: ScrollHandle::new(),
+                metadata: self.metadata.clone(),
+                // A page's image is owned by exactly one view, so the split
+                // starts empty and renders its own visible pages.
+                //
+                // Sharing the `Arc`s would be unsafe, not merely wasteful. A
+                // pane renders as a cached view, and a cached view that is not
+                // dirty replays its scene verbatim, tile ids included, without
+                // calling `paint_image`. `cx.notify()` marks only a view and its
+                // ancestors dirty, and a split is a sibling, so it never
+                // repaints. Meanwhile a two-way split only halves `fit_scale`,
+                // which the re-render hysteresis ignores, so the split would sit
+                // on shared images indefinitely. The primary's free empties the
+                // texture slot, and the split's next replay reads that slot back
+                // as `None`.
+                rendered_pages: RenderedPages::new(),
+                pages_in_flight: HashSet::new(),
+                cancel_token: Arc::new(AtomicBool::new(false)),
+                render_task: Task::ready(()),
+                render_debounce: Task::ready(()),
+                render_error: self.render_error.clone(),
+                zoom_level: self.zoom_level,
+                render_scale: self.render_scale,
+                display_scale: self.display_scale,
+                pan_x: self.pan_x,
+                text_layouts: self.text_layouts.clone(),
+                text_extraction_task: Task::ready(()),
+                selection_start: None,
+                selection_end: None,
+                is_selecting: false,
+            }
         })))
     }
 
@@ -905,4 +1019,81 @@ impl ProjectItem for PdfViewer {
 
 pub fn init(cx: &mut App) {
     workspace::register_project_item::<PdfViewer>(cx);
+}
+
+#[cfg(test)]
+mod rendered_page_tests {
+    //! Pins the sprite-atlas leak fix. Every image these helpers displace must
+    //! come back to the caller, because a `RenderImage`'s GPU tile outlives its
+    //! `Arc` and the Metal atlas never evicts. An image dropped without being
+    //! returned here holds a texture for the window's lifetime.
+    use super::*;
+    use image::Frame;
+    use smallvec::SmallVec;
+
+    fn test_image() -> Arc<RenderImage> {
+        // A 1x1 BGRA pixel. Only the process-unique id matters here.
+        let buffer = image::ImageBuffer::from_raw(1, 1, vec![0u8; 4]).expect("buffer");
+        Arc::new(RenderImage::new(SmallVec::from_elem(Frame::new(buffer), 1)))
+    }
+
+    #[test]
+    fn first_render_of_a_page_displaces_nothing() {
+        let mut pages = RenderedPages::default();
+        let displaced = place_rendered_page(&mut pages, 0, 2.0, test_image());
+        assert!(displaced.is_none(), "a fresh page slot displaces nothing");
+        assert_eq!(pages.len(), 1);
+    }
+
+    #[test]
+    fn re_rendering_a_page_returns_its_previous_image() {
+        let mut pages = RenderedPages::default();
+        let old = test_image();
+        let old_id = old.id;
+        place_rendered_page(&mut pages, 3, 2.0, old);
+
+        let new = test_image();
+        let new_id = new.id;
+        let displaced = place_rendered_page(&mut pages, 3, 4.0, new)
+            .expect("re-rendering a page must return the image it replaced");
+
+        assert_eq!(
+            displaced.id, old_id,
+            "the previous image must come back so its tile can be freed"
+        );
+        assert_eq!(pages[&3].1.id, new_id);
+        assert_eq!(pages[&3].0, 4.0, "the new scale must be recorded");
+    }
+
+    #[test]
+    fn taking_the_cache_returns_every_page_and_empties_it() {
+        let mut pages = RenderedPages::default();
+        let mut expected: Vec<_> = (0..5)
+            .map(|index| {
+                let image = test_image();
+                let id = image.id;
+                place_rendered_page(&mut pages, index, 2.0, image);
+                id
+            })
+            .collect();
+
+        let mut taken: Vec<_> = take_rendered_pages(&mut pages)
+            .iter()
+            .map(|image| image.id)
+            .collect();
+
+        taken.sort();
+        expected.sort();
+        assert_eq!(taken, expected, "every cached page must be handed back");
+        assert!(
+            pages.is_empty(),
+            "the cache must be empty so no page is freed twice"
+        );
+    }
+
+    #[test]
+    fn taking_an_empty_cache_returns_nothing() {
+        let mut pages = RenderedPages::default();
+        assert!(take_rendered_pages(&mut pages).is_empty());
+    }
 }


### PR DESCRIPTION
<!-- PR title: pdf_viewer: Free the atlas tiles of replaced pages -->
<!-- Base: main on dsturnbull/suzuri. Branch: pdf-atlas-leak (942ae5368d, c1f577a170). -->
<!-- Paragraphs and bullets are deliberately unwrapped: GitHub soft-wraps them. -->

# Objective

A `RenderImage`'s GPU sprite-atlas tile is keyed by a process-unique id and is freed only by `Window::drop_image`. Dropping the `Arc` frees just the CPU bitmap, and no platform atlas evicts: `MetalAtlas`, `WgpuAtlas` and `DirectXAtlas` each expose only `get_or_insert_with` and `remove`. So a tile nobody removes stays allocated for the window's lifetime.

`pdf_viewer` never called `drop_image`. `reload_document` cleared `rendered_pages` and the render loop replaced entries, and both paths dropped the `Arc` alone, orphaning a whole texture per page. A page tile fills its own atlas texture, because `push_texture` sizes a texture to the tile it is given, so the cost is one full page bitmap each time.

`reload_document` runs on every Typst or LaTeX recompile, because the compiler rewrites the same PDF and `PdfItem` reloads off the fs watch. That makes writing a paper the worst case rather than an unusual one. Measured on an Apple M4 Pro, five minutes of ordinary composing orphaned 1963.5 MiB against a steady 32.7 MiB once the tiles are freed, which is about 393 MiB per minute of writing that never returns until the tab's window closes.

No linked issue.

## Solution

- Route every mutation of `rendered_pages` through `place_rendered_page` and `take_rendered_pages`, which hand back each image they displace so the caller can free its tile. The field carries a comment saying so, so a later edit cannot orphan a tile without deleting that comment first.
- Free at all three displacement sites: the reload, a re-render at a new scale, and tab close.
- Make image ownership exclusive per view. `clone_on_split` previously cloned the map, sharing the `Arc`s. Sharing is unsafe rather than merely wasteful: a pane renders as a cached view, a cached view that is not dirty replays its scene verbatim with the old tile id and never calls `paint_image`, and `cx.notify` marks only a view and its ancestors, so a sibling split never repaints and never re-uploads. The primary's free empties the texture slot and the split's next replay reads that slot back as `None`. A two-way split only halves `fit_scale`, which the re-render hysteresis ignores, so the split would hold those shared images indefinitely.
- Factor the reload subscription and the release hook into `register_subscriptions`, called from both `new` and `clone_on_split`. This fixes a separate bug: `clone_on_split` built its view from a struct literal and skipped the subscription registered in `new`, so a split pane never reloaded when the file changed on disk.
- Restore the page-count trim, so a recompile that shortens the document frees the pages past its new end.
- Stop the detached render thread on release. It holds the whole document as an `Arc<[u8]>` and would otherwise keep rasterising a page nobody will see after the tab closes.
- Use `cx.on_release` rather than `cx.on_release_in`, and pass `None` for the window. `App::drop_image` iterates `self.windows`, and a window being updated is taken out of that map, so `on_release_in` with `None` would free nothing. Release callbacks run with an `&mut App` and no window in hand, so the window is still in the map.

The second commit adds the measurement to `crates/gpui_apple/src/metal_atlas.rs`. That is vendor code, so it is kept separate deliberately: it can be split off and offered upstream, or dropped once the number is recorded, without touching the fix.

## Testing

Four unit tests in `crates/pdf_viewer` pin the contract that every displaced image comes back to the caller: a first render displaces nothing, a re-render returns the previous image and records the new scale, taking the cache returns every page and empties it so nothing is freed twice, and taking an empty cache returns nothing. They are plain `#[test]`s and need no new dev-dependencies.

One `#[ignore]`d measurement in `crates/gpui_apple` runs a real `metal::Device` and a real `MetalAtlas` through sixty simulated reloads twice, once orphaning every superseded tile and once removing it, reading `device.current_allocated_size()` either side.

```
cargo nextest run -p gpui_apple -p pdf_viewer --run-ignored all --no-capture
cargo clippy -p pdf_viewer -p gpui_apple --all-targets -- --deny warnings
```

17 tests pass and clippy is clean at `--deny warnings`.

**What needs more testing.** The split-pane safety argument is derived from reading GPUI's cached-view and scene-replay paths, and no test covers it. A reviewer should build the app, open a PDF, split the pane, and trigger a recompile, then confirm neither pane goes blank or shows a corrupt page. That is the one check no unit test here replaces.

**Platforms.** Tested on macOS, Apple M4 Pro. The fix is platform-independent, because `drop_image` and the atlas contract are shared, and all three real atlas backends lack eviction. The measurement is macOS-only, since it drives Metal directly. Windows and Linux are untested.

**Unrelated condition found in passing.** `crates/pdf_viewer` has never been rustfmt'd. `cargo fmt -p pdf_viewer -- --check` reports 31 violations on the base commit across five files this PR does not touch, so `cargo fmt --all -- --check` already fails there. The count is still exactly 31 with this PR applied, measured by stashing and restoring, so this adds none. Formatting the crate belongs in its own commit.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (none added)
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines) (no UI change)
- [x] Tests cover the new/changed behavior, with one gap named under Testing: the split-pane path is argued from code and not covered by a test
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view the measured before and after</summary>

Three 1460x1890 page tiles across sixty reloads, which is five minutes of ordinary composing against a live Typst preview, on an Apple M4 Pro.

```
device: Apple M4 Pro
page tile: 1460x1890 BGRA = 10.53 MiB
3 pages x 60 reloads = 180 uploads (about 5 minutes of composing)

                     held after run      peak during run
orphaned (current)      1963.5 MiB        1963.5 MiB
freed (fixed)             32.7 MiB          32.7 MiB

what the viewer actually needs live: 3 tiles = 31.6 MiB
orphaned run holds 62x that, and grows without bound
orphaned rate: 393 MiB per minute of composing
```

Reproduce with:

```
cargo nextest run -p gpui_apple --run-ignored only --no-capture \
  -E 'test(measure_page_tile_orphaning)'
```

Three notes on reading those figures. The orphaned arm measures 1963.5 MiB against an arithmetic 1895 MiB for 180 tiles, 3.6 per cent above, which is texture alignment, so the arithmetic is a floor rather than the cost. The freed arm's peak equals its held figure because peak is sampled at the end of each cycle, after the removes, and the true intra-cycle peak is about six tiles near 63 MiB, since new tiles go in before old ones come out. The steady state of 32.7 MiB is the figure that matters.

</details>

Release Notes:

- Fixed the PDF viewer leaking GPU memory every time a document reloaded, which affected live Typst and LaTeX previews most because each recompile rewrites the PDF.
- Fixed a split PDF pane not reloading when the file changed on disk.
