### PR TITLE
Fix the style gates that fail on main

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -86,8 +86,8 @@ pub use block_map::{
 };
 pub use crease_map::*;
 pub use fold_map::{
-    Concealment,
-    ChunkRenderer, ChunkRendererContext, ChunkRendererId, Fold, FoldId, FoldPlaceholder, FoldPoint,
+    ChunkRenderer, ChunkRendererContext, ChunkRendererId, Concealment, Fold, FoldId,
+    FoldPlaceholder, FoldPoint,
 };
 pub use inlay_map::{InlayOffset, InlayPoint};
 use invisibles::is_standalone_grapheme;
@@ -817,7 +817,8 @@ impl DisplayMap {
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
 
-        self.block_map.write(new_wrap_snapshot, new_wrap_edits, None);
+        self.block_map
+            .write(new_wrap_snapshot, new_wrap_edits, None);
     }
 
     /// Removes any folds with the given ranges.

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -4,6 +4,7 @@ use super::{
     Highlights,
     inlay_map::{InlayBufferRows, InlayChunks, InlayEdit, InlayOffset, InlayPoint, InlaySnapshot},
 };
+use collections::HashMap;
 use gpui::{AnyElement, App, ElementId, HighlightStyle, Pixels, SharedString, Stateful, Window};
 use language::{Edit, HighlightId, LanguageAwareStyling, Point};
 use multi_buffer::{
@@ -19,7 +20,6 @@ use std::{
     sync::Arc,
     usize,
 };
-use collections::HashMap;
 use sum_tree::{Bias, Cursor, Dimensions, FilterCursor, SumTree, Summary, TreeMap};
 use ui::IntoElement as _;
 use util::post_inc;
@@ -411,8 +411,9 @@ impl FoldMapWriter<'_> {
                         self.0.snapshot.fold_metadata_by_id.remove(&old.id);
                         self.0.concealment_content_keys.remove(&old.id);
                     }
-                    let fold_range =
-                        FoldRange(buffer.anchor_after(range.start)..buffer.anchor_before(range.end));
+                    let fold_range = FoldRange(
+                        buffer.anchor_after(range.start)..buffer.anchor_before(range.end),
+                    );
                     if buffer
                         .anchor_range_to_buffer_anchor_range(fold_range.0.clone())
                         .is_none()
@@ -435,8 +436,8 @@ impl FoldMapWriter<'_> {
                         range: fold_range,
                         placeholder: concealment.placeholder,
                     });
