### PR TITLE
markdown_live_preview: Add callouts, highlights, tags, footnotes, and transclusion

### DIFF
--- a/crates/markdown_live_preview/Cargo.toml
+++ b/crates/markdown_live_preview/Cargo.toml
@@ -30,6 +30,7 @@ tree-sitter.workspace = true
 ui.workspace = true
 urlencoding.workspace = true
 util.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -9,7 +9,13 @@
 //! Preview mode. Tables, images, and frontmatter are the exception: they are
 //! edited through their widgets and only reveal source via their `</>` button.
 
-use std::{any::TypeId, borrow::Cow, ops::Range, path::PathBuf, sync::Arc};
+use std::{
+    any::TypeId,
+    borrow::Cow,
+    ops::Range,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use collections::{HashMap, HashSet};
 use editor::{
@@ -30,7 +36,7 @@ use math_render::{MathStyle, MathTheme};
 use multi_buffer::{
     Anchor, MultiBufferOffset, MultiBufferRow, MultiBufferSnapshot, ToOffset as _, ToPoint as _,
 };
-use project::PathChange;
+use project::{PathChange, Project, ProjectPath};
 use settings::{RegisterSetting, Settings};
 use text::Point;
 use ui::{Checkbox, ToggleState, prelude::*};
@@ -169,43 +175,65 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
     if let Some(project) = editor.project().cloned() {
         subscriptions.push(cx.subscribe_in(&project, window, {
             let image_cache = image_cache.clone();
-            move |_editor, project, event, window, cx| {
+            move |editor, project, event, window, cx| {
                 let project::Event::WorktreeUpdatedEntries(worktree_id, changes) = event else {
                     return;
                 };
                 let Some(worktree) = project.read(cx).worktree_for_id(*worktree_id, cx) else {
                     return;
                 };
-                let changed_images: Vec<PathBuf> = {
+                let (changed_images, changed_notes, note_created) = {
                     let worktree = worktree.read(cx);
-                    changes
-                        .iter()
+                    let mut images = Vec::new();
+                    let mut notes = Vec::new();
+                    let mut created = false;
+                    for (path, _, change) in changes.iter() {
                         // `Loaded` is the initial scan reporting what was
                         // already there, not a change; acting on it would
                         // re-decode every image in the project on open.
-                        .filter(|(_, _, change)| *change != PathChange::Loaded)
-                        .filter(|(path, _, _)| path.extension().is_some_and(is_image_extension))
-                        .map(|(path, _, _)| {
-                            let absolute = worktree.absolutize(path);
+                        if *change == PathChange::Loaded {
+                            continue;
+                        }
+                        let Some(extension) = path.extension() else {
+                            continue;
+                        };
+                        let absolute = worktree.absolutize(path);
+                        if is_image_extension(extension) {
                             // Matches how `resolve_image_source` keys the
                             // cache. A just-deleted file cannot be
                             // canonicalized; fall back to the literal path so
                             // an exactly-spelled reference still evicts.
-                            std::fs::canonicalize(&absolute).unwrap_or(absolute)
-                        })
-                        .collect()
-                };
-                if changed_images.is_empty() {
-                    return;
-                }
-                image_cache.update(cx, |image_cache, cx| {
-                    for path in changed_images {
-                        image_cache.remove(&Resource::Path(Arc::from(path.as_path())), window, cx);
+                            images.push(std::fs::canonicalize(&absolute).unwrap_or(absolute));
+                        } else if extension == "md" {
+                            created |=
+                                matches!(change, PathChange::Added | PathChange::AddedOrUpdated);
+                            notes.push(absolute);
+                        }
                     }
-                });
-                // The widgets keep their blocks; they just need to redraw so
-                // the evicted images are fetched again.
-                cx.notify();
+                    (images, notes, created)
+                };
+
+                if !changed_images.is_empty() {
+                    image_cache.update(cx, |image_cache, cx| {
+                        for path in changed_images {
+                            image_cache.remove(
+                                &Resource::Path(Arc::from(path.as_path())),
+                                window,
+                                cx,
+                            );
+                        }
+                    });
+                    // The widgets keep their blocks; they just need to redraw
+                    // so the evicted images are fetched again.
+                    cx.notify();
+                }
+
+                // A transclusion's content is baked into its block when the
+                // block is inserted, so unlike an image it needs a recompute
+                // rather than a repaint to pick a changed note up.
+                if !changed_notes.is_empty() && evict_embeds(&changed_notes, note_created, cx) {
+                    recompute(editor, cx);
+                }
             }
         }));
     }
@@ -395,6 +423,13 @@ enum BlockRenderKind {
         display_width: Option<f32>,
         destination: Option<String>,
         alt: String,
+    },
+    /// An Obsidian note transclusion (`![[Note]]`, `![[Note#Heading]]`),
+    /// rendered as a card holding the target note's markdown. The body is
+    /// loaded asynchronously and reaches the widget through [`EmbedCache`].
+    Embed {
+        target: String,
+        section: Option<String>,
     },
     /// An Obsidian callout (`> [!note] Title`), rendered as a tinted card
     /// with its type's icon and color. `collapse` carries what the `+`/`-`
@@ -791,6 +826,9 @@ struct DesiredBlock<'a> {
     source: String,
     below: bool,
     collapsed: bool,
+    /// What the cache held for an embed this pass. Not on `AppliedBlock`,
+    /// because `source` already stands in for it in the reuse check.
+    embed: Option<EmbedState>,
 }
 
 fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
@@ -826,6 +864,8 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
         addon.source_revealed = source_revealed.clone();
     }
     let selection_offsets = selection_offset_ranges(editor, &snapshot);
+    let base_directory = buffer_base_directory(editor, cx);
+    let project = editor.project().cloned();
 
     // --- Inline concealments ---
 
@@ -933,6 +973,23 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
             source.push_str("\n\n");
             source.push_str(&markers.definitions);
         }
+        let embed = match &marker.kind {
+            BlockRenderKind::Embed { target, section } => {
+                let state = embed_state(
+                    EmbedKey {
+                        source_directory: base_directory.clone(),
+                        target: target.clone(),
+                        section: section.clone(),
+                    },
+                    project.clone(),
+                    weak_editor.clone(),
+                    cx,
+                );
+                source = state.reuse_key();
+                Some(state)
+            }
+            _ => None,
+        };
         // What the reader last asked for wins over what the `+`/`-` in the
         // syntax asked for.
         let collapsed = match &marker.kind {
@@ -949,6 +1006,7 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
                 source,
                 below,
                 collapsed,
+                embed,
             },
         );
     }
@@ -973,7 +1031,6 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
 
     let mut blocks_to_insert = Vec::new();
     let mut pending_applied = Vec::new();
-    let base_directory = buffer_base_directory(editor, cx);
     // The language registry lets rendered code blocks (and code spans in
     // tables/quotes) get syntax highlighting.
     let language_registry = editor
@@ -986,6 +1043,7 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
         source,
         below,
         collapsed,
