### PR TITLE
markdown_live_preview: Reload an image referenced through a parent folder

### DIFF
--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -181,7 +181,14 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
                         // re-decode every image in the project on open.
                         .filter(|(_, _, change)| *change != PathChange::Loaded)
                         .filter(|(path, _, _)| path.extension().is_some_and(is_image_extension))
-                        .map(|(path, _, _)| worktree.absolutize(path))
+                        .map(|(path, _, _)| {
+                            let absolute = worktree.absolutize(path);
+                            // Matches how `resolve_image_source` keys the
+                            // cache. A just-deleted file cannot be
+                            // canonicalized; fall back to the literal path so
+                            // an exactly-spelled reference still evicts.
+                            std::fs::canonicalize(&absolute).unwrap_or(absolute)
+                        })
                         .collect()
                 };
                 if changed_images.is_empty() {
@@ -3266,9 +3273,13 @@ fn resolve_image_source(
     } else {
         base_directory?.join(path)
     };
-    if !path.exists() {
-        return None;
-    }
+    // Canonicalizing proves the file exists *and* collapses `..` and symlinks,
+    // so a note that spells its image `../images/x.png` keys the cache by the
+    // same path the worktree reports when that file changes. Without it the two
+    // spellings hash differently and the eviction below silently matches
+    // nothing — which is the common case, since a shared `images/` folder
+    // beside the notes is an ordinary vault layout.
+    let path = std::fs::canonicalize(&path).ok()?;
     // Deliberately not `ImageSource::Resource`: that reads through gpui's
     // app-level asset cache, which has no eviction, so a file rewritten in
     // place would keep serving its first-decoded bitmap. Routing every local

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -1976,15 +1976,16 @@ fn test_buttons_prevent_default_on_mouse_down(cx: &mut TestAppContext) {
 // holds an `Arc<dyn Fn>` with no `Send`/`Sync` bound, so any wrapper of one
 // trips this lint by construction.
 #[allow(clippy::arc_with_non_send_sync)]
-#[gpui::test]
-async fn test_rewriting_an_image_in_place_reloads_it(cx: &mut TestAppContext) {
-    init_test(cx);
-
-    let directory = tempfile::tempdir().expect("failed to create a temp dir");
-    let path = directory.path().join("screenshot.png");
+async fn image_sizes_across_eviction(
+    cx: &mut TestAppContext,
+    destination: &str,
+    base_directory: &std::path::Path,
+    image_path: &std::path::Path,
+    evict_path: &std::path::Path,
+) -> [Option<(i32, i32)>; 3] {
     let write_image = |width: u32, height: u32| {
         image::save_buffer(
-            &path,
+            image_path,
             &vec![0xff; (width * height * 4) as usize],
             width,
             height,
@@ -1995,8 +1996,8 @@ async fn test_rewriting_an_image_in_place_reloads_it(cx: &mut TestAppContext) {
     write_image(4, 2);
 
     let image_cache = cx.update(RetainAllImageCache::new);
-    let source = resolve_image_source("screenshot.png", Some(directory.path()), &image_cache)
-        .expect("an existing file next to the document should resolve");
+    let source = resolve_image_source(destination, Some(base_directory), &image_cache)
+        .expect("an existing image file should resolve");
     assert!(
         matches!(source, ImageSource::Custom(_)),
         "a local image resolved to an app-level asset source, which cannot be \
@@ -2040,33 +2041,85 @@ async fn test_rewriting_an_image_in_place_reloads_it(cx: &mut TestAppContext) {
 
     draw(&mut cx);
     draw(&mut cx);
-    pretty_assertions::assert_eq!(
-        *drawn.lock().unwrap(),
-        Some((4, 2)),
-        "the image never finished loading"
-    );
+    let initial = *drawn.lock().unwrap();
 
     write_image(8, 3);
     draw(&mut cx);
-    pretty_assertions::assert_eq!(
-        *drawn.lock().unwrap(),
-        Some((4, 2)),
-        "an image cache that reloads on its own would make the eviction below \
-         dead code"
-    );
+    let after_rewrite = *drawn.lock().unwrap();
 
     cx.update(|window, cx| {
         image_cache.update(cx, |image_cache, cx| {
-            image_cache.remove(&Resource::Path(Arc::from(path.as_path())), window, cx);
+            image_cache.remove(&Resource::Path(Arc::from(evict_path)), window, cx);
         });
     });
     draw(&mut cx);
     draw(&mut cx);
+    let after_eviction = *drawn.lock().unwrap();
+
+    [initial, after_rewrite, after_eviction]
+}
+
+#[gpui::test]
+async fn test_rewriting_an_image_in_place_reloads_it(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let directory = tempfile::tempdir().expect("failed to create a temp dir");
+    let path = directory.path().join("screenshot.png");
+    // What the fs-change handler would evict: the file's real, canonical path.
+    let evict_path = std::fs::canonicalize(directory.path())
+        .expect("temp dir should canonicalize")
+        .join("screenshot.png");
+
+    let [initial, after_rewrite, after_eviction] =
+        image_sizes_across_eviction(cx, "screenshot.png", directory.path(), &path, &evict_path)
+            .await;
+
+    pretty_assertions::assert_eq!(initial, Some((4, 2)), "the image never finished loading");
     pretty_assertions::assert_eq!(
-        *drawn.lock().unwrap(),
+        after_rewrite,
+        Some((4, 2)),
+        "an image cache that reloads on its own would make the eviction below \
+         dead code"
+    );
+    pretty_assertions::assert_eq!(
+        after_eviction,
         Some((8, 3)),
         "evicting the rewritten path did not bring back the new bitmap, so a \
          re-cropped screenshot still renders at its old size"
+    );
+}
+
+/// A vault that keeps its images in a folder beside its notes spells every
+/// reference `../images/x.png`. Joining that onto the note's directory keeps the
+/// `..` literally, while the worktree reports the file under its collapsed path
+/// — so unless both sides canonicalize, the two hash differently and eviction
+/// silently matches nothing. That layout is ordinary, not exotic: this pins it.
+#[gpui::test]
+async fn test_image_reference_climbing_out_of_its_folder_reloads(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let vault = tempfile::tempdir().expect("failed to create a temp dir");
+    let notes = vault.path().join("lectures");
+    let images = vault.path().join("images");
+    std::fs::create_dir_all(&notes).expect("failed to create the notes dir");
+    std::fs::create_dir_all(&images).expect("failed to create the images dir");
+    let path = images.join("screenshot.png");
+    // The worktree reports a changed file by its collapsed path, never with `..`.
+    let evict_path = std::fs::canonicalize(&images)
+        .expect("images dir should canonicalize")
+        .join("screenshot.png");
+
+    let [initial, after_rewrite, after_eviction] =
+        image_sizes_across_eviction(cx, "../images/screenshot.png", &notes, &path, &evict_path)
+            .await;
+
+    pretty_assertions::assert_eq!(initial, Some((4, 2)), "the image never finished loading");
+    pretty_assertions::assert_eq!(after_rewrite, Some((4, 2)), "the cache reloaded unprompted");
+    pretty_assertions::assert_eq!(
+        after_eviction,
+        Some((8, 3)),
+        "a `../images/x.png` reference did not pick up the rewritten file, so \
+         re-cropping a screenshot still needs the document reopened"
     );
 }
 


### PR DESCRIPTION
Follow-up to #12, which fixed images rewritten in place but missed the layout
that actually matters: a vault with `images/` beside `lectures/`, where every
reference is spelled `../images/x.png`.

## Cause

The two halves of the reload built the cache key differently:

- **Resolution** joined the destination onto the note's directory. `PathBuf::join`
  keeps `..` literally, producing `.../lectures/../images/x.png`.
- **Eviction** used the worktree's own absolute path, `.../images/x.png`.

Same file, two spellings, two hashes. `RetainAllImageCache::remove` ran and
matched nothing, so the stale bitmap stayed and the document still had to be
closed and reopened.

#12 called this out as a known gap and judged it an edge case. It isn't — a
shared `images/` folder beside the notes is the ordinary Obsidian layout.

## Fix

Canonicalize on both sides. On the resolve side `canonicalize` also replaces the
`exists()` check, since it fails for a missing file — so it costs no syscall that
wasn't already being paid on every draw.

Canonicalization resolves symlinks as well as `..`, which is what makes the two
keys agree rather than merely agree more often. That was the objection that made
me skip lexical normalization in #12: collapsing `..` by string surgery changes
meaning under a symlinked directory. Resolving beats guessing, and macOS alone
routes `/var` through `/private/var`, so the same-directory case depended on it
too once eviction canonicalized.

A just-deleted file can't be canonicalized, so eviction falls back to the literal
absolutized path.

## Tests

`test_image_reference_climbing_out_of_its_folder_reloads` builds the real vault
shape — `lectures/` and `images/` siblings, reference spelled `../images/…` — and
drives the full cycle: draw, rewrite the file at new dimensions, draw again
(asserting it is *still* stale, so the eviction isn't dead code), evict, draw.

Both image tests were verified to **fail** with the canonicalization removed,
reproducing the reported symptom exactly (stale 4×2 where 8×3 was expected), and
pass with it. The shared cycle is factored into a helper.

`cargo nextest run -p markdown_live_preview` is 47/47; clippy and fmt clean.

Release Notes:

- Fixed a markdown image referenced through a parent folder (`../images/x.png`) not reloading after the file was overwritten in place
