### PR TITLE
markdown_live_preview: Hug the image with its selection border

### DIFF
--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -3048,7 +3048,14 @@ fn render_image_block(
                     })
                     .log_err();
             })
-            .child(div().max_w(max_width).child(content))
+            // `flex()` is load-bearing: gpui's `div()` is `display: block`, so a
+            // block child fills its parent's width and the bordered container
+            // would stretch to its own `max_w` cap — leaving the selection
+            // border, the `</>` button and the resize handle floating out to the
+            // right of any image narrower than that cap. As a flex item it
+            // shrink-wraps the image instead. Pinned by
+            // `test_a_block_child_fills_its_parent_but_a_flex_child_hugs`.
+            .child(div().flex().max_w(max_width).child(content))
             .into_any_element()
     })
 }

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -2132,3 +2132,72 @@ fn test_remote_images_still_use_the_shared_asset_cache(cx: &mut TestAppContext) 
         .expect("an http destination should resolve");
     assert!(matches!(source, ImageSource::Resource(Resource::Uri(_))));
 }
+
+/// The image widget draws its selection border, its `</>` button and its resize
+/// handle on a container that is supposed to hug the image exactly. gpui's
+/// `div()` defaults to `display: block` (`Style::default`), and a block box with
+/// `width: auto` fills its containing block — so that container stretches to its
+/// own `max_w` cap and the border floats out to the right of any image narrower
+/// than the cap. Wrapping it in a flex parent makes it shrink-wrap instead.
+///
+/// Both halves are pinned here: an upstream change that made `div()` shrink-wrap
+/// by default, or that stopped flex items sizing to content, would silently move
+/// the border off the image again.
+#[gpui::test]
+async fn test_a_block_child_fills_its_parent_but_a_flex_child_hugs(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    const PARENT: gpui::Pixels = gpui::px(400.);
+    const CHILD: gpui::Pixels = gpui::px(80.);
+
+    struct Frames;
+    impl Render for Frames {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .w(PARENT)
+                // A block parent: the bordered child fills the whole width.
+                .child(
+                    div()
+                        .debug_selector(|| "BLOCK-PARENT".into())
+                        .child(div().w(CHILD).h(gpui::px(20.))),
+                )
+                // A flex parent: the same bordered child hugs its content.
+                .child(
+                    div().flex().child(
+                        div()
+                            .debug_selector(|| "FLEX-PARENT".into())
+                            .child(div().w(CHILD).h(gpui::px(20.))),
+                    ),
+                )
+        }
+    }
+
+    let (view, cx) = cx.add_window_view(|_window, _cx| Frames);
+    cx.run_until_parked();
+    cx.draw(
+        gpui::point(gpui::px(0.), gpui::px(0.)),
+        gpui::size(gpui::px(600.), gpui::px(200.)),
+        |_window, _cx| view.clone().into_any_element(),
+    );
+    cx.run_until_parked();
+
+    let in_block = cx
+        .debug_bounds("BLOCK-PARENT")
+        .expect("the block-parented frame should have been laid out");
+    let in_flex = cx
+        .debug_bounds("FLEX-PARENT")
+        .expect("the flex-parented frame should have been laid out");
+
+    pretty_assertions::assert_eq!(
+        in_block.size.width,
+        PARENT,
+        "a block child no longer fills its parent, so the image widget's container \
+         may not need a flex parent to hug the image any more"
+    );
+    pretty_assertions::assert_eq!(
+        in_flex.size.width,
+        CHILD,
+        "a flex child no longer hugs its content, so the image widget's selection \
+         border will float out to the right of the image"
+    );
+}


### PR DESCRIPTION
The width artifact spotted after the reload fixes landed. It is not a reload bug — the
reload just made a long-standing layout bug obvious.

## Cause

The image widget's bordered container is what carries the selection border, the `</>`
button and the resize handle, and the code comments say it is meant to hug the image
exactly. It never did.

`gpui`'s `div()` defaults to `display: Block` (`crates/gpui/src/style.rs`), and a block
box with `width: auto` fills its containing block. So the container stretched to its own
`max_w(max_width * 0.66)` cap while the `img` inside sat at its intrinsic width, flush
left. Everything anchored to the container's right edge ended up floating in empty space.

The overhang is the difference between the cap and the image width, which is why nobody
noticed: a wide screenshot leaves a thin gap. Overwrite an image with a much smaller one
— routine now that reloading works — and the gap becomes most of the pane.

## Fix

One word: give the container a flex parent, so it shrink-wraps its content instead of
filling the width.

## Tests

`test_a_block_child_fills_its_parent_but_a_flex_child_hugs` pins both halves of the gpui
behavior this depends on — that a block child fills its parent (400pt) and a flex child
hugs its content (80pt) — measured through `debug_bounds`. It was written to falsify the
diagnosis before the fix was trusted, and belongs in the contract-tests section because an
upstream change to either half would silently move the border off the image again.

48/48 in `cargo nextest run -p markdown_live_preview`; clippy and fmt clean.

## Not verified on screen

Diagnosed and pinned from code and layout measurements, not from a screenshot of the
running app — the machine was in use. Worth a look when convenient: select a small image
and confirm the border, the `</>` button and the resize handle all sit on its edge.

Release Notes:

- Fixed a selected image's border, source button, and resize handle sitting to the right of the image instead of hugging it