+        embed,
     } in desired_blocks.into_values()
     {
         let render = match &marker.kind {
@@ -1092,6 +1150,39 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
             ),
             BlockRenderKind::Frontmatter => {
                 render_frontmatter_block(weak_editor.clone(), marker.range.clone(), source.clone())
+            }
+            BlockRenderKind::Embed { target, section } => {
+                let state = embed.clone().unwrap_or(EmbedState::Missing);
+                let body = match &state {
+                    EmbedState::Ready { body, .. } => Some(cx.new(|cx| {
+                        Markdown::new_with_options(
+                            body.clone(),
+                            language_registry.clone(),
+                            None,
+                            markdown::MarkdownOptions {
+                                parse_html: true,
+                                render_mermaid_diagrams: true,
+                                ..Default::default()
+                            },
+                            cx,
+                        )
+                    })),
+                    EmbedState::Loading | EmbedState::Missing => None,
+                };
+                let label = match section {
+                    Some(section) => format!("{target} › {section}"),
+                    None => target.clone(),
+                };
+                render_embed_block(
+                    state,
+                    SharedString::from(label),
+                    body,
+                    weak_editor.clone(),
+                    marker.range.clone(),
+                    base_directory.clone(),
+                    marker.indent_columns,
+                    image_cache.clone(),
+                )
             }
             BlockRenderKind::Callout {
                 kind,
@@ -1275,6 +1366,245 @@ fn rows_intersect(selection_rows: &[Range<u32>], start_row: u32, end_row: u32) -
 /// Identity of a rendered formula. Two formulas that agree on every field
 /// rasterize identically, so the cache is shared across editors: the same
 /// equation in two panes is typeset once.
+/// Drops the cached transclusions a set of changed notes invalidates, and
+/// reports whether anything was dropped. Creating a note also drops every
+/// `Missing` entry: that creation may be exactly what an unresolved target
+/// was waiting for.
+fn evict_embeds(changed: &[PathBuf], note_created: bool, cx: &mut App) -> bool {
+    let cache = cx.default_global::<EmbedCache>();
+    let before = cache.entries.len();
+    cache.entries.retain(|_, entry| match entry {
+        EmbedEntry::Ready { absolute, .. } => !changed.contains(absolute),
+        EmbedEntry::Missing => !note_created,
+        EmbedEntry::Pending => true,
+    });
+    cache.entries.len() != before
+}
+
+/// Identifies one note transclusion's content. The embedding note's folder
+/// takes part in the key so that two vaults open at once, each with their own
+/// `Index.md`, do not share an entry.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct EmbedKey {
+    source_directory: Option<PathBuf>,
+    target: String,
+    section: Option<String>,
+}
+
+enum EmbedEntry {
+    Pending,
+    /// The target resolved and loaded. `absolute` is kept so a change on disk
+    /// can evict exactly this entry, and `path` so the card's header can open
+    /// the note it is showing.
+    Ready {
+        body: SharedString,
+        path: ProjectPath,
+        absolute: PathBuf,
+    },
+    /// No note in the project answers to this target.
+    Missing,
+}
+
+/// Loaded transclusions, shared across editors: the same note embedded from
+/// two places is read once. Entries are evicted when their file changes on
+/// disk, and every `Missing` entry is dropped whenever a markdown file is
+/// created, since that creation may be what the target was waiting for.
+#[derive(Default)]
+struct EmbedCache {
+    entries: HashMap<EmbedKey, EmbedEntry>,
+}
+
+impl gpui::Global for EmbedCache {}
+
+/// What `apply_decorations` found in the cache for one embed, carried to the
+/// render closure. Distinct from [`EmbedEntry`] because the widget needs an
+/// owned snapshot, not a borrow of the global.
+#[derive(Clone, PartialEq)]
+enum EmbedState {
+    Loading,
+    Missing,
+    Ready {
+        body: SharedString,
+        path: ProjectPath,
+    },
+}
+
+impl EmbedState {
+    /// A string standing in for the block's source in the reuse check. An
+    /// embed draws the note it points at, not the `![[..]]` that points
+    /// there, so a load finishing after the block was inserted has to change
+    /// this or the new content never reaches the screen.
+    fn reuse_key(&self) -> String {
+        match self {
+            Self::Loading => "\u{0}loading".to_string(),
+            Self::Missing => "\u{0}missing".to_string(),
+            Self::Ready { body, .. } => format!("\u{0}ready\n{body}"),
+        }
+    }
+}
+
+/// Reads an embed's state, starting the load if this is the first time it has
+/// been asked for. The editor is recomputed when the load lands, which is what
+/// gets the loaded body onto the screen.
+fn embed_state(
+    key: EmbedKey,
+    project: Option<Entity<Project>>,
+    editor: WeakEntity<Editor>,
+    cx: &mut App,
+) -> EmbedState {
+    if let Some(entry) = cx.default_global::<EmbedCache>().entries.get(&key) {
+        return match entry {
+            EmbedEntry::Pending => EmbedState::Loading,
+            EmbedEntry::Missing => EmbedState::Missing,
+            EmbedEntry::Ready { body, path, .. } => EmbedState::Ready {
+                body: body.clone(),
+                path: path.clone(),
+            },
+        };
+    }
+    // Without a project there is no vault to resolve a note name against.
+    let Some(project) = project else {
+        return EmbedState::Missing;
+    };
+
+    let resolved = resolve_embed_target(&project, key.source_directory.as_deref(), &key.target, cx);
+    let Some((path, absolute)) = resolved else {
+        cx.default_global::<EmbedCache>()
+            .entries
+            .insert(key, EmbedEntry::Missing);
+        return EmbedState::Missing;
+    };
+
+    cx.global_mut::<EmbedCache>()
+        .entries
+        .insert(key.clone(), EmbedEntry::Pending);
+    let fs = project.read(cx).fs().clone();
+    cx.spawn(async move |cx| {
+        let loaded = cx
+            .background_spawn({
+                let absolute = absolute.clone();
+                async move { fs.load(&absolute).await }
+            })
+            .await;
+        cx.update(|cx| {
+            let entry = match loaded {
+                Ok(text) => {
+                    let body = match &key.section {
+                        Some(section) => embed_section(&text, section),
+                        None => Some(text),
+                    };
+                    match body {
+                        Some(body) => EmbedEntry::Ready {
+                            body: SharedString::from(body),
+                            path,
+                            absolute,
+                        },
+                        // The note exists but has no such heading.
+                        None => EmbedEntry::Missing,
+                    }
+                }
+                Err(_) => EmbedEntry::Missing,
+            };
+            cx.global_mut::<EmbedCache>().entries.insert(key, entry);
+        });
+        editor
+            .update(cx, |editor, cx| recompute(editor, cx))
+            .log_err();
+    })
+    .detach();
+
+    EmbedState::Loading
+}
+
+/// Resolves a wikilink target to a note, the way Obsidian does: a target that
+/// spells out a path is matched against the whole relative path first, and a
+/// bare name is matched by file stem, preferring a note beside the embedding
+/// one and then the shallowest match. The `.md` extension is implied.
+fn resolve_embed_target(
+    project: &Entity<Project>,
+    source_directory: Option<&Path>,
+    target: &str,
+    cx: &App,
+) -> Option<(ProjectPath, PathBuf)> {
+    let target = target.trim().trim_end_matches(".md");
+    if target.is_empty() {
+        return None;
+    }
+    let wanted_path = target.to_lowercase();
+    let wanted_stem = Path::new(target).file_stem()?.to_str()?.to_lowercase();
+
+    let mut best: Option<(u32, usize, ProjectPath, PathBuf)> = None;
+    for worktree in project.read(cx).worktrees(cx) {
+        let worktree_id = worktree.read(cx).id();
+        let worktree = worktree.read(cx);
+        for entry in worktree.entries(false, 0) {
+            if !entry.is_file() || entry.path.extension() != Some("md") {
+                continue;
+            }
+            let relative = entry.path.as_unix_str().to_lowercase();
+            let stem = entry.path.file_stem().map(str::to_lowercase);
+            let rank = if relative.trim_end_matches(".md") == wanted_path {
+                0
+            } else if stem.as_deref() == Some(wanted_stem.as_str()) {
+                let beside = source_directory.is_some_and(|directory| {
+                    worktree.absolutize(&entry.path).parent() == Some(directory)
+                });
+                if beside { 1 } else { 2 }
+            } else {
+                continue;
+            };
+            let depth = entry.path.components().count();
+            let better = best.as_ref().is_none_or(|(best_rank, best_depth, ..)| {
+                (rank, depth) < (*best_rank, *best_depth)
+            });
+            if better {
+                let absolute = worktree.absolutize(&entry.path);
+                let path = ProjectPath {
+                    worktree_id,
+                    path: entry.path.clone(),
+                };
+                best = Some((rank, depth, path, absolute));
+            }
+        }
+    }
+    best.map(|(_, _, path, absolute)| (path, absolute))
+}
+
+/// The slice of a note under one heading: from that heading to the next one at
+/// the same or a higher level. Returns `None` when the note has no such
+/// heading, which the card reports rather than silently embedding everything.
+fn embed_section(text: &str, section: &str) -> Option<String> {
+    let wanted = section.trim().to_lowercase();
+    let heading_level = |line: &str| {
+        let hashes = line
+            .chars()
+            .take_while(|character| *character == '#')
+            .count();
+        (1..=6).contains(&hashes).then_some(hashes)
+    };
+
+    let mut lines = text.lines().enumerate();
+    let (start, level) = lines.find_map(|(index, line)| {
+        let level = heading_level(line)?;
+        let title = line[level..].trim().to_lowercase();
+        (title == wanted).then_some((index, level))
+    })?;
+
+    let end = text
+        .lines()
+        .enumerate()
+        .skip(start + 1)
+        .find(|(_, line)| heading_level(line).is_some_and(|found| found <= level))
+        .map_or(text.lines().count(), |(index, _)| index);
+    Some(
+        text.lines()
+            .take(end)
+            .skip(start)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+}
+
 #[derive(Clone, PartialEq, Eq, Hash)]
 struct MathKey {
     source: SharedString,
@@ -3554,6 +3884,164 @@ fn render_rule_block(
     })
 }
 
+/// Opens the note a transclusion is showing, in the workspace the embedding
+/// editor belongs to.
+fn open_embedded_note(
+    editor: &WeakEntity<Editor>,
+    path: ProjectPath,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let Some(workspace) = editor
+        .read_with(cx, |editor, _| editor.workspace())
+        .ok()
+        .flatten()
+    else {
+        return;
+    };
+    workspace.update(cx, |workspace, cx| {
+        workspace
+            .open_path(path, None, true, window, cx)
+            .detach_and_log_err(cx);
+    });
+}
+
+/// Renders a note transclusion as a card: a header naming the note, which
+/// opens it, over the note's own markdown.
+///
+/// The body is loaded asynchronously, so the card also has to draw the two
+/// states that are not content — still loading, and no such note — rather
+/// than collapsing to nothing and leaving the reader with a blank line where
+/// they wrote an embed.
+#[allow(clippy::too_many_arguments)]
+fn render_embed_block(
+    state: EmbedState,
+    label: SharedString,
+    body: Option<Entity<Markdown>>,
+    editor: WeakEntity<Editor>,
+    range: Range<Anchor>,
+    base_directory: Option<PathBuf>,
+    indent_columns: u32,
+    image_cache: Entity<RetainAllImageCache>,
+) -> RenderBlock {
+    Arc::new(move |block_cx| {
+        let colors = block_cx.app.theme().colors();
+        let border_color = colors.border;
+        let muted_color = colors.text_muted;
+        let accent_color = colors.text_accent;
+        let style = block_markdown_style(block_cx.window, block_cx.app);
+        let gutter_width =
+            block_cx.margins.gutter.full_width() + block_cx.em_width * indent_columns as f32;
+        let header_id = block_cx.block_id;
+        let start = range.start;
+        let base_directory = base_directory.clone();
+        let image_cache = image_cache.clone();
+        let body = body.clone();
+        let open_editor = editor.clone();
+        let open_path = match &state {
+            EmbedState::Ready { path, .. } => Some(path.clone()),
+            EmbedState::Loading | EmbedState::Missing => None,
+        };
+        // Accent color promises a click. A target that has not resolved has
+        // nothing to open, so its header recedes instead of lying.
+        let label_color = if open_path.is_some() {
+            accent_color
+        } else {
+            muted_color
+        };
+        let source_click_editor = editor.clone();
+        let source_range = range.clone();
+
+        div()
+            .pl(gutter_width)
+            .w(block_cx.max_width)
+            .cursor_pointer()
+            .on_mouse_down(
+                MouseButton::Left,
+                reveal_source_on_mouse_down(editor.clone(), start),
+            )
+            .child(
+                v_flex()
+                    .gap_1()
+                    .px_3()
+                    .py_2()
+                    .border_1()
+                    .border_color(border_color)
+                    .rounded_md()
+                    .child(
+                        h_flex()
+                            .id(header_id)
+                            .gap_1p5()
+                            .items_center()
+                            .when_some(open_path, |this, path| {
+                                // Opening the note is the header's job, so it
+                                // claims the click instead of letting the
+                                // wrapper reveal the embed's source.
+                                this.on_mouse_down(MouseButton::Left, |_, window, _| {
+                                    window.prevent_default()
+                                })
+                                .on_click(move |_, window, cx| {
+                                    open_embedded_note(&open_editor, path.clone(), window, cx);
+                                })
+                            })
+                            .child(
+                                Icon::new(IconName::Link)
+                                    .size(IconSize::XSmall)
+                                    .color(Color::Custom(muted_color)),
+                            )
+                            .child(
+                                div()
+                                    .text_size(
+                                        block_cx
+                                            .window
+                                            .text_style()
+                                            .font_size
+                                            .to_pixels(block_cx.window.rem_size())
+                                            * 0.9,
+                                    )
+                                    .text_color(label_color)
+                                    .child(label.clone()),
+                            ),
+                    )
+                    .map(|this| match (&state, body) {
+                        (EmbedState::Ready { .. }, Some(body)) => this.child(
+                            MarkdownElement::new(body, style)
+                                .image_resolver(move |destination, _cx| {
+                                    resolve_image_source(
+                                        destination,
+                                        base_directory.as_deref(),
+                                        &image_cache,
+                                    )
+                                })
+                                .on_source_click(move |_source_index, _click_count, window, cx| {
+                                    if window.default_prevented() {
+                                        return false;
+                                    }
+                                    // The indices point into the embedded
+                                    // note, not this buffer, so they cannot
+                                    // be mapped to a character here; reveal
+                                    // at the embed's own start instead.
+                                    reveal_at_source_index(
+                                        &source_click_editor,
+                                        &source_range,
+                                        0,
+                                        window,
+                                        cx,
+                                    )
+                                }),
+                        ),
+                        (EmbedState::Missing, _) => this.child(
+                            div()
+                                .text_color(muted_color)
+                                .child("No note in this project answers to that name."),
+                        ),
+                        _ => this.child(div().text_color(muted_color).child("Loading\u{2026}")),
+                    }),
+            )
+            .into_any_element()
+    })
+}
+
 /// Renders an Obsidian callout as a tinted card: the type's icon and color, a
 /// title row, and the quote's body with its `>` prefixes stripped.
 ///
@@ -5099,7 +5587,7 @@ impl Extraction<'_> {
                     continue;
                 }
                 if is_embed {
-                    self.embed_image_block(start - 1, end, inner);
+                    self.embed_block(start - 1, end, inner);
                     continue;
                 }
 