-                    let inlay_range = snapshot.to_inlay_offset(range.start)
-                        ..snapshot.to_inlay_offset(range.end);
+                    let inlay_range =
+                        snapshot.to_inlay_offset(range.start)..snapshot.to_inlay_offset(range.end);
                     edits.push(InlayEdit {
                         old: inlay_range.clone(),
                         new: inlay_range,
@@ -451,8 +452,7 @@ impl FoldMapWriter<'_> {
             self.0.snapshot.fold_metadata_by_id.remove(&old.id);
             self.0.concealment_content_keys.remove(&old.id);
             if end > start {
-                let inlay_range =
-                    snapshot.to_inlay_offset(start)..snapshot.to_inlay_offset(end);
+                let inlay_range = snapshot.to_inlay_offset(start)..snapshot.to_inlay_offset(end);
                 edits.push(InlayEdit {
                     old: inlay_range.clone(),
                     new: inlay_range,
@@ -460,8 +460,7 @@ impl FoldMapWriter<'_> {
             }
         }
 
-        new_items
-            .sort_unstable_by(|a, b| sum_tree::SeekTarget::cmp(&a.range, &b.range, &buffer));
+        new_items.sort_unstable_by(|a, b| sum_tree::SeekTarget::cmp(&a.range, &b.range, &buffer));
         let mut tree = SumTree::new(&buffer);
         for item in new_items {
             tree.push(item, &buffer);
@@ -646,18 +645,17 @@ impl FoldMap {
                     let inlay_snapshot = &inlay_snapshot;
                     move || {
                         // Merge real folds and concealments in range order.
-                        let next_is_fold =
-                            match (folds_cursor.item(), concealments_cursor.item()) {
-                                (Some(fold), Some(concealment)) => sum_tree::SeekTarget::cmp(
-                                    &fold.range,
-                                    &concealment.range,
-                                    &inlay_snapshot.buffer,
-                                )
-                                .is_le(),
-                                (Some(_), None) => true,
-                                (None, Some(_)) => false,
-                                (None, None) => true,
-                            };
+                        let next_is_fold = match (folds_cursor.item(), concealments_cursor.item()) {
+                            (Some(fold), Some(concealment)) => sum_tree::SeekTarget::cmp(
+                                &fold.range,
+                                &concealment.range,
+                                &inlay_snapshot.buffer,
+                            )
+                            .is_le(),
+                            (Some(_), None) => true,
+                            (None, Some(_)) => false,
+                            (None, None) => true,
+                        };
                         let active_cursor = if next_is_fold {
                             &mut folds_cursor
                         } else {
@@ -688,15 +686,12 @@ impl FoldMap {
 
                     assert!(fold_range.start.0 >= sum.input.len);
 
-                    while folds
-                        .peek()
-                        .is_some_and(|(next_fold, next_fold_range, _)| {
-                            next_fold_range.start < fold_range.end
-                                || (next_fold_range.start == fold_range.end
-                                    && fold.placeholder.merge_adjacent
-                                    && next_fold.placeholder.merge_adjacent)
-                        })
-                    {
+                    while folds.peek().is_some_and(|(next_fold, next_fold_range, _)| {
+                        next_fold_range.start < fold_range.end
+                            || (next_fold_range.start == fold_range.end
+                                && fold.placeholder.merge_adjacent
+                                && next_fold.placeholder.merge_adjacent)
+                    }) {
                         let (_, next_fold_range, next_is_concealment) = folds.next().unwrap();
                         // A region containing a real fold is a fold.
                         is_concealment &= next_is_concealment;

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -2539,7 +2539,6 @@ impl settings::Settings for MarkdownAttachmentSettings {
     }
 }
 
-
 /// Inserts block-level markdown at the cursor, padded with blank lines so it
 /// cannot fuse with its neighbors: a following `---` would otherwise turn an
 /// inserted link line into a setext heading underline, and a preceding text
@@ -2713,8 +2712,7 @@ pub fn paste_clipboard_image(editor: &Editor, cx: &mut App) -> bool {
 
 /// `pasted-image-YYYYMMDD-HHMMSS`, local time when determinable.
 fn pasted_image_stem() -> String {
-    let now = time::OffsetDateTime::now_local()
-        .unwrap_or_else(|_| time::OffsetDateTime::now_utc());
+    let now = time::OffsetDateTime::now_local().unwrap_or_else(|_| time::OffsetDateTime::now_utc());
     format!(
         "pasted-image-{:04}{:02}{:02}-{:02}{:02}{:02}",
         now.year(),
@@ -2768,7 +2766,6 @@ fn handle_image_drop_on_markdown(
     paths: &[std::path::PathBuf],
     cx: &mut App,
 ) -> bool {
-
     let Some(buffer) = editor.buffer().read(cx).as_singleton() else {
         return false;
     };

--- a/crates/languages/src/markdown_oxide.rs
+++ b/crates/languages/src/markdown_oxide.rs
@@ -74,13 +74,8 @@ impl LspInstaller for MarkdownOxideLspAdapter {
         _: &mut AsyncApp,
     ) -> Result<GitHubLspBinaryVersion> {
         let release =
-            get_release_by_tag_name(REPOSITORY, PINNED_RELEASE_TAG, delegate.http_client())
-                .await?;
-        let asset_name = format!(
-            "{}.{}",
-            Self::asset_stem()?,
-            Self::asset_kind_extension()
-        );
+            get_release_by_tag_name(REPOSITORY, PINNED_RELEASE_TAG, delegate.http_client()).await?;
+        let asset_name = format!("{}.{}", Self::asset_stem()?, Self::asset_kind_extension());
         let asset = release
             .assets
             .iter()
@@ -260,9 +255,7 @@ mod tests {
         );
         let binary = MarkdownOxideLspAdapter::binary_in(std::path::Path::new("dir"));
         assert!(
-            binary
-                .to_string_lossy()
-                .starts_with("dir/markdown-oxide")
+            binary.to_string_lossy().starts_with("dir/markdown-oxide")
                 || binary.to_string_lossy().starts_with("dir\\markdown-oxide"),
             "{binary:?}"
         );

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -5159,7 +5159,7 @@ impl Extraction<'_> {
     /// neighbors and display-style layout cannot fit within a line.
     fn latex(&mut self, node: tree_sitter::Node) {
         let mut delimiters = Vec::new();
-        for index in 0..node.child_count() as u32 {
+        for index in 0..node.child_count() {
             let Some(child) = node.child(index) else {
                 continue;
             };
@@ -5410,7 +5410,7 @@ impl Extraction<'_> {
     fn list_item_markers(&mut self, node: tree_sitter::Node) {
         let mut list_marker = None;
         let mut task_marker = None;
-        for index in 0..node.child_count() as u32 {
+        for index in 0..node.child_count() {
             let Some(child) = node.child(index) else {
                 continue;
             };
@@ -5476,7 +5476,7 @@ impl Extraction<'_> {
                         "emphasis" => self.italic.push(range),
                         _ => self.bold.push(range),
                     }
-                    for index in 0..node.child_count() as u32 {
+                    for index in 0..node.child_count() {
                         let Some(child) = node.child(index) else {
                             continue;
                         };
@@ -5491,7 +5491,7 @@ impl Extraction<'_> {
                 }
                 "code_span" => {
                     self.code_spans.push(node.byte_range());
-                    for index in 0..node.child_count() as u32 {
+                    for index in 0..node.child_count() {
                         let Some(child) = node.child(index) else {
                             continue;
                         };
@@ -5503,7 +5503,7 @@ impl Extraction<'_> {
                 "inline_link" | "full_reference_link" | "collapsed_reference_link" => {
                     let mut open_bracket = None;
                     let mut close_bracket = None;
-                    for index in 0..node.child_count() as u32 {
+                    for index in 0..node.child_count() {
                         let Some(child) = node.child(index) else {
                             continue;
                         };
@@ -5531,13 +5531,13 @@ impl Extraction<'_> {
                     // literal text (the preview pane has the same limit). The
                     // image sits under a `link_text` node, not directly under
                     // the link.
-                    let wrapped_image = (0..node.child_count() as u32)
+                    let wrapped_image = (0..node.child_count())
                         .filter_map(|index| node.child(index))
                         .find_map(|child| {
                             if child.kind() == "image" {
                                 Some(child)
                             } else if child.kind() == "link_text" {
-                                (0..child.child_count() as u32)
+                                (0..child.child_count())
                                     .filter_map(|index| child.child(index))
                                     .find(|grandchild| grandchild.kind() == "image")
                             } else {
@@ -5583,7 +5583,7 @@ impl Extraction<'_> {
                     }
                     if self.is_alone_on_line(node) {
                         self.image_block(node);
-                    } else if let Some(description) = (0..node.child_count() as u32)
+                    } else if let Some(description) = (0..node.child_count())
                         .filter_map(|index| node.child(index))
                         .find(|child| child.kind() == "image_description")
                     {
@@ -5986,14 +5986,14 @@ impl Extraction<'_> {
     }
 
     fn image_alt(&self, image_node: tree_sitter::Node) -> Option<&str> {
-        let description = (0..image_node.child_count() as u32)
+        let description = (0..image_node.child_count())
             .filter_map(|index| image_node.child(index))
             .find(|child| child.kind() == "image_description")?;
         self.text.get(description.byte_range())
     }
 
     fn image_destination(&self, image_node: tree_sitter::Node) -> Option<String> {
-        let destination = (0..image_node.child_count() as u32)
+        let destination = (0..image_node.child_count())
             .filter_map(|index| image_node.child(index))
             .find(|child| child.kind() == "link_destination")?;
         self.text
@@ -6147,7 +6147,7 @@ fn toggle_callout(
 }
 
 fn push_children<'a>(node: tree_sitter::Node<'a>, stack: &mut Vec<tree_sitter::Node<'a>>) {
-    for index in (0..node.child_count() as u32).rev() {
+    for index in (0..node.child_count()).rev() {
         if let Some(child) = node.child(index) {
             stack.push(child);
         }
@@ -6155,7 +6155,7 @@ fn push_children<'a>(node: tree_sitter::Node<'a>, stack: &mut Vec<tree_sitter::N
 }
 
 fn heading_level(node: tree_sitter::Node) -> u32 {
-    for index in 0..node.child_count() as u32 {
+    for index in 0..node.child_count() {
         if let Some(child) = node.child(index) {
             match child.kind() {
                 "atx_h1_marker" => return 1,

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -485,7 +485,7 @@ async fn test_frontmatter_property_edit_round_trip(cx: &mut TestAppContext) {
     // "Add property" commits a `<key>: ` line before the closing delimiter
     // and hands back the key so Enter can chain into editing its value.
     let weak = editor.downgrade();
-    let add_range = frontmatter_range.clone();
+    let add_range = frontmatter_range;
     cx.update(|window, cx| start_add_property(weak, add_range, window, cx));
     let key_editor = cx.update_editor(|editor, _, _| {
         editor
@@ -703,7 +703,7 @@ async fn test_linked_image_renders_as_block(cx: &mut TestAppContext) {
                     let mut stack = vec![layer.node()];
                     while let Some(node) = stack.pop() {
                         nodes.push(format!("{} {:?}", node.kind(), node.byte_range()));
-                        for index in (0..node.child_count() as u32).rev() {
+                        for index in (0..node.child_count()).rev() {
                             if let Some(child) = node.child(index) {
                                 stack.push(child);
                             }

--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -347,7 +347,10 @@ impl Render for Onboarding {
                                     .child(
                                         h_flex()
                                             .gap_4()
-                                            .child(Vector::square(VectorName::SuzuriLogo, rems(2.5)))
+                                            .child(Vector::square(
+                                                VectorName::SuzuriLogo,
+                                                rems(2.5),
+                                            ))
                                             .child(
                                                 v_flex()
                                                     .child(

--- a/crates/pdf_viewer/src/pdf_item.rs
+++ b/crates/pdf_viewer/src/pdf_item.rs
@@ -88,10 +88,7 @@ impl ProjectItem for PdfItem {
         }
 
         let worktree = project.read(cx).worktree_for_id(path.worktree_id, cx)?;
-        let abs_path = worktree
-            .read(cx)
-            .abs_path()
-            .join(path.path.as_std_path());
+        let abs_path = worktree.read(cx).abs_path().join(path.path.as_std_path());
         let project_path = path.clone();
         let project = project.clone();
         let background = cx.background_executor().clone();

--- a/crates/pdf_viewer/src/pdf_renderer.rs
+++ b/crates/pdf_viewer/src/pdf_renderer.rs
@@ -22,7 +22,6 @@ const SAME_LINE_THRESHOLD: f32 = 0.8;
 // that position words without explicit space glyphs.
 const SPACE_DIST: f32 = 0.15;
 
-
 /// Dimensions of a single PDF page in PDF points (1/72 inch).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PageDimensions {
@@ -194,8 +193,7 @@ impl PageTextLayout {
             if index > 0 {
                 let previous = &slice[index - 1];
                 let size = previous.font_size.max(glyph.font_size).max(1.0);
-                let same_line =
-                    (glyph.y - previous.y).abs() / size < SAME_LINE_THRESHOLD;
+                let same_line = (glyph.y - previous.y).abs() / size < SAME_LINE_THRESHOLD;
 
                 if same_line {
                     // Same line — insert a synthetic space for large
@@ -304,8 +302,6 @@ pub fn render_single_page(
     })
 }
 
-
-
 #[cfg(all(test, feature = "test-bench"))]
 #[path = "pdf_renderer_bench.rs"]
 mod pdf_renderer_bench;
@@ -351,7 +347,9 @@ mod tests {
         );
 
         let obj4_offset = pdf.len();
-        pdf.extend_from_slice(format!("4 0 obj\n<< /Length {stream_length} >>\nstream\n").as_bytes());
+        pdf.extend_from_slice(
+            format!("4 0 obj\n<< /Length {stream_length} >>\nstream\n").as_bytes(),
+        );
         pdf.extend_from_slice(stream_bytes);
         pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
 
@@ -363,7 +361,13 @@ mod tests {
         let xref_offset = pdf.len();
         pdf.extend_from_slice(b"xref\n0 6\n");
         pdf.extend_from_slice(format!("{:010} 65535 f \n", 0).as_bytes());
-        for offset in [obj1_offset, obj2_offset, obj3_offset, obj4_offset, obj5_offset] {
+        for offset in [
+            obj1_offset,
+            obj2_offset,
+            obj3_offset,
+            obj4_offset,
+            obj5_offset,
+        ] {
             pdf.extend_from_slice(format!("{:010} 00000 n \n", offset).as_bytes());
         }
 
@@ -386,10 +390,7 @@ mod tests {
 
     #[test]
     fn text_extraction_multiple_lines() {
-        let pdf_bytes = build_pdf(&[
-            (72.0, 720.0, "First line"),
-            (72.0, 706.0, "Second line"),
-        ]);
+        let pdf_bytes = build_pdf(&[(72.0, 720.0, "First line"), (72.0, 706.0, "Second line")]);
         let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
         let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
 
@@ -474,10 +475,7 @@ mod tests {
     fn untagged_pdf_joins_lines() {
         // Without structure tags, different lines are joined with spaces
         // regardless of gap size (no heuristic paragraph detection).
-        let pdf_bytes = build_pdf(&[
-            (72.0, 720.0, "Heading"),
-            (72.0, 690.0, "Body text"),
-        ]);
+        let pdf_bytes = build_pdf(&[(72.0, 720.0, "Heading"), (72.0, 690.0, "Body text")]);
         let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
         let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
 
@@ -500,6 +498,4 @@ mod tests {
         let index = layout.glyph_index_at_point(hit_x, hit_y);
         assert_eq!(index, Some(1), "Expected to hit glyph 'B' at index 1");
     }
-
-
 }

--- a/crates/pdf_viewer/src/pdf_renderer_bench.rs
+++ b/crates/pdf_viewer/src/pdf_renderer_bench.rs
@@ -4,8 +4,7 @@ use std::time::Instant;
 
 #[test]
 fn dump_real_pdf_glyphs() {
-    let pdf_path =
-        std::env::var("PDF_DUMP_PATH").expect("set PDF_DUMP_PATH to a PDF file path");
+    let pdf_path = std::env::var("PDF_DUMP_PATH").expect("set PDF_DUMP_PATH to a PDF file path");
     let pdf_bytes = std::fs::read(&pdf_path).expect("Failed to read PDF file");
     let pdf = open_pdf(&pdf_bytes).expect("Failed to open PDF");
     let layout = extract_page_text(&pdf, 0).expect("Failed to extract text");
@@ -48,8 +47,7 @@ fn dump_real_pdf_glyphs() {
 
 #[test]
 fn bench_render_phases() {
-    let pdf_path =
-        std::env::var("PDF_BENCH_PATH").expect("set PDF_BENCH_PATH to a PDF file path");
+    let pdf_path = std::env::var("PDF_BENCH_PATH").expect("set PDF_BENCH_PATH to a PDF file path");
     let scale = std::env::var("PDF_BENCH_SCALE")
         .ok()
         .and_then(|s| s.parse::<f32>().ok())

--- a/crates/pdf_viewer/src/pdf_viewer.rs
+++ b/crates/pdf_viewer/src/pdf_viewer.rs
@@ -26,17 +26,16 @@ use std::time::Duration;
 
 use file_icons::FileIcons;
 use gpui::{
-    actions, div, img, point, px, AnyElement, App, Context, CursorStyle, Entity,
-    EventEmitter, FocusHandle, Focusable, Font, IntoElement, MouseButton,
-    ParentElement, Pixels, Point, RenderImage, Render, ScrollDelta,
-    ScrollHandle, ScrollWheelEvent, SharedString, Styled, Task, Window,
+    AnyElement, App, Context, CursorStyle, Entity, EventEmitter, FocusHandle, Focusable, Font,
+    IntoElement, MouseButton, ParentElement, Pixels, Point, Render, RenderImage, ScrollDelta,
+    ScrollHandle, ScrollWheelEvent, SharedString, Styled, Task, Window, actions, div, img, point,
+    px,
 };
 use project::Project;
-use ui::prelude::*;
 use ui::WithScrollbar;
+use ui::prelude::*;
 use workspace::{
-    Pane, ToolbarItemLocation,
-    WorkspaceId,
+    Pane, ToolbarItemLocation, WorkspaceId,
     invalid_item_view::InvalidItemView,
     item::{HighlightedText, Item, ProjectItem, TabContentParams},
 };
@@ -156,11 +155,12 @@ impl PdfViewer {
         // Live-preview loop: the item reloads itself when the file changes
         // on disk (e.g. a Typst/LaTeX recompile); rebuild rendering state
         // but keep zoom and scroll so the document doesn't jump.
-        cx.subscribe(pdf_item, |this, _, event: &pdf_item::PdfItemEvent, cx| {
-            match event {
+        cx.subscribe(
+            pdf_item,
+            |this, _, event: &pdf_item::PdfItemEvent, cx| match event {
                 pdf_item::PdfItemEvent::Reloaded => this.reload_document(cx),
-            }
-        })
+            },
+        )
         .detach();
         // Free the sprite-atlas tiles of every page still displayed when the
         // tab closes. Dropping the view frees the CPU bitmaps, but a
@@ -493,9 +493,7 @@ impl PdfViewer {
                 let pdf = match pdf_renderer::open_pdf(&pdf_bytes) {
                     Ok(pdf) => pdf,
                     Err(error) => {
-                        log::error!(
-                            "pdf_viewer: failed to open PDF for rendering: {error:#}"
-                        );
+                        log::error!("pdf_viewer: failed to open PDF for rendering: {error:#}");
                         return;
                     }
                 };
@@ -505,12 +503,7 @@ impl PdfViewer {
                         break;
                     }
                     log::debug!("pdf_viewer: rendering page {}...", page_index + 1);
-                    match pdf_renderer::render_single_page(
-                        &pdf,
-                        page_index,
-                        render_scale,
-                        WHITE,
-                    ) {
+                    match pdf_renderer::render_single_page(&pdf, page_index, render_scale, WHITE) {
                         Ok(rendered) => {
                             log::debug!(
                                 "pdf_viewer: page {} rendered ({}x{})",
@@ -627,10 +620,8 @@ impl PdfViewer {
                 let bounds = self.scroll_handle.bounds();
                 let offset = self.scroll_handle.offset();
 
-                let cursor_in_container = point(
-                    cursor.x - bounds.origin.x,
-                    cursor.y - bounds.origin.y,
-                );
+                let cursor_in_container =
+                    point(cursor.x - bounds.origin.x, cursor.y - bounds.origin.y);
 
                 let content_x = cursor_in_container.x - offset.x;
                 let content_y = cursor_in_container.y - offset.y;
@@ -746,10 +737,7 @@ impl Render for PdfViewer {
             let container_width = if container_width > 0.0 {
                 container_width
             } else {
-                dimensions
-                    .iter()
-                    .map(|d| d.width)
-                    .fold(0.0_f32, f32::max)
+                dimensions.iter().map(|d| d.width).fold(0.0_f32, f32::max)
             };
 
             // When all pages fit inside the viewport, centre them vertically
@@ -850,15 +838,9 @@ impl Render for PdfViewer {
                     .overflow_y_scroll()
                     .track_scroll(&self.scroll_handle)
                     .on_scroll_wheel(cx.listener(Self::handle_scroll_wheel))
-                    .on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(Self::handle_mouse_down),
-                    )
+                    .on_mouse_down(MouseButton::Left, cx.listener(Self::handle_mouse_down))
                     .on_mouse_move(cx.listener(Self::handle_mouse_move))
-                    .on_mouse_up(
-                        MouseButton::Left,
-                        cx.listener(Self::handle_mouse_up),
-                    )
+                    .on_mouse_up(MouseButton::Left, cx.listener(Self::handle_mouse_up))
                     .cursor(CursorStyle::IBeam)
                     .child(content)
                     .vertical_scrollbar_for(&self.scroll_handle, window, cx),

--- a/crates/pdf_viewer/src/selection.rs
+++ b/crates/pdf_viewer/src/selection.rs
@@ -1,10 +1,10 @@
 use gpui::{
-    div, px, AnyElement, ClipboardItem, Context, IntoElement, MouseButton, MouseDownEvent,
-    MouseMoveEvent, MouseUpEvent, Pixels, Point, Styled, Window,
+    AnyElement, ClipboardItem, Context, IntoElement, MouseButton, MouseDownEvent, MouseMoveEvent,
+    MouseUpEvent, Pixels, Point, Styled, Window, div, px,
 };
 
 use super::pdf_renderer;
-use super::{CopyDocumentText, PdfViewer, TextPosition, PAGE_GAP_PX};
+use super::{CopyDocumentText, PAGE_GAP_PX, PdfViewer, TextPosition};
 
 impl PdfViewer {
     pub(crate) fn extract_all_text(&mut self, cx: &mut Context<Self>) {
@@ -29,7 +29,8 @@ impl PdfViewer {
 
         let pdf_bytes = self.pdf_item.read(cx).pdf_bytes().clone();
 
-        let (sender, receiver) = smol::channel::unbounded::<(usize, pdf_renderer::PageTextLayout)>();
+        let (sender, receiver) =
+            smol::channel::unbounded::<(usize, pdf_renderer::PageTextLayout)>();
 
         if let Err(error) = std::thread::Builder::new()
             .name("pdf-text-extractor".into())
@@ -178,7 +179,9 @@ impl PdfViewer {
 
         let container_width: f32 = {
             let w: f32 = bounds.size.width.into();
-            if w > 0.0 { w } else {
+            if w > 0.0 {
+                w
+            } else {
                 log::debug!("pdf_viewer: hit test — container_width=0");
                 return None;
             }
@@ -210,13 +213,17 @@ impl PdfViewer {
              scroll_y={:.0} content_y={:.0} centering_pad={:.0} content_y_adjusted={:.0} \
              container_width={:.0} viewport_height={:.0} total_content_h={:.0} \
              text_layouts_count={} zoom={:.2}",
-            window_x, window_y,
-            bounds_origin_x, bounds_origin_y,
+            window_x,
+            window_y,
+            bounds_origin_x,
+            bounds_origin_y,
             scroll_offset_y,
             content_y,
             centering_pad,
             content_y_adjusted,
-            container_width, viewport_height, total_content_h,
+            container_width,
+            viewport_height,
+            total_content_h,
             self.text_layouts.len(),
             self.zoom_level,
         );
@@ -244,7 +251,8 @@ impl PdfViewer {
             if content_y_adjusted < accumulated_y {
                 log::debug!(
                     "pdf_viewer: hit test — in gap between pages {} and {}",
-                    index + 1, index + 2
+                    index + 1,
+                    index + 2
                 );
                 return None;
             }
@@ -276,17 +284,22 @@ impl PdfViewer {
             "pdf_viewer: hit test — page {} (dim={:.0}x{:.0}) fit_scale={:.3} scale={:.3} \
              page_display_width={:.0} page_left={:.0} pan_x={:.0} content_x={:.0} page_local_y={:.0}",
             page_index + 1,
-            page_dim.width, page_dim.height,
-            fit_scale, scale,
-            page_display_width, page_left_in_container,
+            page_dim.width,
+            page_dim.height,
+            fit_scale,
+            scale,
+            page_display_width,
+            page_left_in_container,
             pan_x_f32,
-            content_x, page_local_y,
+            content_x,
+            page_local_y,
         );
 
         if content_x < 0.0 || content_x > page_display_width {
             log::debug!(
                 "pdf_viewer: hit test — outside page horizontally (content_x={:.0}, page_width={:.0})",
-                content_x, page_display_width
+                content_x,
+                page_display_width
             );
             return None;
         }
@@ -296,7 +309,8 @@ impl PdfViewer {
 
         log::debug!(
             "pdf_viewer: hit test — pdf coords ({:.1}, {:.1})",
-            pdf_x, pdf_y
+            pdf_x,
+            pdf_y
         );
 
         let layout = match self.text_layouts.get(&page_index) {
@@ -322,7 +336,12 @@ impl PdfViewer {
                 if let Some(glyph) = layout.glyphs.get(idx) {
                     log::debug!(
                         "pdf_viewer: hit test — matched glyph {} '{}' at ({:.1},{:.1}) w={:.1} fs={:.1}",
-                        idx, glyph.character, glyph.x, glyph.y, glyph.width, glyph.font_size
+                        idx,
+                        glyph.character,
+                        glyph.x,
+                        glyph.y,
+                        glyph.width,
+                        glyph.font_size
                     );
                 }
                 idx
@@ -486,9 +505,12 @@ impl PdfViewer {
                     log::debug!(
                         "pdf_viewer: first highlight glyph '{}' — pdf({:.1},{:.1}) display({:.0},{:.0}) size({:.0}x{:.0})",
                         glyph.character,
-                        glyph.x, glyph.y,
-                        display_x, display_y,
-                        display_width, display_height,
+                        glyph.x,
+                        glyph.y,
+                        display_x,
+                        display_y,
+                        display_width,
+                        display_height,
                     );
                 }
 

--- a/crates/pdf_viewer/src/toolbar.rs
+++ b/crates/pdf_viewer/src/toolbar.rs
@@ -3,9 +3,7 @@ use ui::prelude::*;
 use ui::{IconButton, IconName, IconSize, Tooltip};
 use workspace::{ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, item::ItemHandle};
 
-use super::{
-    CopyDocumentText, FitToView, PdfViewer, ResetZoom, ZoomIn, ZoomOut,
-};
+use super::{CopyDocumentText, FitToView, PdfViewer, ResetZoom, ZoomIn, ZoomOut};
 
 pub struct PdfViewToolbarControls {
     pdf_view: Option<WeakEntity<PdfViewer>>,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1920,10 +1920,7 @@ impl ProjectPanel {
                 cx.spawn_in(window, async move |_, cx| {
                     if open.await.log_err().is_some() {
                         cx.update(|window, cx| {
-                            window.dispatch_action(
-                                Box::new(typeset_preview::OpenLivePreview),
-                                cx,
-                            );
+                            window.dispatch_action(Box::new(typeset_preview::OpenLivePreview), cx);
                         })
                         .ok();
                     }

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -3,9 +3,8 @@ use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockSide, IntoGpui, ProjectPanelEntrySpacing, ProjectPanelSortDirection,
-    ProjectPanelSortMode, ProjectPanelSortOrder, RegisterSetting, Settings, ShowDiagnostics,
-    ShowIndentGuides,
+    DockSide, IntoGpui, ProjectPanelEntrySpacing, ProjectPanelSortDirection, ProjectPanelSortMode,
+    ProjectPanelSortOrder, RegisterSetting, Settings, ShowDiagnostics, ShowIndentGuides,
 };
 use ui::scrollbars::{ScrollbarVisibility, ShowScrollbar};
 

--- a/crates/typeset_preview/src/typeset_preview.rs
+++ b/crates/typeset_preview/src/typeset_preview.rs
@@ -65,7 +65,6 @@ fn typesetter_for(path: &Path) -> Option<Typesetter> {
     }
 }
 
-
 pub fn init(cx: &mut App) {
     cx.set_global(LiveCompileRegistry::default());
 
@@ -232,11 +231,7 @@ fn open_pdf_in_split(
         return;
     }
 
-    let Some(project_path) = workspace
-        .project()
-        .read(cx)
-        .find_project_path(output, cx)
-    else {
+    let Some(project_path) = workspace.project().read(cx).find_project_path(output, cx) else {
         show_toast(
             workspace,
             "Compiled PDF is outside the project, open it manually.",
@@ -276,7 +271,9 @@ fn compile(path: PathBuf, workspace: Option<Entity<Workspace>>, cx: &mut Context
             })
             .await;
         cx.update(|cx| {
-            cx.global_mut::<LiveCompileRegistry>().in_flight.remove(&path);
+            cx.global_mut::<LiveCompileRegistry>()
+                .in_flight
+                .remove(&path);
             if let Some(workspace) = workspace {
                 workspace.update(cx, |workspace, cx| match &result {
                     Ok(()) => dismiss_toast(workspace, cx),
@@ -354,17 +351,13 @@ fn typst_asset_stem() -> Result<String> {
 /// "Downloading …" before the user waits on it.
 fn pending_download_name(path: &Path) -> Option<&'static str> {
     match typesetter_for(path)? {
-        Typesetter::Typst => {
-            (which::which("typst").is_err()
-                && !provisioned_binary("typst").ok()?.exists())
-            .then_some("the Typst compiler")
-        }
-        Typesetter::Latex => {
-            (which::which("tectonic").is_err()
-                && which::which("latexmk").is_err()
-                && !provisioned_binary("tectonic").ok()?.exists())
-            .then_some("the Tectonic LaTeX compiler")
-        }
+        Typesetter::Typst => (which::which("typst").is_err()
+            && !provisioned_binary("typst").ok()?.exists())
+        .then_some("the Typst compiler"),
+        Typesetter::Latex => (which::which("tectonic").is_err()
+            && which::which("latexmk").is_err()
+            && !provisioned_binary("tectonic").ok()?.exists())
+        .then_some("the Tectonic LaTeX compiler"),
         // Browsers are never downloaded on the user's behalf.
         Typesetter::Html => None,
     }
@@ -459,8 +452,7 @@ async fn ensure_typst(http: std::sync::Arc<dyn http_client::HttpClient>) -> Resu
         // doesn't handle; fetch and hand it to the system tar, which
         // decompresses xz natively on macOS and Linux.
         let asset_name = format!("typst-{arch}-{os}.tar.xz");
-        let (url, digest) =
-            release_asset(&http, TYPST_REPOSITORY, TYPST_TAG, &asset_name).await?;
+        let (url, digest) = release_asset(&http, TYPST_REPOSITORY, TYPST_TAG, &asset_name).await?;
         let bytes = fetch_verified(&http, &url, digest.as_deref()).await?;
         std::fs::create_dir_all(&destination)
             .with_context(|| format!("creating {destination:?}"))?;
@@ -503,8 +495,15 @@ async fn ensure_tectonic(http: std::sync::Arc<dyn http_client::HttpClient>) -> R
             http_client::github::AssetKind::TarGz,
         )
     };
-    download_release_archive(&http, TECTONIC_REPOSITORY, TECTONIC_TAG, &asset_name, &destination, kind)
-        .await?;
+    download_release_archive(
+        &http,
+        TECTONIC_REPOSITORY,
+        TECTONIC_TAG,
+        &asset_name,
+        &destination,
+        kind,
+    )
+    .await?;
     anyhow::ensure!(
         binary.exists(),
         "downloaded tectonic archive did not contain {binary:?}"
@@ -528,9 +527,10 @@ async fn release_asset(
         .with_context(|| format!("no release asset named {asset_name:?}"))?;
     // The GitHub API returns digests as `sha256:<hex>`; the comparison side
     // wants bare hex.
-    let digest = asset.digest.as_deref().map(|digest| {
-        digest.strip_prefix("sha256:").unwrap_or(digest).to_string()
-    });
+    let digest = asset
+        .digest
+        .as_deref()
+        .map(|digest| digest.strip_prefix("sha256:").unwrap_or(digest).to_string());
     Ok((asset.browser_download_url.clone(), digest))
 }
 
@@ -641,7 +641,12 @@ fn run_until_artifact(command: CompileCommand, artifact: PathBuf) -> Result<()> 
             // Two equal readings mean the write has settled.
             Some(size) if size > 0 && last_size == Some(size) => break Ok(()),
             Some(size) => last_size = Some(size),
-            None if exited => break Err(anyhow::anyhow!("{} wrote no output", command.program.display())),
+            None if exited => {
+                break Err(anyhow::anyhow!(
+                    "{} wrote no output",
+                    command.program.display()
+                ));
+            }
             None => {}
         }
         if started.elapsed() > Duration::from_secs(60) {

--- a/crates/typeset_preview/src/typeset_preview.rs
+++ b/crates/typeset_preview/src/typeset_preview.rs
@@ -177,13 +177,10 @@ pub fn open_live_preview_for_editor(
         );
     }
     let http = cx.http_client();
-    let task = {
-        let path = path.clone();
-        cx.background_spawn(async move {
-            let command = compile_command(&path, http).await?;
-            run_compile(command).await
-        })
-    };
+    let task = cx.background_spawn(async move {
+        let command = compile_command(&path, http).await?;
+        run_compile(command).await
+    });
     cx.spawn_in(window, async move |workspace, cx| {
         let result = task.await;
         match result {
@@ -459,13 +456,12 @@ async fn ensure_typst(http: std::sync::Arc<dyn http_client::HttpClient>) -> Resu
         let archive_path = destination.join(&asset_name);
         std::fs::write(&archive_path, &bytes)
             .with_context(|| format!("writing {archive_path:?}"))?;
-        let status = util::command::new_std_command("tar")
-            .args(["-xf"])
+        let mut tar = util::command::new_command("tar");
+        tar.args(["-xf"])
             .arg(&archive_path)
             .arg("-C")
-            .arg(&destination)
-            .status()
-            .context("running tar")?;
+            .arg(&destination);
+        let status = tar.status().await.context("running tar")?;
         std::fs::remove_file(&archive_path).ok();
         anyhow::ensure!(status.success(), "extracting {asset_name} failed");
     }
@@ -594,10 +590,13 @@ async fn run_compile(command: CompileCommand) -> Result<()> {
     if let Some(artifact) = command.artifact.clone() {
         return run_until_artifact(command, artifact);
     }
-    let output = util::command::new_std_command(&command.program)
+    let mut compiler = util::command::new_command(&command.program);
+    compiler
         .args(&command.arguments)
-        .current_dir(&command.working_directory)
+        .current_dir(&command.working_directory);
+    let output = compiler
         .output()
+        .await
         .with_context(|| format!("running {}", command.program.display()))?;
     if output.status.success() {
         Ok(())
@@ -614,6 +613,10 @@ async fn run_compile(command: CompileCommand) -> Result<()> {
 /// Runs a program that writes `artifact` and may never exit, giving up after
 /// a minute. The artifact counts as finished once it is newer than the run
 /// and its size has stopped changing.
+#[allow(
+    clippy::disallowed_methods,
+    reason = "the loop below polls the child synchronously; converting it needs an async timer"
+)]
 fn run_until_artifact(command: CompileCommand, artifact: PathBuf) -> Result<()> {
     use std::time::{Duration, Instant};
 

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1649,7 +1649,15 @@ mod tests {
             (RelPath::from_unix_str("Carrot").unwrap(), false),
             (RelPath::from_unix_str("aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         // Case-insensitive: aardvark < Apple < banana < Carrot < zebra
         assert_eq!(
             paths,
@@ -1673,8 +1681,15 @@ mod tests {
             (RelPath::from_unix_str("Carrot").unwrap(), false),
             (RelPath::from_unix_str("aardvark.txt").unwrap(), true),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         // Files first (case-insensitive), then directories (case-insensitive)
         assert_eq!(
             paths,
@@ -1698,8 +1713,15 @@ mod tests {
             (RelPath::from_unix_str("carrot").unwrap(), false),
             (RelPath::from_unix_str("Aardvark.txt").unwrap(), true),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1722,8 +1744,15 @@ mod tests {
             (RelPath::from_unix_str("dir10").unwrap(), false),
             (RelPath::from_unix_str("file1.txt").unwrap(), true),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1744,7 +1773,15 @@ mod tests {
             (RelPath::from_unix_str("readme.txt").unwrap(), true),
             (RelPath::from_unix_str("ReadMe.rs").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         // All "readme" variants should group together, sorted by extension
         assert_eq!(
             paths,
@@ -1765,7 +1802,15 @@ mod tests {
             (RelPath::from_unix_str("file1.txt").unwrap(), true),
             (RelPath::from_unix_str("dir2").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         // Case-insensitive: dir1, dir2, file1, file2 (all mixed)
         assert_eq!(
             paths,
@@ -1784,7 +1829,15 @@ mod tests {
             (RelPath::from_unix_str("Hello.txt").unwrap(), true),
             (RelPath::from_unix_str("hello").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1797,7 +1850,15 @@ mod tests {
             (RelPath::from_unix_str("hello").unwrap(), false),
             (RelPath::from_unix_str("Hello.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1816,7 +1877,15 @@ mod tests {
             (RelPath::from_unix_str("src").unwrap(), false),
             (RelPath::from_unix_str("target").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1837,8 +1906,15 @@ mod tests {
             (RelPath::from_unix_str("src").unwrap(), false),
             (RelPath::from_unix_str("tests").unwrap(), false),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1859,7 +1935,15 @@ mod tests {
             (RelPath::from_unix_str(".github").unwrap(), false),
             (RelPath::from_unix_str("src").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1880,8 +1964,15 @@ mod tests {
             (RelPath::from_unix_str(".github").unwrap(), false),
             (RelPath::from_unix_str("src").unwrap(), false),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1901,7 +1992,15 @@ mod tests {
             (RelPath::from_unix_str("file.md").unwrap(), true),
             (RelPath::from_unix_str("file.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1920,8 +2019,15 @@ mod tests {
             (RelPath::from_unix_str("main.c").unwrap(), true),
             (RelPath::from_unix_str("main").unwrap(), false),
         ];
-        paths
-            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::FilesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -1941,7 +2047,15 @@ mod tests {
             (RelPath::from_unix_str("a.txt").unwrap(), true),
             (RelPath::from_unix_str("A.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default, SortDirection::Ascending));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::Mixed,
+                SortOrder::Default,
+                SortDirection::Ascending,
+            )
+        });
         assert_eq!(
             paths,
             vec![
@@ -3328,24 +3442,48 @@ mod sort_direction_tests {
         let file = (rel_path("notes.txt"), true);
         // Ascending baseline.
         assert_eq!(
-            compare_rel_paths_by(a, b, SortMode::DirectoriesFirst, SortOrder::Default, SortDirection::Ascending),
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::DirectoriesFirst,
+                SortOrder::Default,
+                SortDirection::Ascending
+            ),
             Ordering::Less
         );
         // Descending flips sibling names.
         assert_eq!(
-            compare_rel_paths_by(a, b, SortMode::DirectoriesFirst, SortOrder::Default, SortDirection::Descending),
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::DirectoriesFirst,
+                SortOrder::Default,
+                SortDirection::Descending
+            ),
             Ordering::Greater
         );
         // Grouping unaffected: dirs still before files in DirectoriesFirst.
         assert_eq!(
-            compare_rel_paths_by(b, file, SortMode::DirectoriesFirst, SortOrder::Default, SortDirection::Descending),
+            compare_rel_paths_by(
+                b,
+                file,
+                SortMode::DirectoriesFirst,
+                SortOrder::Default,
+                SortDirection::Descending
+            ),
             Ordering::Less
         );
         // Parents still precede their children.
         let parent = (rel_path("a"), false);
         let child = (rel_path("a/b"), true);
         assert_eq!(
-            compare_rel_paths_by(parent, child, SortMode::DirectoriesFirst, SortOrder::Default, SortDirection::Descending),
+            compare_rel_paths_by(
+                parent,
+                child,
+                SortMode::DirectoriesFirst,
+                SortOrder::Default,
+                SortDirection::Descending
+            ),
             Ordering::Less
         );
     }


### PR DESCRIPTION
Closes #23.

`main` failed both style gates `CLAUDE.md` tells contributors to run. Everything below is fork-owned code -- running `rustfmt` over `upstream/main`'s copies of every shared file this touches produces no diff at all, and all the clippy lints are in `markdown_live_preview` and `typeset_preview`.

### 1. `cargo fmt --all -- --check` -- 75 hunks, 15 files

I blamed all 193 lines rustfmt rewrites: 186 are fork commits, 6 are upstream `sort_order` tests that the fork's own `SortDirection` parameter pushed past 100 columns, and 1 is a `display_map.rs` import list being re-sorted to absorb the fork's `Concealment` export.

So this adds **no new merge-conflict surface**, contrary to what the issue assumed: every reformatted line is already a fork delta.

The issue also guessed `cfbf6ebe96` (the nix/treefmt commit that added `rustfmt.toml`) might be implicated. It is not -- `crates/util/src/paths.rs` still produces 20 hunks under `style_edition = 2015`. These are plain overlong lines that fail under any style edition.

### 2. `markdown_live_preview` -- 13 `unnecessary_cast`, 1 `redundant_clone`

Upstream drift, not bad code. `Node::child_count()` returned `usize` in tree-sitter 0.26, so `as u32` was required when this was written; upstream `2040e0de59` (#62784) moved the pin to 0.27.0 where it returns `u32`. Nothing conflicted and nothing failed to compile -- exactly the silent drift `CLAUDE.md` warns about.

The remaining `as u32` casts in the crate are genuine and were left alone: `start_position().row` is `usize`, the image drag width is a float.

### 3. `typeset_preview` -- 6 `disallowed_methods`, 1 `redundant_clone` (not in the issue)

The issue reported "1 error + 13 warnings" because `--deny warnings` aborts at the first failing crate, so its run never reached `typeset_preview`. Upstream `c69912c76a` (#38894) banned blocking `std::process::Command` after this crate was written.

`ensure_typst` and `run_compile` are already `async` on the background executor, so they move to `util::command::new_command`, whose `status()`/`output()` are futures and which applies the same `CREATE_NO_WINDOW` Windows flag -- behavior unchanged apart from no longer blocking a pool thread.

`run_until_artifact` keeps its synchronous poll loop behind a documented `allow`. Converting it means replacing `thread::sleep` with a timer, which is a change to timing-sensitive artifact-settling logic rather than a lint fix. **Worth a follow-up.**

## Why CI never caught this

The inherited `run_tests.yml` gates on `github.repository_owner == 'zed-industries'` (lines 21/143/921), so it skips on this fork -- run `33116395048` on `92d7e1d5c6` is `skipped`. `suzuri-release.yml` has no style step.

## Verification

- `cargo clippy --workspace --release --all-targets --all-features -- --deny warnings` -- zero errors
- `cargo fmt --all -- --check` -- clean
- `./script/check-todos`, `./script/check-keymaps` -- pass
- `cargo nextest run -p markdown_live_preview -p pdf_viewer -p typeset_preview -p util -p languages` -- 311/311
- `cargo nextest run -p editor -p project_panel` -- 1059/1060; the one failure is `undo_create_dirty_file`, which I confirmed pre-existing by reverting `crates/project_panel/` to `92d7e1d5c6` and reproducing it

Release Notes:

- N/A