### PR TITLE
markdown_live_preview: Size the image widget by width, not natural height

### DIFF
--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -2929,7 +2929,15 @@ fn render_image_block(
                     .id(("mdlp-image", f32::from(max_width) as u64))
                     .max_w_full()
                     .rounded_sm()
-                    .when(content_width.is_some(), |this| this.w_full())
+                    // The explicit width goes on the image itself, as an
+                    // absolute length, and the bordered container shrink-wraps
+                    // it. Sizing the container and giving the image `w_full()`
+                    // instead hits a gpui quirk: a percentage-width image with
+                    // auto height lays out at the file's natural height, not
+                    // the aspect-scaled one, so a widget stretched past the
+                    // file's natural width overflowed its container. Pinned by
+                    // `test_an_absolute_width_image_keeps_its_aspect_ratio`.
+                    .when_some(content_width, |this, width| this.w(width))
                     .with_fallback(move || {
                         div()
                             .text_color(muted)
@@ -2960,7 +2968,6 @@ fn render_image_block(
                     this.border_color(gpui::transparent_black())
                 }
             })
-            .when_some(content_width, |this, width| this.w(width))
             .when(content_width.is_none(), |this| this.max_w(max_width * 0.66))
             .child(image_content);
 

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -2201,3 +2201,78 @@ async fn test_a_block_child_fills_its_parent_but_a_flex_child_hugs(cx: &mut Test
          border will float out to the right of the image"
     );
 }
+
+/// The image widget puts an explicit `|width` on the `img` element itself as an
+/// absolute length and lets the bordered container shrink-wrap it. That relies
+/// on gpui's `img` deriving its height from an absolute width via the file's
+/// aspect ratio — including widths *larger* than the file's natural size, the
+/// shape an in-place crop leaves behind. The tempting alternative — size the
+/// container and give the image `w_full()` — is broken: a fraction width with
+/// auto height makes `img` fall back to the file's natural pixel height, so
+/// the container sizes to that while the image itself lays out aspect-scaled,
+/// painting everything past the natural height over the lines below the block.
+#[gpui::test]
+fn test_an_absolute_width_image_keeps_its_aspect_ratio(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    // Natural size deliberately smaller than the displayed width.
+    const NATURAL_WIDTH: u32 = 200;
+    const NATURAL_HEIGHT: u32 = 100;
+    const DISPLAY_WIDTH: gpui::Pixels = gpui::px(800.);
+    const BORDER: gpui::Pixels = gpui::px(2.);
+
+    struct Widget(Arc<gpui::RenderImage>);
+    impl Render for Widget {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div().w(gpui::px(1000.)).child(
+                div().flex().max_w(gpui::px(1000.)).child(
+                    div()
+                        .debug_selector(|| "IMAGE-CONTAINER".into())
+                        .border_2()
+                        .child(
+                            gpui::img(ImageSource::Render(self.0.clone()))
+                                .id("contract-img")
+                                .debug_selector(|| "IMAGE".into())
+                                .max_w_full()
+                                .rounded_sm()
+                                .w(DISPLAY_WIDTH),
+                        ),
+                ),
+            )
+        }
+    }
+
+    let image = Arc::new(gpui::RenderImage::new([image::Frame::new(
+        image::ImageBuffer::from_pixel(NATURAL_WIDTH, NATURAL_HEIGHT, image::Rgba([0, 0, 0, 255])),
+    )]));
+    let (view, cx) = cx.add_window_view(|_window, _cx| Widget(image));
+    cx.run_until_parked();
+    cx.draw(
+        gpui::point(gpui::px(0.), gpui::px(0.)),
+        gpui::size(gpui::px(1200.), gpui::px(900.)),
+        |_window, _cx| view.clone().into_any_element(),
+    );
+    cx.run_until_parked();
+
+    let image_bounds = cx
+        .debug_bounds("IMAGE")
+        .expect("the image should have been laid out");
+    let container_bounds = cx
+        .debug_bounds("IMAGE-CONTAINER")
+        .expect("the bordered container should have been laid out");
+
+    let expected_height = DISPLAY_WIDTH * (NATURAL_HEIGHT as f32 / NATURAL_WIDTH as f32);
+    pretty_assertions::assert_eq!(
+        image_bounds.size,
+        gpui::size(DISPLAY_WIDTH, expected_height),
+        "an image with an absolute width no longer lays out at its aspect-scaled \
+         height, so explicit `|width` sizes will render distorted or misplaced"
+    );
+    pretty_assertions::assert_eq!(
+        container_bounds.size,
+        gpui::size(DISPLAY_WIDTH + BORDER * 2., expected_height + BORDER * 2.),
+        "the bordered container no longer hugs the aspect-scaled image, so an \
+         image widened past its file's natural size will paint over the lines \
+         below its block"
+    );
+}


### PR DESCRIPTION
Widening an image past its file's natural width made it paint over the lines below its block — the code block and heading underneath rendered on top of the overflowing image. An in-place crop makes this routine: the crop shrinks the file's natural size, so the first enlarge past it overflows (shrinking stayed under the natural size, which is why only enlarging looked broken).

The root cause is a gpui `img` layout quirk: a fractional width (`w_full()`) with auto height resolves the element's height to the file's **natural pixel height** instead of the aspect-scaled one (`crates/gpui/src/elements/img.rs`, the `_` arm of the height match). The widget sized the bordered container and gave the image `w_full()`, so the container took the natural height while the image inside laid out aspect-correct and spilled out.

Fix: put the explicit `|width` on the `img` element itself as an absolute length — the code path that derives height from width via the aspect ratio — and let the bordered container shrink-wrap it, which the flex parent from #15 already enables. `test_an_absolute_width_image_keeps_its_aspect_ratio` joins the contract tests to pin the gpui behavior the widget now relies on: it renders the widget's element tree with a 200×100 image displayed at 800px and asserts the image lays out at 800×400 with the container hugging it at 804×404.

The underlying fraction-width-ignores-aspect-ratio behavior is an upstream gpui bug worth its own PR to zed-industries/zed; Suzuri no longer depends on that path.

Verified in the bundled app against the suzuri-testbed image-reload note: crop the sibling fixture in place, then drag the widget wider than the cropped size — the border hugs the image and the content below stays below.

Release Notes:

- Fixed an image widened past its file's natural size painting over the lines below it, instead of the block growing to fit