@@ -5122,23 +5610,16 @@ impl Extraction<'_> {
         self.prose_regions = regions;
     }
 
-    /// Renders an Obsidian image embed (`![[photo.png]]`, with Obsidian's
-    /// `![[photo.png|640]]` width syntax) as an image block when it is the
-    /// only content on its line. The target resolves like a regular markdown
-    /// image destination — relative to the buffer's directory. Non-image
-    /// embeds (`![[Some Note]]`) and inline embeds stay raw.
-    fn embed_image_block(&mut self, embed_start: usize, embed_end: usize, inner: &str) {
-        let (target, size) = match inner.split_once('|') {
-            Some((target, size)) => (target.trim(), Some(size)),
-            None => (inner.trim(), None),
-        };
-        let is_image = std::path::Path::new(target)
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .is_some_and(is_image_extension);
-        if !is_image {
-            return;
-        }
+    /// Renders an Obsidian embed as a block widget when it is the only
+    /// content on its line; inline embeds stay raw.
+    ///
+    /// A target that names an image (`![[photo.png]]`, with Obsidian's
+    /// `![[photo.png|640]]` width syntax) becomes an image block, resolved
+    /// like a regular markdown image destination — relative to the buffer's
+    /// directory. Anything else is a note transclusion (`![[Some Note]]`,
+    /// `![[Some Note#Part]]`), whose target is a note name resolved against
+    /// the whole project rather than a path.
+    fn embed_block(&mut self, embed_start: usize, embed_end: usize, inner: &str) {
         let row = self
             .snapshot
             .offset_to_point(MultiBufferOffset(embed_start))
@@ -5152,22 +5633,53 @@ impl Extraction<'_> {
         if line_text.trim() != embed_text.trim() {
             return;
         }
-        let display_width = size
-            .map(|size| {
-                size.chars()
-                    .take_while(|character| character.is_ascii_digit())
-                    .collect::<String>()
-            })
-            .and_then(|width| width.parse::<f32>().ok())
-            .filter(|width| *width > 0.);
+
+        let (target, size) = match inner.split_once('|') {
+            Some((target, size)) => (target.trim(), Some(size)),
+            None => (inner.trim(), None),
+        };
+        let is_image = Path::new(target)
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(is_image_extension);
+        if is_image {
+            let display_width = size
+                .map(|size| {
+                    size.chars()
+                        .take_while(|character| character.is_ascii_digit())
+                        .collect::<String>()
+                })
+                .and_then(|width| width.parse::<f32>().ok())
+                .filter(|width| *width > 0.);
+            self.push_block_rows(
+                row,
+                row,
+                8,
+                BlockRenderKind::Image {
+                    display_width,
+                    destination: Some(target.to_string()),
+                    alt: String::new(),
+                },
+            );
+            return;
+        }
+
+        let (target, section) = match target.split_once('#') {
+            Some((target, section)) => (target.trim(), Some(section.trim().to_string())),
+            None => (target, None),
+        };
+        // `![[#Heading]]`, an embed of the current note's own section, needs
+        // no resolution and is not handled here.
+        if target.is_empty() {
+            return;
+        }
         self.push_block_rows(
             row,
             row,
-            8,
-            BlockRenderKind::Image {
-                display_width,
-                destination: Some(target.to_string()),
-                alt: String::new(),
+            6,
+            BlockRenderKind::Embed {
+                target: target.to_string(),
+                section,
             },
         );
     }

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -312,6 +312,13 @@ struct MarkerSet {
     /// Pandoc-style citation keys (`@key` including the `@`), styled as
     /// reference chips once the surrounding brackets are concealed.
     citations: Vec<Range<Anchor>>,
+    /// Bodies of Obsidian `==highlight==` marks, painted with a highlighter
+    /// background once the `==` delimiters are concealed.
+    highlights: Vec<Range<Anchor>>,
+    /// Obsidian tags (`#tag`, `#area/topic`), styled as chips. Unlike the
+    /// other inline constructs a tag has no syntax to hide: the `#` is part
+    /// of the tag's name, so it is styled in place rather than concealed.
+    tags: Vec<Range<Anchor>>,
 }
 
 #[derive(Clone)]
@@ -338,6 +345,9 @@ enum InlineKind {
         /// The range of the `[ ]`/`[x]` marker itself, edited on toggle.
         marker_range: Range<Anchor>,
     },
+    /// A footnote reference (`[^label]`), rendered as a raised chip carrying
+    /// the label, the way a preview renders a superscript marker.
+    Footnote { label: SharedString },
     /// A LaTeX formula (`$x$` or `$$x$$`), rendered as a typeset image.
     ///
     /// Rendering is asynchronous, so the placeholder reads whatever the shared
@@ -546,6 +556,8 @@ const LINK: usize = 3;
 const DEFINITION: usize = 4;
 const ORDERED_MARKER: usize = 5;
 const CITATION: usize = 6;
+const HIGHLIGHT: usize = 7;
+const TAG: usize = 8;
 
 /// Emphasis spans get preview-like typography: the plain text color with true
 /// bold/italic styling, overriding the theme's source-mode markup colors
@@ -563,6 +575,13 @@ fn apply_emphasis_highlights(
         .theme()
         .colors()
         .editor_document_highlight_read_background;
+    // A highlighter mark reads as a wash of color behind the text rather than
+    // a chip, so it is the one decoration that wants a warm, saturated
+    // background; deriving it from the theme's warning hue keeps it legible
+    // in both Suzuri Light and Dark instead of pinning a yellow that only
+    // works in one.
+    let highlight_background = cx.theme().status().warning.opacity(0.28);
+    let tag_background = cx.theme().status().info_background;
     let sets = [
         (
             STRIKE,
@@ -629,6 +648,25 @@ fn apply_emphasis_highlights(
                 ..Default::default()
             },
         ),
+        (
+            HIGHLIGHT,
+            markers.map(|markers| markers.highlights.clone()),
+            HighlightStyle {
+                color: Some(text_color),
+                background_color: Some(highlight_background),
+                ..Default::default()
+            },
+        ),
+        (
+            TAG,
+            markers.map(|markers| markers.tags.clone()),
+            HighlightStyle {
+                color: Some(accent_color),
+                background_color: Some(tag_background),
+                font_style: Some(gpui::FontStyle::Normal),
+                ..Default::default()
+            },
+        ),
     ];
     for (key, ranges, style) in sets {
         match ranges {
@@ -690,9 +728,10 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
             InlineKind::Hide { reveal_span } => reveal_span,
             // Math reveals when the selection touches the formula, so putting
             // the cursor in it hands back the LaTeX to edit.
-            InlineKind::Bullet | InlineKind::Checkbox { .. } | InlineKind::Math { .. } => {
-                &marker.range
-            }
+            InlineKind::Bullet
+            | InlineKind::Checkbox { .. }
+            | InlineKind::Footnote { .. }
+            | InlineKind::Math { .. } => &marker.range,
         };
         let span = reveal_span.start.to_offset(&snapshot).0..reveal_span.end.to_offset(&snapshot).0;
         let revealed = selection_offsets
@@ -1172,7 +1211,10 @@ fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPl
     // element at its measured width.
     let collapsed_text = match &marker.kind {
         InlineKind::Hide { .. } => Some(SharedString::new_static("")),
-        InlineKind::Bullet | InlineKind::Checkbox { .. } | InlineKind::Math { .. } => None,
+        InlineKind::Bullet
+        | InlineKind::Checkbox { .. }
+        | InlineKind::Footnote { .. }
+        | InlineKind::Math { .. } => None,
     };
     let render: Arc<dyn Send + Sync + Fn(_, _, &mut App) -> gpui::AnyElement> = match &marker.kind {
         InlineKind::Hide { .. } => Arc::new(|_, _, _| Empty.into_any_element()),
@@ -1206,6 +1248,24 @@ fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPl
                     toggle_task_marker(&editor, &marker_range, checked, cx);
                 })
                 .into_any_element()
+            })
+        }
+        InlineKind::Footnote { label } => {
+            let label = label.clone();
+            Arc::new(move |_, _, cx: &mut App| {
+                let theme_settings = theme_settings::ThemeSettings::get_global(cx);
+                let font_size = theme_settings.buffer_font_size(cx);
+                // The editor centers an inline element in the line, so the
+                // only way to raise a marker above the baseline is to pad it
+                // asymmetrically: bottom padding of 2d shifts it up by d.
+                let raise = font_size * 0.3;
+                div()
+                    .pb(raise * 2.0)
+                    .font(theme_settings.buffer_font.clone())
+                    .text_size(font_size * 0.75)
+                    .text_color(cx.theme().colors().text_accent)
+                    .child(label.clone())
+                    .into_any_element()
             })
         }
         InlineKind::Math { source, style } => {
@@ -1299,6 +1359,14 @@ fn marker_content_key(kind: &InlineKind) -> u64 {
         InlineKind::Hide { .. } => 0,
         InlineKind::Bullet => 1,
         InlineKind::Checkbox { checked, .. } => 2 + u64::from(*checked),
+        // The label is what the placeholder draws, so a `[^1]` edited into
+        // `[^2]` over an unchanged range must not reuse the old concealment.
+        InlineKind::Footnote { label } => {
+            use std::hash::{Hash as _, Hasher as _};
+            let mut hasher = collections::FxHasher::default();
+            label.hash(&mut hasher);
+            4 + hasher.finish()
+        }
         // Editing a formula changes what its placeholder must draw even though
         // its range is unchanged, so the source has to take part in the key or
         // the concealment is reused with a stale image.
@@ -1307,7 +1375,9 @@ fn marker_content_key(kind: &InlineKind) -> u64 {
             let mut hasher = collections::FxHasher::default();
             source.hash(&mut hasher);
             style.hash(&mut hasher);
-            // Keep clear of the discriminants above.
+            // Keep clear of the discriminants above. Footnotes hash into the
+            // same space; the differing seed text makes a collision no more
+            // likely than between two formulas.
             4 + hasher.finish()
         }
     }
@@ -4126,6 +4196,8 @@ fn extract_markers(editor: &Editor, cx: &App) -> Option<MarkerSet> {
         definition_ranges: Vec::new(),
         ordered_markers: Vec::new(),
         citations: Vec::new(),
+        highlights: Vec::new(),
+        tags: Vec::new(),
     };
 
     for layer in buffer_snapshot.syntax_layers() {
@@ -4139,6 +4211,9 @@ fn extract_markers(editor: &Editor, cx: &App) -> Option<MarkerSet> {
 
     extraction.scan_wikilinks();
     extraction.scan_citations();
+    extraction.scan_footnotes();
+    extraction.scan_highlights();
+    extraction.scan_tags();
 
     let Extraction {
         inline,
@@ -4151,6 +4226,8 @@ fn extract_markers(editor: &Editor, cx: &App) -> Option<MarkerSet> {
         definition_ranges,
         ordered_markers,
         citations,
+        highlights,
+        tags,
         ..
     } = extraction;
 
@@ -4189,6 +4266,8 @@ fn extract_markers(editor: &Editor, cx: &App) -> Option<MarkerSet> {
         definition_ranges,
         ordered_markers,
         citations,
+        highlights,
+        tags,
     })
 }
 
@@ -4212,6 +4291,8 @@ struct Extraction<'a> {
     definition_ranges: Vec<Range<Anchor>>,
     ordered_markers: Vec<Range<Anchor>>,
     citations: Vec<Range<Anchor>>,
+    highlights: Vec<Range<Anchor>>,
+    tags: Vec<Range<Anchor>>,
 }
 
 impl Extraction<'_> {
@@ -4839,6 +4920,169 @@ impl Extraction<'_> {
                     self.citations.push(range);
                 }
                 search_from = close + 1;
+            }
+        }
+        self.prose_regions = regions;
+    }
+
+    /// Conceal footnote references (`[^label]`), rendering each as a raised
+    /// chip carrying the label. The markdown grammar has no footnote nodes, so
+    /// like wikilinks this scans the prose regions directly, skipping code
+    /// spans.
+    ///
+    /// A definition (`[^label]: text` at the start of a line) is not a
+    /// reference: concealing its marker would leave a bare paragraph with no
+    /// sign of which footnote it defines, so it recedes like a link reference
+    /// definition instead of disappearing.
+    fn scan_footnotes(&mut self) {
+        let regions = std::mem::take(&mut self.prose_regions);
+        for region in &regions {
+            let Some(region_text) = self.text.get(region.clone()) else {
+                continue;
+            };
+            let mut search_from = 0;
+            while let Some(open_offset) = region_text[search_from..].find("[^") {
+                let open = search_from + open_offset;
+                search_from = open + 2;
+                let Some(close_offset) = region_text[open + 2..].find(']') else {
+                    break;
+                };
+                let close = open + 2 + close_offset;
+                let label = &region_text[open + 2..close];
+                if label.is_empty() || label.contains(char::is_whitespace) || label.contains('[') {
+                    continue;
+                }
+                let start = region.start + open;
+                let end = region.start + close + 1;
+                if self
+                    .code_spans
+                    .iter()
+                    .any(|span| span.start < end && start < span.end)
+                {
+                    continue;
+                }
+                search_from = close + 1;
+
+                let line_start = self.text[..start].rfind('\n').map_or(0, |index| index + 1);
+                let is_definition = self.text[line_start..start]
+                    .chars()
+                    .all(char::is_whitespace)
+                    && self.text[end..].starts_with(':');
+                if is_definition {
+                    let range = self.anchor_range(start..end + 1);
+                    self.definition_ranges.push(range);
+                    continue;
+                }
+
+                let range = self.anchor_range(start..end);
+                self.inline.push(InlineMarker {
+                    range,
+                    kind: InlineKind::Footnote {
+                        label: SharedString::from(label.to_string()),
+                    },
+                });
+            }
+        }
+        self.prose_regions = regions;
+    }
+
+    /// Conceal Obsidian's `==highlight==` marks, leaving the body painted with
+    /// a highlighter background. The markdown grammar has no highlight node,
+    /// so like wikilinks this scans the prose regions directly, skipping code
+    /// spans.
+    fn scan_highlights(&mut self) {
+        let regions = std::mem::take(&mut self.prose_regions);
+        for region in &regions {
+            let Some(region_text) = self.text.get(region.clone()) else {
+                continue;
+            };
+            let mut search_from = 0;
+            while let Some(open_offset) = region_text[search_from..].find("==") {
+                let open = search_from + open_offset;
+                search_from = open + 2;
+                let Some(close_offset) = region_text[open + 2..].find("==") else {
+                    break;
+                };
+                let close = open + 2 + close_offset;
+                let inner = &region_text[open + 2..close];
+                // Delimiters bind tightly, as emphasis does: without this,
+                // prose comparing two values ("a == b == c") reads as a mark.
+                if inner.is_empty()
+                    || inner.contains('\n')
+                    || inner.starts_with(char::is_whitespace)
+                    || inner.ends_with(char::is_whitespace)
+                {
+                    continue;
+                }
+                let start = region.start + open;
+                let end = region.start + close + 2;
+                if self
+                    .code_spans
+                    .iter()
+                    .any(|span| span.start < end && start < span.end)
+                {
+                    continue;
+                }
+                search_from = close + 2;
+
+                let reveal = start..end;
+                self.hide(start..start + 2, reveal.clone());
+                self.hide(end - 2..end, reveal);
+                let range = self.anchor_range(start + 2..end - 2);
+                self.highlights.push(range);
+            }
+        }
+        self.prose_regions = regions;
+    }
+
+    /// Style Obsidian tags (`#tag`, `#area/topic`) as chips. A tag is the one
+    /// inline construct with no syntax to hide — the `#` is part of its name —
+    /// so it is only highlighted.
+    ///
+    /// A heading can never be mistaken for a tag: `walk_block_layer` claims
+    /// `atx_heading` without descending into it, so a heading's text never
+    /// becomes a prose region in the first place.
+    fn scan_tags(&mut self) {
+        let regions = std::mem::take(&mut self.prose_regions);
+        for region in &regions {
+            let Some(region_text) = self.text.get(region.clone()) else {
+                continue;
+            };
+            for (hash, _) in region_text.match_indices('#') {
+                // A tag has to open a word. This is what keeps a URL fragment
+                // (`example.com/#top`) and a wikilink's heading target
+                // (`[[Note#section]]`) from reading as tags.
+                let opens_word = match region_text[..hash].chars().last() {
+                    None => true,
+                    Some(character) => character.is_whitespace(),
+                };
+                if !opens_word {
+                    continue;
+                }
+                let body: String = region_text[hash + 1..]
+                    .chars()
+                    .take_while(|character| {
+                        character.is_alphanumeric() || matches!(character, '_' | '-' | '/')
+                    })
+                    .collect();
+                // Trailing separators belong to the prose, not the tag.
+                let body = body.trim_end_matches(['-', '/']);
+                // `#1` is an issue reference or a heading level; Obsidian
+                // likewise requires at least one non-numeric character.
+                if body.is_empty() || body.chars().all(|character| character.is_numeric()) {
+                    continue;
+                }
+                let start = region.start + hash;
+                let end = start + 1 + body.len();
+                if self
+                    .code_spans
+                    .iter()
+                    .any(|span| span.start < end && start < span.end)
+                {
+                    continue;
+                }
+                let range = self.anchor_range(start..end);
+                self.tags.push(range);
             }
         }
         self.prose_regions = regions;

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -510,11 +510,15 @@ impl CalloutKind {
     fn accent(self, cx: &App) -> Hsla {
         let status = cx.theme().status();
         match self {
-            Self::Note | Self::Abstract | Self::Todo => status.info,
+            // Obsidian gives `example` a purple of its own, but the status
+            // palette has no purple: `hint` is blue in Zed's base theme and
+            // grey in Suzuri's, which would make this family collide with
+            // `note` under one theme and with `quote` under the other. It
+            // takes `info` and leans on its book icon to stay distinct.
+            Self::Note | Self::Abstract | Self::Todo | Self::Example => status.info,
             Self::Tip | Self::Success => status.success,
             Self::Question | Self::Warning => status.warning,
             Self::Failure | Self::Danger => status.error,
-            Self::Example => status.hint,
             Self::Quote => cx.theme().colors().text_muted,
         }
     }
@@ -1156,7 +1160,7 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
                 let body = match &state {
                     EmbedState::Ready { body, .. } => Some(cx.new(|cx| {
                         Markdown::new_with_options(
-                            body.clone(),
+                            SharedString::from(wikilink_display_text(body).into_owned()),
                             language_registry.clone(),
                             None,
                             markdown::MarkdownOptions {
@@ -1189,7 +1193,11 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
                 title,
                 collapse,
             } => {
+                // Like a table cell, the body renders through the markdown
+                // crate, which has no wikilink syntax — so `[[Note]]` would
+                // otherwise reach the screen with its brackets on.
                 let body_source = callout_body(&source);
+                let body_source = wikilink_display_text(&body_source).into_owned();
                 let body = (!collapsed && !body_source.trim().is_empty()).then(|| {
                     cx.new(|cx| {
                         Markdown::new_with_options(
@@ -5334,9 +5342,15 @@ impl Extraction<'_> {
                                 title,
                                 collapse,
                             },
-                            // A title row plus the body; a collapsed callout
-                            // is resized down when the editor measures it.
-                            end_row - start_row + 2,
+                            // The same row count a plain block quote uses.
+                            // A card looks taller than its source — padding,
+                            // a title row — but its body is markdown, where
+                            // consecutive quoted lines collapse into one
+                            // wrapped paragraph, so it usually is not.
+                            // Guessing high made every callout on screen
+                            // need a resize round, and enough of them at
+                            // once exhausted the editor's prepaint depth.
+                            end_row - start_row + 1,
                         ),
                         None => (BlockRenderKind::Markdown, end_row - start_row + 1),
                     };

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -224,6 +224,7 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
         handle_press: None,
         source_revealed: None,
         last_resize_at: None,
+        callout_collapse: Vec::new(),
         _subscriptions: subscriptions,
     });
 
@@ -273,6 +274,10 @@ struct LivePreviewAddon {
     /// When a resize drag last wrote a width, so selection isn't cleared by
     /// the selection refresh that buffer edits trigger mid-drag.
     last_resize_at: Option<std::time::Instant>,
+    /// Callouts the reader has expanded or collapsed by clicking their title,
+    /// overriding the `+`/`-` their syntax asks for. Anchored, so the state
+    /// follows the callout as text above it changes.
+    callout_collapse: Vec<(Range<Anchor>, bool)>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -391,6 +396,14 @@ enum BlockRenderKind {
         destination: Option<String>,
         alt: String,
     },
+    /// An Obsidian callout (`> [!note] Title`), rendered as a tinted card
+    /// with its type's icon and color. `collapse` carries what the `+`/`-`
+    /// suffix asked for: `None` when the callout is not collapsible at all.
+    Callout {
+        kind: CalloutKind,
+        title: String,
+        collapse: Option<bool>,
+    },
     /// Display math (`$$...$$` alone on its lines), rendered as a centered
     /// typeset formula. Unlike other blocks, revealing its source does not
     /// remove the widget: the rendering stays below the source lines and
@@ -399,6 +412,94 @@ enum BlockRenderKind {
         /// The LaTeX between the delimiters.
         source: String,
     },
+}
+
+/// Obsidian's callout types, collapsed onto the handful of visual treatments
+/// they actually have. Its full alias list maps many names onto one look —
+/// `tip`, `hint`, and `important` are the same callout — so this models the
+/// looks and resolves aliases into them.
+///
+/// An unrecognized type deliberately renders as `Note` rather than falling
+/// back to a plain quote: a vault full of `[!recipe]` callouts should still
+/// read as callouts.
+#[derive(Clone, Copy, PartialEq)]
+enum CalloutKind {
+    Note,
+    Abstract,
+    Todo,
+    Tip,
+    Success,
+    Question,
+    Warning,
+    Failure,
+    Danger,
+    Example,
+    Quote,
+}
+
+impl CalloutKind {
+    fn from_name(name: &str) -> Self {
+        match name.to_ascii_lowercase().as_str() {
+            "abstract" | "summary" | "tldr" => Self::Abstract,
+            "todo" => Self::Todo,
+            "tip" | "hint" | "important" => Self::Tip,
+            "success" | "check" | "done" => Self::Success,
+            "question" | "help" | "faq" => Self::Question,
+            "warning" | "caution" | "attention" => Self::Warning,
+            "failure" | "fail" | "missing" | "bug" => Self::Failure,
+            "danger" | "error" => Self::Danger,
+            "example" => Self::Example,
+            "quote" | "cite" => Self::Quote,
+            _ => Self::Note,
+        }
+    }
+
+    fn icon(self) -> IconName {
+        match self {
+            Self::Note => IconName::Info,
+            Self::Abstract => IconName::Notepad,
+            Self::Todo => IconName::ListTodo,
+            Self::Tip => IconName::Flame,
+            Self::Success => IconName::Check,
+            Self::Question => IconName::CircleHelp,
+            Self::Warning => IconName::Warning,
+            Self::Failure => IconName::XCircle,
+            Self::Danger => IconName::BoltFilled,
+            Self::Example => IconName::Book,
+            Self::Quote => IconName::Quote,
+        }
+    }
+
+    /// The callout's accent, taken from the theme's status palette so both
+    /// Suzuri Light and Dark stay legible without pinning hex values.
+    fn accent(self, cx: &App) -> Hsla {
+        let status = cx.theme().status();
+        match self {
+            Self::Note | Self::Abstract | Self::Todo => status.info,
+            Self::Tip | Self::Success => status.success,
+            Self::Question | Self::Warning => status.warning,
+            Self::Failure | Self::Danger => status.error,
+            Self::Example => status.hint,
+            Self::Quote => cx.theme().colors().text_muted,
+        }
+    }
+
+    /// What Obsidian titles an untitled callout: the type's own name.
+    fn default_title(self) -> &'static str {
+        match self {
+            Self::Note => "Note",
+            Self::Abstract => "Abstract",
+            Self::Todo => "Todo",
+            Self::Tip => "Tip",
+            Self::Success => "Success",
+            Self::Question => "Question",
+            Self::Warning => "Warning",
+            Self::Failure => "Failure",
+            Self::Danger => "Danger",
+            Self::Example => "Example",
+            Self::Quote => "Quote",
+        }
+    }
 }
 
 #[derive(Clone, PartialEq)]
@@ -509,6 +610,10 @@ struct AppliedBlock {
     /// True when the widget is placed below its source lines instead of
     /// replacing them — display math while its source is revealed.
     below: bool,
+    /// A collapsed callout draws different content over identical source, so
+    /// this has to take part in the reuse check or toggling one redraws
+    /// nothing. Always false for every other block kind.
+    collapsed: bool,
     block_id: CustomBlockId,
 }
 
@@ -678,12 +783,23 @@ fn apply_emphasis_highlights(
     }
 }
 
+/// A block widget `apply_decorations` wants on screen this pass, paired with
+/// everything the reuse check compares against the block already applied
+/// there.
+struct DesiredBlock<'a> {
+    marker: &'a BlockMarker,
+    source: String,
+    below: bool,
+    collapsed: bool,
+}
+
 fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
     let Some(addon) = editor.addon_mut::<LivePreviewAddon>() else {
         return;
     };
     let markers = addon.markers.clone();
     let image_cache = addon.image_cache.clone();
+    let callout_collapse = addon.callout_collapse.clone();
     let applied_blocks = std::mem::take(&mut addon.applied_blocks);
 
     let snapshot = editor.buffer().read(cx).snapshot(cx);
@@ -765,8 +881,7 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
 
     // --- Block widgets ---
 
-    let mut desired_blocks: HashMap<(usize, usize), (&BlockMarker, String, bool)> =
-        HashMap::default();
+    let mut desired_blocks: HashMap<(usize, usize), DesiredBlock<'_>> = HashMap::default();
     for marker in &markers.blocks {
         let start = marker.range.start.to_point(&snapshot);
         let end = marker.range.end.to_point(&snapshot);
@@ -810,13 +925,32 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
         // document's definitions, which live outside the widget's slice.
         if matches!(
             marker.kind,
-            BlockRenderKind::Markdown | BlockRenderKind::Image { .. }
+            BlockRenderKind::Markdown
+                | BlockRenderKind::Image { .. }
+                | BlockRenderKind::Callout { .. }
         ) && !markers.definitions.is_empty()
         {
             source.push_str("\n\n");
             source.push_str(&markers.definitions);
         }
-        desired_blocks.insert((start_offset.0, end_offset.0), (marker, source, below));
+        // What the reader last asked for wins over what the `+`/`-` in the
+        // syntax asked for.
+        let collapsed = match &marker.kind {
+            BlockRenderKind::Callout { collapse, .. } => callout_collapse
+                .iter()
+                .find(|(range, _)| range.start.to_offset(&snapshot) == start_offset)
+                .map_or(collapse.unwrap_or(false), |(_, collapsed)| *collapsed),
+            _ => false,
+        };
+        desired_blocks.insert(
+            (start_offset.0, end_offset.0),
+            DesiredBlock {
+                marker,
+                source,
+                below,
+                collapsed,
+            },
+        );
     }
 
     let mut new_applied_blocks = Vec::new();
@@ -824,9 +958,11 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
     for applied in applied_blocks {
         let start = applied.range.start.to_offset(&snapshot).0;
         let end = applied.range.end.to_offset(&snapshot).0;
-        let keep = desired_blocks
-            .get(&(start, end))
-            .is_some_and(|(_, source, below)| *source == applied.source && *below == applied.below);
+        let keep = desired_blocks.get(&(start, end)).is_some_and(|desired| {
+            desired.source == applied.source
+                && desired.below == applied.below
+                && desired.collapsed == applied.collapsed
+        });
         if keep {
             desired_blocks.remove(&(start, end));
             new_applied_blocks.push(applied);
@@ -845,7 +981,13 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
         .read(cx)
         .as_singleton()
         .and_then(|buffer| buffer.read(cx).language_registry());
-    for (marker, source, below) in desired_blocks.into_values() {
+    for DesiredBlock {
+        marker,
+        source,
+        below,
+        collapsed,
+    } in desired_blocks.into_values()
+    {
         let render = match &marker.kind {
             BlockRenderKind::Markdown => {
                 let markdown = cx.new(|cx| {
@@ -951,6 +1093,40 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
             BlockRenderKind::Frontmatter => {
                 render_frontmatter_block(weak_editor.clone(), marker.range.clone(), source.clone())
             }
+            BlockRenderKind::Callout {
+                kind,
+                title,
+                collapse,
+            } => {
+                let body_source = callout_body(&source);
+                let body = (!collapsed && !body_source.trim().is_empty()).then(|| {
+                    cx.new(|cx| {
+                        Markdown::new_with_options(
+                            SharedString::from(body_source),
+                            language_registry.clone(),
+                            None,
+                            markdown::MarkdownOptions {
+                                parse_html: true,
+                                render_mermaid_diagrams: true,
+                                ..Default::default()
+                            },
+                            cx,
+                        )
+                    })
+                });
+                render_callout_block(
+                    *kind,
+                    SharedString::from(title.clone()),
+                    body,
+                    weak_editor.clone(),
+                    marker.range.clone(),
+                    base_directory.clone(),
+                    marker.indent_columns,
+                    image_cache.clone(),
+                    collapse.is_some(),
+                    collapsed,
+                )
+            }
             BlockRenderKind::Math { source } => {
                 let text_color = cx.theme().colors().editor_foreground;
                 request_math_render(
@@ -982,7 +1158,7 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
             render,
             priority: 0,
         });
-        pending_applied.push((marker.range.clone(), source, below));
+        pending_applied.push((marker.range.clone(), source, below, collapsed));
     }
 
     if !block_ids_to_remove.is_empty() {
@@ -990,11 +1166,14 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
     }
     if !blocks_to_insert.is_empty() {
         let block_ids = editor.insert_blocks(blocks_to_insert, None, cx);
-        for ((range, source, below), block_id) in pending_applied.into_iter().zip(block_ids) {
+        for ((range, source, below, collapsed), block_id) in
+            pending_applied.into_iter().zip(block_ids)
+        {
             new_applied_blocks.push(AppliedBlock {
                 range,
                 source,
                 below,
+                collapsed,
                 block_id,
             });
         }
@@ -1324,11 +1503,7 @@ fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPl
                             .w(width)
                             .pt(pad_top)
                             .pb(pad_bottom)
-                            .child(
-                                img(ImageSource::Render(image.clone()))
-                                    .h(height)
-                                    .w(width),
-                            )
+                            .child(img(ImageSource::Render(image.clone())).h(height).w(width))
                             .into_any_element()
                     }
                     // While a render is in flight — and permanently for a
@@ -3379,6 +3554,132 @@ fn render_rule_block(
     })
 }
 
+/// Renders an Obsidian callout as a tinted card: the type's icon and color, a
+/// title row, and the quote's body with its `>` prefixes stripped.
+///
+/// A collapsible callout's title row claims its own click so it toggles
+/// instead of revealing source, the way a rendered code block's copy button
+/// does. Everything else in the card falls through to the wrapper and reveals
+/// the markdown for editing, like any other block widget.
+#[allow(clippy::too_many_arguments)]
+fn render_callout_block(
+    kind: CalloutKind,
+    title: SharedString,
+    body: Option<Entity<Markdown>>,
+    editor: WeakEntity<Editor>,
+    range: Range<Anchor>,
+    base_directory: Option<PathBuf>,
+    indent_columns: u32,
+    image_cache: Entity<RetainAllImageCache>,
+    collapsible: bool,
+    collapsed: bool,
+) -> RenderBlock {
+    Arc::new(move |block_cx| {
+        let accent = kind.accent(block_cx.app);
+        let style = block_markdown_style(block_cx.window, block_cx.app);
+        let gutter_width =
+            block_cx.margins.gutter.full_width() + block_cx.em_width * indent_columns as f32;
+        // The title row is the only stateful element in the card, so the
+        // block's own id is enough to keep it distinct from every other
+        // callout on screen.
+        let title_id = block_cx.block_id;
+        let start = range.start;
+        let base_directory = base_directory.clone();
+        let image_cache = image_cache.clone();
+        let body = body.clone();
+        let toggle_editor = editor.clone();
+        let toggle_range = range.clone();
+        let source_click_editor = editor.clone();
+        let source_range = range.clone();
+
+        div()
+            .pl(gutter_width)
+            .w(block_cx.max_width)
+            .cursor_pointer()
+            .on_mouse_down(
+                MouseButton::Left,
+                reveal_source_on_mouse_down(editor.clone(), start),
+            )
+            .child(
+                v_flex()
+                    .gap_1()
+                    .px_3()
+                    .py_2()
+                    .border_l_2()
+                    .border_color(accent)
+                    .rounded_r_md()
+                    .bg(accent.opacity(0.1))
+                    .child(
+                        h_flex()
+                            .id(title_id)
+                            .gap_1p5()
+                            .items_center()
+                            .when(collapsible, |this| {
+                                this.on_mouse_down(MouseButton::Left, |_, window, _| {
+                                    window.prevent_default()
+                                })
+                                .on_click(move |_, _, cx| {
+                                    toggle_callout(&toggle_editor, &toggle_range, collapsed, cx);
+                                })
+                            })
+                            .child(
+                                Icon::new(kind.icon())
+                                    .size(IconSize::Small)
+                                    .color(Color::Custom(accent)),
+                            )
+                            .child(
+                                div()
+                                    .font_weight(FontWeight::BOLD)
+                                    .text_color(accent)
+                                    .child(title.clone()),
+                            )
+                            .when(collapsible, |this| {
+                                this.child(
+                                    Icon::new(if collapsed {
+                                        IconName::ChevronRight
+                                    } else {
+                                        IconName::ChevronDown
+                                    })
+                                    .size(IconSize::XSmall)
+                                    .color(Color::Custom(accent)),
+                                )
+                            }),
+                    )
+                    .when_some(body, |this, body| {
+                        this.child(
+                            MarkdownElement::new(body, style)
+                                .image_resolver(move |destination, _cx| {
+                                    resolve_image_source(
+                                        destination,
+                                        base_directory.as_deref(),
+                                        &image_cache,
+                                    )
+                                })
+                                .on_source_click(move |_source_index, _click_count, window, cx| {
+                                    if window.default_prevented() {
+                                        return false;
+                                    }
+                                    // The body's indices point into the
+                                    // stripped markdown, which has had a
+                                    // header line and a `>` per line removed,
+                                    // so they do not map back onto buffer
+                                    // characters; reveal at the callout's
+                                    // start instead of at the wrong one.
+                                    reveal_at_source_index(
+                                        &source_click_editor,
+                                        &source_range,
+                                        0,
+                                        window,
+                                        cx,
+                                    )
+                                }),
+                        )
+                    }),
+            )
+            .into_any_element()
+    })
+}
+
 /// Renders display math as a centered formula.
 ///
 /// In replace mode (`below == false`) the widget stands in for the source
@@ -4525,12 +4826,25 @@ impl Extraction<'_> {
                 }
                 "block_quote" => {
                     let (start_row, end_row) = self.node_rows(node);
-                    self.push_block_rows(
-                        start_row,
-                        end_row,
-                        end_row - start_row + 1,
-                        BlockRenderKind::Markdown,
-                    );
+                    let header = self
+                        .text
+                        .get(node.byte_range())
+                        .and_then(|text| text.lines().next())
+                        .and_then(parse_callout_header);
+                    let (kind, height) = match header {
+                        Some((kind, title, collapse)) => (
+                            BlockRenderKind::Callout {
+                                kind,
+                                title,
+                                collapse,
+                            },
+                            // A title row plus the body; a collapsed callout
+                            // is resized down when the editor measures it.
+                            end_row - start_row + 2,
+                        ),
+                        None => (BlockRenderKind::Markdown, end_row - start_row + 1),
+                    };
+                    self.push_block_rows(start_row, end_row, height, kind);
                     push_children(node, &mut stack);
                 }
                 "link_reference_definition" => {
@@ -5195,6 +5509,81 @@ fn citation_keys(inner: &str) -> Vec<Range<usize>> {
         keys.push(at..at + 1 + key.len());
     }
     keys
+}
+
+/// Parses a callout's header line — `> [!type]`, `> [!type] Title`, with an
+/// optional `+`/`-` collapse suffix on the type — into its kind, title, and
+/// initial collapsed state. Returns `None` for an ordinary block quote, which
+/// keeps rendering as one.
+fn parse_callout_header(line: &str) -> Option<(CalloutKind, String, Option<bool>)> {
+    let rest = line.trim_start().strip_prefix('>')?.trim_start();
+    let (name, after) = rest.strip_prefix("[!")?.split_once(']')?;
+    // The fold character sits immediately after the `]`, so a title that
+    // merely opens with a dash (`> [!note] - like this`) is left alone.
+    let (collapse, title) = match after.strip_prefix('+') {
+        Some(title) => (Some(false), title),
+        None => match after.strip_prefix('-') {
+            Some(title) => (Some(true), title),
+            None => (None, after),
+        },
+    };
+    let name = name.trim();
+    // A type is one word. Without this, an ordinary quote that happens to
+    // open with a bracketed aside would be claimed as a callout.
+    if name.is_empty() || name.contains(char::is_whitespace) {
+        return None;
+    }
+    let kind = CalloutKind::from_name(name);
+    let title = title.trim();
+    let title = if title.is_empty() {
+        kind.default_title().to_string()
+    } else {
+        title.to_string()
+    };
+    Some((kind, title, collapse))
+}
+
+/// A callout's body: the block quote's `>` prefixes stripped, and its header
+/// line dropped, leaving markdown a widget can render. Lines with no `>` pass
+/// through unchanged, which is what carries the reference definitions
+/// `apply_decorations` appends past the quote's own text.
+fn callout_body(source: &str) -> String {
+    source
+        .lines()
+        .skip(1)
+        .map(|line| {
+            let trimmed = line.trim_start();
+            match trimmed.strip_prefix('>') {
+                Some(rest) => rest.strip_prefix(' ').unwrap_or(rest),
+                None => line,
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Flips a callout between expanded and collapsed, recording the choice on
+/// the addon so it survives the redraw and overrides the `+`/`-` the syntax
+/// asked for.
+fn toggle_callout(
+    editor: &WeakEntity<Editor>,
+    range: &Range<Anchor>,
+    collapsed: bool,
+    cx: &mut App,
+) {
+    editor
+        .update(cx, |editor, cx| {
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let start = range.start.to_offset(&snapshot);
+            if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                addon
+                    .callout_collapse
+                    .retain(|(existing, _)| existing.start.to_offset(&snapshot) != start);
+                addon.callout_collapse.push((range.clone(), !collapsed));
+            }
+            recompute(editor, cx);
+        })
+        .log_err();
 }
 
 fn push_children<'a>(node: tree_sitter::Node<'a>, stack: &mut Vec<tree_sitter::Node<'a>>) {

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -3971,6 +3971,10 @@ fn render_embed_block(
                     .child(
                         h_flex()
                             .id(header_id)
+                            .debug_selector({
+                                let label = label.clone();
+                                move || format!("mdlp-embed-header-{label}")
+                            })
                             .gap_1p5()
                             .items_center()
                             .when_some(open_path, |this, path| {
@@ -4100,6 +4104,10 @@ fn render_callout_block(
                     .child(
                         h_flex()
                             .id(title_id)
+                            .debug_selector({
+                                let title = title.clone();
+                                move || format!("mdlp-callout-title-{title}")
+                            })
                             .gap_1p5()
                             .items_center()
                             .when(collapsible, |this| {

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -2029,7 +2029,10 @@ async fn test_highlight_marks_conceal(cx: &mut TestAppContext) {
     let display = cx.display_text();
     assert!(display.contains("a marked phrase here"), "{display}");
     assert!(display.contains("code stays raw: ==nope=="), "{display}");
-    assert!(display.contains("loose delimiters: a == b == c"), "{display}");
+    assert!(
+        display.contains("loose delimiters: a == b == c"),
+        "{display}"
+    );
     assert!(display.contains("empty stays raw: ===="), "{display}");
 
     // Only the one real mark carries the highlight.
@@ -2145,6 +2148,141 @@ async fn test_footnotes_conceal_references_and_mute_definitions(cx: &mut TestApp
         "{}",
         cx.display_text()
     );
+}
+
+#[gpui::test]
+async fn test_callouts_render_as_callout_blocks(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        > [!warning] Careful
+        > This is the body.
+
+        > an ordinary quote
+        > stays an ordinary quote
+    "});
+    cx.executor().run_until_parked();
+
+    let kinds = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .expect("markdown buffer should produce markers")
+            .blocks
+            .iter()
+            .map(|block| block.kind.clone())
+            .collect::<Vec<_>>()
+    });
+    assert_eq!(kinds.len(), 2, "one callout and one plain quote");
+    assert!(
+        matches!(
+            &kinds[0],
+            BlockRenderKind::Callout {
+                kind: CalloutKind::Warning,
+                title,
+                collapse: None,
+            } if title == "Careful"
+        ),
+        "expected a warning callout"
+    );
+    assert!(
+        matches!(kinds[1], BlockRenderKind::Markdown),
+        "a plain block quote must keep rendering as one"
+    );
+}
+
+#[gpui::test]
+async fn test_collapsed_callout_hides_its_body(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        > [!note]- Folded
+        > Hidden body.
+
+        > [!note]+ Open
+        > Shown body.
+    "});
+    cx.executor().run_until_parked();
+
+    let collapsed = cx.update_editor(|editor, _, _| {
+        editor
+            .addon::<LivePreviewAddon>()
+            .unwrap()
+            .applied_blocks
+            .iter()
+            .map(|block| block.collapsed)
+            .collect::<Vec<_>>()
+    });
+    assert_eq!(
+        collapsed,
+        vec![true, false],
+        "`-` starts collapsed, `+` starts expanded"
+    );
+}
+
+#[test]
+fn test_parse_callout_header() {
+    let parse = parse_callout_header;
+
+    // An untitled callout takes its type's name as the title, like Obsidian.
+    assert!(matches!(
+        parse("> [!note]"),
+        Some((CalloutKind::Note, ref title, None)) if title == "Note"
+    ));
+    assert!(matches!(
+        parse("> [!TIP] Try this"),
+        Some((CalloutKind::Tip, ref title, None)) if title == "Try this"
+    ));
+
+    // Aliases collapse onto one look.
+    assert!(matches!(
+        parse("> [!tldr]"),
+        Some((CalloutKind::Abstract, ..))
+    ));
+    assert!(matches!(
+        parse("> [!faq]"),
+        Some((CalloutKind::Question, ..))
+    ));
+    assert!(matches!(
+        parse("> [!caution]"),
+        Some((CalloutKind::Warning, ..))
+    ));
+
+    // Collapse suffixes.
+    assert!(matches!(parse("> [!note]- x"), Some((_, _, Some(true)))));
+    assert!(matches!(parse("> [!note]+ x"), Some((_, _, Some(false)))));
+    // The fold character binds to the `]`; a title may still open with a dash.
+    assert!(matches!(
+        parse("> [!note] - a dash"),
+        Some((_, ref title, None)) if title == "- a dash"
+    ));
+
+    // An unknown type is still a callout, styled as a note.
+    assert!(matches!(
+        parse("> [!recipe] Pasta"),
+        Some((CalloutKind::Note, ..))
+    ));
+
+    // Not callouts.
+    assert!(parse("> just a quote").is_none());
+    assert!(parse("> [!two words] x").is_none());
+    assert!(parse("> [!unclosed").is_none());
+    assert!(parse("[!note] no quote marker").is_none());
+}
+
+#[test]
+fn test_callout_body_strips_quote_prefixes() {
+    assert_eq!(
+        callout_body("> [!note] Title\n> first\n> - item\n>\n> last"),
+        "first\n- item\n\nlast"
+    );
+    // Reference definitions are appended past the quote's own text and carry
+    // no `>`; they must survive the strip.
+    assert_eq!(
+        callout_body("> [!note]\n> see [ref]\n\n[ref]: https://example.com"),
+        "see [ref]\n\n[ref]: https://example.com"
+    );
+    assert_eq!(callout_body("> [!note] Title"), "");
 }
 
 // --- Contract tests ---

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -937,15 +937,27 @@ async fn test_obsidian_image_embed_renders_as_block(cx: &mut TestAppContext) {
     "});
     cx.executor().run_until_parked();
 
-    // The two standalone image embeds render as image blocks; the inline
-    // embed and the non-image note embed stay raw.
-    assert_eq!(applied_block_count(&mut cx), 2);
+    // The two standalone image embeds render as image blocks, and the note
+    // embed as a transclusion card; only the inline embed stays raw.
+    assert_eq!(applied_block_count(&mut cx), 3);
     let display = cx.display_text();
     assert!(
         display.contains("inline stays raw: ![[photo.png]]"),
         "{display}"
     );
-    assert!(display.contains("![[Some Note]]"), "{display}");
+
+    let image_blocks = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .expect("markdown buffer should produce markers")
+            .blocks
+            .iter()
+            .filter(|block| matches!(block.kind, BlockRenderKind::Image { .. }))
+            .count()
+    });
+    assert_eq!(
+        image_blocks, 2,
+        "an image target must not become a note embed"
+    );
 }
 
 #[gpui::test]
@@ -2283,6 +2295,152 @@ fn test_callout_body_strips_quote_prefixes() {
         "see [ref]\n\n[ref]: https://example.com"
     );
     assert_eq!(callout_body("> [!note] Title"), "");
+}
+
+#[gpui::test]
+async fn test_note_embeds_extract_as_embed_blocks(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        ![[Some Note]]
+
+        ![[Some Note#Method]]
+
+        ![[photo.png]]
+
+        inline ![[Some Note]] stays raw
+    "});
+    cx.executor().run_until_parked();
+
+    let kinds = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .expect("markdown buffer should produce markers")
+            .blocks
+            .iter()
+            .map(|block| block.kind.clone())
+            .collect::<Vec<_>>()
+    });
+    assert_eq!(kinds.len(), 3, "an inline embed must not become a block");
+    assert!(
+        matches!(&kinds[0], BlockRenderKind::Embed { target, section: None } if target == "Some Note"),
+        "a bare note embed"
+    );
+    assert!(
+        matches!(
+            &kinds[1],
+            BlockRenderKind::Embed { target, section: Some(section) }
+                if target == "Some Note" && section == "Method"
+        ),
+        "a section embed"
+    );
+    assert!(
+        matches!(kinds[2], BlockRenderKind::Image { .. }),
+        "an image target must still render as an image"
+    );
+
+    // The inline embed keeps its source on screen rather than disappearing.
+    assert!(
+        cx.display_text()
+            .contains("inline ![[Some Note]] stays raw"),
+        "{}",
+        cx.display_text()
+    );
+}
+
+#[test]
+fn test_embed_section_extraction() {
+    let note = indoc::indoc! {"
+        # Title
+
+        Intro text.
+
+        ## Method
+
+        The method body.
+
+        ### Detail
+
+        Nested detail.
+
+        ## Results
+
+        Results body.
+    "};
+
+    let method = embed_section(note, "Method").expect("the heading exists");
+    assert!(method.contains("The method body."), "{method}");
+    // A deeper heading belongs to the section; a sibling ends it.
+    assert!(method.contains("Nested detail."), "{method}");
+    assert!(!method.contains("Results body."), "{method}");
+
+    // The last section runs to the end of the note.
+    let results = embed_section(note, "Results").expect("the heading exists");
+    assert!(results.contains("Results body."), "{results}");
+
+    // Matching ignores case, and a missing heading is reported rather than
+    // silently embedding the whole note.
+    assert!(embed_section(note, "method").is_some());
+    assert!(embed_section(note, "Nowhere").is_none());
+}
+
+#[gpui::test]
+async fn test_resolve_embed_target(cx: &mut TestAppContext) {
+    init_test(cx);
+    use project::Fs as _;
+
+    let fs = project::FakeFs::new(cx.executor());
+    for directory in [
+        "/vault",
+        "/vault/notes",
+        "/vault/notes/deep",
+        "/vault/archive",
+    ] {
+        fs.create_dir(directory.as_ref())
+            .await
+            .expect("failed to create the test directory");
+    }
+    for path in [
+        "/vault/Index.md",
+        "/vault/notes/Method.md",
+        "/vault/notes/deep/Method.md",
+        "/vault/archive/Index.md",
+    ] {
+        fs.insert_file(path, Vec::new()).await;
+    }
+    let project = project::Project::test(fs, ["/vault".as_ref()], cx).await;
+
+    let resolve =
+        |directory: Option<&'static str>, target: &'static str, cx: &mut TestAppContext| {
+            let project = project.clone();
+            cx.update(|cx| {
+                resolve_embed_target(&project, directory.map(Path::new), target, cx)
+                    .map(|(_, absolute)| absolute)
+            })
+        };
+
+    // A bare name prefers the note beside the embedding one over a deeper match.
+    assert_eq!(
+        resolve(Some("/vault/notes"), "Method", cx),
+        Some(PathBuf::from("/vault/notes/Method.md"))
+    );
+    // With no directory to prefer, the shallowest match wins.
+    assert_eq!(
+        resolve(None, "Index", cx),
+        Some(PathBuf::from("/vault/Index.md"))
+    );
+    // A target that spells out a path matches that path exactly, beating the
+    // shallower note of the same name.
+    assert_eq!(
+        resolve(None, "archive/Index", cx),
+        Some(PathBuf::from("/vault/archive/Index.md"))
+    );
+    // The `.md` extension is implied but may be written out.
+    assert_eq!(
+        resolve(None, "notes/Method.md", cx),
+        Some(PathBuf::from("/vault/notes/Method.md"))
+    );
+    assert_eq!(resolve(None, "Nowhere", cx), None);
 }
 
 // --- Contract tests ---

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -2443,6 +2443,206 @@ async fn test_resolve_embed_target(cx: &mut TestAppContext) {
     assert_eq!(resolve(None, "Nowhere", cx), None);
 }
 
+/// Clicks the center of a rendered element located by its debug selector.
+fn click_debug_element(cx: &mut EditorTestContext, selector: &'static str) {
+    let bounds = cx
+        .cx
+        .debug_bounds(selector)
+        .unwrap_or_else(|| panic!("{selector} was not rendered"));
+    cx.cx.simulate_mouse_down(
+        bounds.center(),
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    cx.cx.simulate_mouse_up(
+        bounds.center(),
+        gpui::MouseButton::Left,
+        gpui::Modifiers::none(),
+    );
+    cx.executor().run_until_parked();
+}
+
+fn callout_collapse_states(cx: &mut EditorTestContext) -> Vec<bool> {
+    cx.update_editor(|editor, _, _| {
+        editor
+            .addon::<LivePreviewAddon>()
+            .unwrap()
+            .applied_blocks
+            .iter()
+            .map(|block| block.collapsed)
+            .collect()
+    })
+}
+
+#[gpui::test]
+async fn test_clicking_a_callout_title_toggles_it(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        > [!danger]- Folded
+        > Hidden body.
+    "});
+    cx.executor().run_until_parked();
+    assert_eq!(callout_collapse_states(&mut cx), vec![true]);
+
+    // Expanding must not also reveal the source: the title claims the click,
+    // so the widget stays on screen instead of dissolving into markdown.
+    click_debug_element(&mut cx, "mdlp-callout-title-Folded");
+    assert_eq!(callout_collapse_states(&mut cx), vec![false]);
+    assert!(
+        !cx.display_text().contains("[!danger]"),
+        "{}",
+        cx.display_text()
+    );
+
+    click_debug_element(&mut cx, "mdlp-callout-title-Folded");
+    assert_eq!(callout_collapse_states(&mut cx), vec![true]);
+}
+
+#[gpui::test]
+async fn test_clicking_a_plain_callout_title_reveals_its_source(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        > [!note] Plain
+        > Body text.
+    "});
+    cx.executor().run_until_parked();
+    assert!(!cx.display_text().contains("[!note]"), "starts rendered");
+
+    // A callout with no `+`/`-` is not collapsible, so its title falls
+    // through to the wrapper and reveals the markdown for editing.
+    click_debug_element(&mut cx, "mdlp-callout-title-Plain");
+    assert!(
+        cx.display_text().contains("> [!note] Plain"),
+        "{}",
+        cx.display_text()
+    );
+}
+
+/// An editor over a real project, which transclusion needs: a target is a
+/// note name resolved against the project's worktrees, not a path resolved
+/// against the buffer's directory, so an editor with no project can only ever
+/// report the target missing.
+async fn markdown_vault_test_context<'a>(
+    cx: &'a mut TestAppContext,
+    files: &[(&'static str, &'static str)],
+    open: &str,
+) -> (
+    Entity<Editor>,
+    Arc<project::FakeFs>,
+    &'a mut gpui::VisualTestContext,
+) {
+    use project::Fs as _;
+
+    init_test(cx);
+    let fs = project::FakeFs::new(cx.executor());
+    fs.create_dir("/vault".as_ref())
+        .await
+        .expect("failed to create the vault");
+    for (path, content) in files {
+        fs.insert_file(format!("/vault/{path}"), content.as_bytes().to_vec())
+            .await;
+    }
+    let project = project::Project::test(fs.clone(), ["/vault".as_ref()], cx).await;
+
+    let registry = project.read_with(cx, |project, _| project.languages().clone());
+    registry.add(language::markdown_lang());
+    registry.add(markdown_inline_lang());
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(format!("/vault/{open}"), cx)
+        })
+        .await
+        .expect("failed to open the note");
+    cx.executor().run_until_parked();
+
+    let (editor, cx) = cx.add_window_view({
+        let project = project.clone();
+        |window, cx| Editor::for_buffer(buffer, Some(project), window, cx)
+    });
+    cx.run_until_parked();
+    (editor, fs, cx)
+}
+
+/// The markdown a transclusion widget is currently drawing, or the state it is
+/// reporting instead. Read from the applied block's source, which is where
+/// `EmbedState::reuse_key` records what reached the screen.
+fn embed_block_sources(editor: &Entity<Editor>, cx: &mut gpui::VisualTestContext) -> Vec<String> {
+    editor.update(cx, |editor, _| {
+        editor
+            .addon::<LivePreviewAddon>()
+            .unwrap()
+            .applied_blocks
+            .iter()
+            .filter(|block| block.source.starts_with('\u{0}'))
+            .map(|block| block.source.clone())
+            .collect()
+    })
+}
+
+#[gpui::test]
+async fn test_an_embed_loads_its_target_and_redraws(cx: &mut TestAppContext) {
+    use project::Fs as _;
+
+    let (editor, fs, cx) = markdown_vault_test_context(
+        cx,
+        &[
+            ("Note.md", "Opening line.\n\n![[Method]]\n"),
+            ("Method.md", "# Method\n\nWe sampled 40 participants.\n"),
+        ],
+        "Note.md",
+    )
+    .await;
+
+    let sources = embed_block_sources(&editor, cx);
+    assert_eq!(sources.len(), 1, "one transclusion block");
+    assert!(
+        sources[0].contains("We sampled 40 participants."),
+        "the load never reached the screen: {:?}",
+        sources[0]
+    );
+
+    // Changing the target on disk evicts its cache entry and redraws, so an
+    // embed does not keep showing a note that has since been edited.
+    fs.save(
+        "/vault/Method.md".as_ref(),
+        &"# Method\n\nWe sampled 80 participants.\n".into(),
+        Default::default(),
+    )
+    .await
+    .expect("failed to rewrite the target");
+    cx.run_until_parked();
+
+    let sources = embed_block_sources(&editor, cx);
+    assert!(
+        sources[0].contains("We sampled 80 participants."),
+        "a target edited on disk kept showing its old text: {:?}",
+        sources[0]
+    );
+}
+
+#[gpui::test]
+async fn test_an_unresolved_embed_reports_itself(cx: &mut TestAppContext) {
+    let (editor, _fs, cx) = markdown_vault_test_context(
+        cx,
+        &[("Note.md", "Opening line.\n\n![[Nowhere]]\n")],
+        "Note.md",
+    )
+    .await;
+
+    let sources = embed_block_sources(&editor, cx);
+    assert_eq!(sources.len(), 1, "a missing target still draws a block");
+    assert!(
+        sources[0].contains("missing"),
+        "expected the missing state, got {:?}",
+        sources[0]
+    );
+}
+
 // --- Contract tests ---
 //
 // These pin behavior this crate relies on from `editor` and `gpui` rather than

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -2015,6 +2015,138 @@ fn test_wikilink_display_text_in_cells() {
     );
 }
 
+#[gpui::test]
+async fn test_highlight_marks_conceal(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        a ==marked phrase== here
+        code stays raw: `==nope==`
+        loose delimiters: a == b == c
+        empty stays raw: ====
+    "});
+    cx.executor().run_until_parked();
+    let display = cx.display_text();
+    assert!(display.contains("a marked phrase here"), "{display}");
+    assert!(display.contains("code stays raw: ==nope=="), "{display}");
+    assert!(display.contains("loose delimiters: a == b == c"), "{display}");
+    assert!(display.contains("empty stays raw: ===="), "{display}");
+
+    // Only the one real mark carries the highlight.
+    let highlighted = cx.update_editor(|editor, _, cx| {
+        editor
+            .text_highlights(HighlightKey::MarkdownLivePreview(HIGHLIGHT), cx)
+            .map_or(0, |(_, ranges)| ranges.len())
+    });
+    assert_eq!(highlighted, 1);
+
+    // Touching the mark hands back its source, like every inline construct.
+    cx.set_state(indoc::indoc! {"
+        plain line
+        a ==markeˇd phrase== here
+    "});
+    cx.executor().run_until_parked();
+    assert!(
+        cx.display_text().contains("a ==marked phrase== here"),
+        "{}",
+        cx.display_text()
+    );
+}
+
+#[gpui::test]
+async fn test_tags_are_styled_without_concealment(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        filed under #research and #area/methods today
+        not a tag: example.com/#top or [[Note#section]] or #1
+        code stays raw: `#nope`
+    "});
+    cx.executor().run_until_parked();
+
+    // A tag keeps its `#`: it is styled in place, never concealed.
+    let display = cx.display_text();
+    assert!(
+        display.contains("filed under #research and #area/methods today"),
+        "{display}"
+    );
+
+    let tags = cx.update_editor(|editor, _, cx| {
+        editor
+            .text_highlights(HighlightKey::MarkdownLivePreview(TAG), cx)
+            .map_or(0, |(_, ranges)| ranges.len())
+    });
+    assert_eq!(tags, 2, "only the two real tags should be styled");
+}
+
+#[gpui::test]
+async fn test_headings_are_never_read_as_tags(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+
+        # Heading One
+
+        ### Heading Three
+    "});
+    cx.executor().run_until_parked();
+
+    let tags = cx.update_editor(|editor, _, cx| {
+        editor
+            .text_highlights(HighlightKey::MarkdownLivePreview(TAG), cx)
+            .map_or(0, |(_, ranges)| ranges.len())
+    });
+    assert_eq!(tags, 0);
+}
+
+#[gpui::test]
+async fn test_footnotes_conceal_references_and_mute_definitions(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        a claim[^1] and another[^note] here
+        code stays raw: `[^2]`
+        not a footnote: [^ spaced]
+
+        [^1]: The first note.
+        [^note]: The second note.
+    "});
+    cx.executor().run_until_parked();
+
+    let display = cx.display_text();
+    assert!(display.contains("a claim⋯ and another⋯ here"), "{display}");
+    assert!(display.contains("code stays raw: [^2]"), "{display}");
+    assert!(display.contains("not a footnote: [^ spaced]"), "{display}");
+
+    // Definitions keep their marker on screen, muted rather than concealed:
+    // a bare paragraph would not say which footnote it defines.
+    assert!(display.contains("[^1]: The first note."), "{display}");
+
+    let markers = cx.update_editor(|editor, _, cx| {
+        let markers = extract_markers(editor, cx).expect("markdown buffer should produce markers");
+        let references = markers
+            .inline
+            .iter()
+            .filter(|marker| matches!(marker.kind, InlineKind::Footnote { .. }))
+            .count();
+        (references, markers.definition_ranges.len())
+    });
+    assert_eq!(markers.0, 2, "two references");
+    assert_eq!(markers.1, 2, "two definition markers muted");
+
+    // Touching a reference reveals its source.
+    cx.set_state(indoc::indoc! {"
+        plain line
+        a claim[^ˇ1] and another[^note] here
+    "});
+    cx.executor().run_until_parked();
+    assert!(
+        cx.display_text().contains("a claim[^1] and another⋯ here"),
+        "{}",
+        cx.display_text()
+    );
+}
+
 // --- Contract tests ---
 //
 // These pin behavior this crate relies on from `editor` and `gpui` rather than


### PR DESCRIPTION
Adds the five Obsidian constructs most likely to be in a vault someone opens in Suzuri for the first time. Today a note full of callouts renders as a wall of raw `[!note]` block quotes, which is the kind of thing that makes someone close the editor before they try anything else.

Closes #17, closes #18, closes #19, closes #20, closes #21.

## What's here

| Construct | Behavior |
| --- | --- |
| `> [!note] Title` | Tinted card with the type's icon and accent, its body rendered as markdown. `+`/`-` makes it collapsible; clicking the title folds it. |
| `==highlight==` | Delimiters concealed, body painted with a highlighter wash. |
| `#tag`, `#area/topic` | Styled as a chip. The one inline construct with nothing to conceal — the `#` is part of the name. |
| `[^label]` | Concealed to a raised chip. Definition lines are muted rather than hidden. |
| `![[Note]]`, `![[Note#Heading]]` | The target note's markdown in a card whose header opens it. |

## Vendor delta

None. The diff is three files, all inside `crates/markdown_live_preview/`, and the only dependency added is `workspace` (already reachable — `editor` depends on it, so no cycle). Nothing upstream touches, nothing to reconcile on the next merge.

## Worth a reviewer's attention

**The block reuse key.** Block widgets are reused when their range and source text are unchanged. A collapsed callout draws different content over identical source, and an embed's source — the `![[..]]` itself — never changes even as its content loads. Both had to be folded into the reuse check or the redraw silently never happens. This is the subtlest thing in the diff and the one I'd most want a second pair of eyes on.

**Callout height estimates.** A card *looks* taller than its source, but its body is markdown, where consecutive quoted lines collapse into one wrapped paragraph, so it usually isn't. Guessing high made every callout on screen need a resize round, and enough of them at once exhausted the editor's prepaint depth — a `debug_panic!` in a dev build, a dropped resize in a release one. It now uses the same row count a plain block quote does.

**Colors come from the theme's status palette,** never from Obsidian's hex values, so callouts stay legible in both Suzuri Light and Dark. One casualty: `example` has no purple to take, so it shares `note`'s blue and leans on its book icon.

**No recursion guard is needed for transclusion.** An embedded body is drawn by `markdown::MarkdownElement`, which has no embed syntax of its own, so a note embedding itself renders one level and stops.

## Testing

58 → 69 tests. The interaction and async paths use the `debug_selector` + real-mouse-event pattern the table drag tests already established, so no GPU and no screenshot baselines.

Four of the new tests were checked by mutation rather than just by going green — dropping `collapsed` from the reuse check, making embed eviction a no-op, and collapsing `EmbedState::reuse_key` to a constant each turn the relevant test red.

Everything was also rendered offscreen through `VisualTestAppContext` against a real vault, in both themes, with the folds actually clicked. That pass is what found three defects no unit test reached: the prepaint-depth bug above, the `example` color rendering blue in one theme and grey in the other, and wikilinks reaching the screen with their brackets on inside card bodies.

## Known limits

- Wikilinks inside a callout or embed body have their brackets stripped (as table cells do) but are not clickable.
- `![[#Heading]]`, an embed of the current note's own section, is not handled.
- `![[Note#^block-id]]` is out of scope.

## Companion

[suzuri-testbed](https://github.com/harrywang/suzuri-testbed) gains `callout-`, `inline-`, and `embed-rendering-check.md`, following the vault's existing convention. They lean on regression-prone cases rather than galleries — an ordinary block quote staying one, aliases that must come out identical, a title that merely opens with a dash not being read as a fold marker.

## Suggested .rules additions

Repo root, under a build or tooling heading:

> Use `cargo fmt -p <crate>`, never `cargo fmt --all`. This tree is mostly vendored Zed, and `--all` reformats it: one invocation here silently rewrote 14 files across `pdf_viewer`, `typeset_preview`, `util`, and `editor` that the session had never opened, turning a three-file change into an eighteen-file one.

Candidate for a new `crates/markdown_live_preview/.rules`, if we want one:

> A block widget is reused when its range and source text are unchanged. Anything else that changes what it draws — a fold state, an async load — has to take part in the reuse check too, or the redraw silently never happens.

Release Notes:

- Added Obsidian callouts, `==highlight==`, `#tag` styling, footnotes, and note transclusion to the markdown live preview
