### PR TITLE
script: Add suzuri-agent-log, an opt-in archiver for agent transcripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "authoring_ledger"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "editor",
+ "gpui",
+ "language",
+ "log",
+ "parking_lot",
+ "project",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "text",
+ "util",
+ "uuid",
+]
+
+[[package]]
 name = "auto_update"
 version = "0.1.0"
 dependencies = [
@@ -23226,6 +23247,7 @@ dependencies = [
  "askpass",
  "assets",
  "audio",
+ "authoring_ledger",
  "auto_update",
  "auto_update_ui",
  "breadcrumbs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/askpass",
     "crates/assets",
     "crates/audio",
+    "crates/authoring_ledger",
     "crates/auto_update",
     "crates/auto_update_helper",
     "crates/auto_update_ui",
@@ -293,6 +294,7 @@ anthropic = { path = "crates/anthropic" }
 askpass = { path = "crates/askpass" }
 assets = { path = "crates/assets" }
 audio = { path = "crates/audio" }
+authoring_ledger = { path = "crates/authoring_ledger" }
 auto_update = { path = "crates/auto_update" }
 auto_update_ui = { path = "crates/auto_update_ui" }
 aws_http_client = { path = "crates/aws_http_client" }

--- a/crates/authoring_ledger/Cargo.toml
+++ b/crates/authoring_ledger/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "authoring_ledger"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/authoring_ledger.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+chrono.workspace = true
+editor.workspace = true
+gpui.workspace = true
+language.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+project.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+text.workspace = true
+util.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/authoring_ledger/src/authoring_ledger.rs
+++ b/crates/authoring_ledger/src/authoring_ledger.rs
@@ -1,0 +1,528 @@
+//! Records how a document was actually written.
+//!
+//! Claude Code already writes a complete record of what an *agent* did, which
+//! `script/suzuri-agent-log.py` archives into the project. This crate records the
+//! other half — what happened inside the editor — because two things are
+//! invisible from outside it:
+//!
+//!   * A human edit leaves no event anywhere. Only the final text survives, so
+//!     after the fact there is no way to know an edit happened, in what order, or
+//!     whether it was typed or pasted.
+//!   * An agent that writes a file by any means other than the Write/Edit tools
+//!     — a `cat > file <<EOF` heredoc, `sed -i`, a formatter — fires no tool hook
+//!     and leaves no checkpoint. The editor still sees the file change.
+//!
+//! Records are JSONL in the same envelope Claude Code uses (`type`, `uuid`,
+//! `parentUuid`, `timestamp`, `sessionId`, `cwd`, `gitBranch`), so the two
+//! streams parse with one reader and merge on timestamp into a single timeline
+//! of human and agent activity.
+//!
+//! What is deliberately *not* recorded is the text itself. A record carries
+//! offsets, lengths, and timing; the content already lives in the file. Pasted
+//! text is reduced to a length and a hash, which is enough to later match it
+//! against an archived agent transcript without either side storing prose.
+//!
+//! Recording is opt-in per project and off by default: it begins only when
+//! `<project>/.suzuri/editor-log/enabled` exists.
+
+use std::{
+    collections::HashMap,
+    fs::{File, OpenOptions},
+    io::Write as _,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::{Context as _, Result};
+use chrono::{SecondsFormat, Utc};
+use editor::{Editor, EditorEvent};
+use gpui::{App, Context, Entity, Global, Window};
+use language::{Buffer, BufferEvent};
+use parking_lot::Mutex;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+/// Marker file that turns recording on for a project.
+const ENABLED_MARKER: &str = "enabled";
+const LEDGER_DIR: &[&str] = &[".suzuri", "editor-log"];
+/// How far up the tree to look for the marker before giving up.
+const MAX_ROOT_SEARCH_DEPTH: usize = 64;
+
+pub fn init(cx: &mut App) {
+    cx.set_global(GlobalLedger::default());
+    cx.observe_new(register_editor).detach();
+}
+
+// ---------------------------------------------------------------------------
+// records
+
+/// One line of the ledger.
+///
+/// Field names match Claude Code's transcript records so both streams can be
+/// read by the same parser. `payload` carries the per-type detail.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Record {
+    pub r#type: &'static str,
+    pub uuid: String,
+    pub parent_uuid: Option<String>,
+    /// UTC, RFC 3339, millisecond precision - the format Claude Code writes.
+    pub timestamp: String,
+    pub session_id: String,
+    pub cwd: String,
+    pub version: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    pub payload: serde_json::Value,
+}
+
+/// Where an edit came from.
+///
+/// `Typed` and `Pasted` are both local user input; they are separated because
+/// that distinction is the whole point of recording, and it is the one thing a
+/// file-level diff can never recover.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EditSource {
+    Typed,
+    Pasted,
+    /// An in-editor agent (Zed's own agent panel).
+    Agent,
+    /// The file changed on disk and the editor did not do it - an external
+    /// agent, a formatter, another process.
+    External,
+    /// A collaborator over the network.
+    Remote,
+    Undo,
+    Unknown,
+}
+
+pub const VERSION: &str = concat!("authoring_ledger/", env!("CARGO_PKG_VERSION"));
+
+fn now_iso() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn hash_text(text: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+// ---------------------------------------------------------------------------
+// opt-in and paths
+
+fn ledger_dir(root: &Path) -> PathBuf {
+    let mut path = root.to_path_buf();
+    for part in LEDGER_DIR {
+        path.push(part);
+    }
+    path
+}
+
+/// Walk up from `start` looking for a project whose ledger is switched on.
+///
+/// Returns the project root, not the ledger directory, because the root is what
+/// identifies the project in the record and what the agent-log archive keys on.
+pub fn enabled_root_for(start: &Path) -> Option<PathBuf> {
+    let mut current = if start.is_dir() {
+        Some(start)
+    } else {
+        start.parent()
+    };
+    for _ in 0..MAX_ROOT_SEARCH_DEPTH {
+        let dir = current?;
+        if ledger_dir(dir).join(ENABLED_MARKER).exists() {
+            return Some(dir.to_path_buf());
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// writer
+
+/// Append-only JSONL writer for one project's session.
+pub struct SessionWriter {
+    session_id: String,
+    root: PathBuf,
+    file: File,
+    last_uuid: Option<String>,
+}
+
+impl SessionWriter {
+    pub fn open(root: &Path) -> Result<Self> {
+        let session_id = Uuid::new_v4().to_string();
+        let sessions = ledger_dir(root).join("sessions");
+        std::fs::create_dir_all(&sessions)
+            .with_context(|| format!("creating {}", sessions.display()))?;
+        let path = sessions.join(format!("{session_id}.jsonl"));
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("opening {}", path.display()))?;
+        Ok(Self {
+            session_id,
+            root: root.to_path_buf(),
+            file,
+            last_uuid: None,
+        })
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Append one record. Records are chained by `parentUuid` in write order,
+    /// which is what lets a reader reconstruct the sequence even though
+    /// timestamps from interleaved sources are not globally monotonic.
+    pub fn write(
+        &mut self,
+        kind: &'static str,
+        file: Option<String>,
+        payload: serde_json::Value,
+    ) -> Result<()> {
+        let uuid = Uuid::new_v4().to_string();
+        let record = Record {
+            r#type: kind,
+            uuid: uuid.clone(),
+            parent_uuid: self.last_uuid.clone(),
+            timestamp: now_iso(),
+            session_id: self.session_id.clone(),
+            cwd: self.root.to_string_lossy().into_owned(),
+            version: VERSION,
+            file,
+            payload,
+        };
+        let line = serde_json::to_string(&record)?;
+        self.file.write_all(line.as_bytes())?;
+        self.file.write_all(b"\n")?;
+        self.file.flush()?;
+        self.last_uuid = Some(uuid);
+        Ok(())
+    }
+}
+
+/// One writer per project root, shared by every editor open on that project.
+#[derive(Default)]
+pub struct GlobalLedger {
+    writers: Arc<Mutex<HashMap<PathBuf, Option<SessionWriter>>>>,
+}
+
+impl Global for GlobalLedger {}
+
+impl GlobalLedger {
+    /// Run `f` against the writer for `root`, opening one on first use.
+    ///
+    /// A project whose writer failed to open is remembered as `None` so a broken
+    /// path does not retry on every keystroke.
+    fn with_writer(&self, root: &Path, f: impl FnOnce(&mut SessionWriter) -> Result<()>) {
+        let mut writers = self.writers.lock();
+        let entry = writers
+            .entry(root.to_path_buf())
+            .or_insert_with(|| match SessionWriter::open(root) {
+                Ok(mut writer) => {
+                    let payload = serde_json::json!({ "root": root.to_string_lossy() });
+                    if let Err(error) = writer.write("session_start", None, payload) {
+                        log::error!("authoring_ledger: session_start failed: {error:#}");
+                    }
+                    Some(writer)
+                }
+                Err(error) => {
+                    log::error!("authoring_ledger: disabled for this project: {error:#}");
+                    None
+                }
+            });
+        if let Some(writer) = entry.as_mut()
+            && let Err(error) = f(writer)
+        {
+            log::error!("authoring_ledger: write failed: {error:#}");
+        }
+    }
+}
+
+fn record(
+    cx: &mut App,
+    root: &Path,
+    kind: &'static str,
+    file: Option<String>,
+    payload: serde_json::Value,
+) {
+    if !cx.has_global::<GlobalLedger>() {
+        return;
+    }
+    let ledger = cx.global::<GlobalLedger>().writers.clone();
+    let global = GlobalLedger { writers: ledger };
+    global.with_writer(root, |writer| writer.write(kind, file, payload));
+}
+
+// ---------------------------------------------------------------------------
+// editor integration
+
+/// Per-editor state: which project this buffer belongs to, and enough of the
+/// buffer's edit stream to describe a change without storing its text.
+pub struct LedgerAddon {
+    path: Option<String>,
+    subscription: text::Subscription<usize>,
+    /// Set when the last local edit's text matched the clipboard, which is how a
+    /// paste is told from typing without patching the editor's paste handler.
+    last_source: EditSource,
+    _subscriptions: Vec<gpui::Subscription>,
+}
+
+impl editor::Addon for LedgerAddon {
+    fn to_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn to_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+}
+
+fn register_editor(editor: &mut Editor, _window: Option<&mut Window>, cx: &mut Context<Editor>) {
+    if !editor.mode().is_full() {
+        return;
+    }
+    let Some(buffer) = editor.buffer().read(cx).as_singleton() else {
+        // Multi-buffer editors (search results, diffs) are not authoring
+        // surfaces; recording them would attribute edits to the wrong file.
+        return;
+    };
+
+    let Some(abs_path) = buffer
+        .read(cx)
+        .file()
+        .and_then(|file| file.as_local().map(|local| local.abs_path(cx)))
+    else {
+        return;
+    };
+    let Some(root) = enabled_root_for(&abs_path) else {
+        return;
+    };
+    let path = abs_path
+        .strip_prefix(&root)
+        .unwrap_or(&abs_path)
+        .to_string_lossy()
+        .into_owned();
+
+    let subscription = buffer.update(cx, |buffer, _| buffer.subscribe());
+
+    let mut subscriptions = Vec::new();
+    subscriptions.push(cx.subscribe(&buffer, {
+        let root = root.clone();
+        move |editor, buffer, event: &BufferEvent, cx| {
+            on_buffer_event(editor, &buffer, event, &root, cx)
+        }
+    }));
+    subscriptions.push(cx.subscribe_self({
+        let root = root.clone();
+        let path = path.clone();
+        move |_editor, event: &EditorEvent, cx| {
+            let kind = match event {
+                EditorEvent::Focused => "focus",
+                EditorEvent::Blurred => "blur",
+                EditorEvent::Saved => "save",
+                _ => return,
+            };
+            record(cx, &root, kind, Some(path.clone()), serde_json::json!({}));
+        }
+    }));
+
+    editor.register_addon(LedgerAddon {
+        path: Some(path),
+        subscription,
+        last_source: EditSource::Unknown,
+        _subscriptions: subscriptions,
+    });
+}
+
+fn on_buffer_event(
+    editor: &mut Editor,
+    buffer: &Entity<Buffer>,
+    event: &BufferEvent,
+    root: &Path,
+    cx: &mut Context<Editor>,
+) {
+    match event {
+        BufferEvent::Edited { source } => {
+            let clipboard = cx.read_from_clipboard().and_then(|item| item.text());
+            let Some(addon) = editor.addon_mut::<LedgerAddon>() else {
+                return;
+            };
+            let edits = addon.subscription.consume().into_inner();
+            if edits.is_empty() {
+                return;
+            }
+            let path = addon.path.clone();
+            let snapshot = buffer.read(cx).text_snapshot();
+
+            let mut payload_edits = Vec::new();
+            let mut source_kind = match source {
+                language::BufferEditSource::Agent => EditSource::Agent,
+                language::BufferEditSource::Remote => EditSource::Remote,
+                language::BufferEditSource::User => EditSource::Typed,
+            };
+            for edit in &edits {
+                let inserted_len = edit.new.end.saturating_sub(edit.new.start);
+                let deleted_len = edit.old.end.saturating_sub(edit.old.start);
+                let inserted: String = snapshot
+                    .text_for_range(edit.new.start..edit.new.end)
+                    .collect();
+                // A local insert whose text is exactly the clipboard is a paste.
+                // Typing the clipboard's contents by hand would be
+                // misclassified, which is a price worth paying to avoid
+                // patching the editor's paste path.
+                if source_kind == EditSource::Typed
+                    && inserted_len > 1
+                    && clipboard.as_deref() == Some(inserted.as_str())
+                {
+                    source_kind = EditSource::Pasted;
+                }
+                payload_edits.push(serde_json::json!({
+                    "offset": edit.new.start,
+                    "inserted": inserted_len,
+                    "deleted": deleted_len,
+                    // Content is never stored; the hash is enough to later match
+                    // a pasted span against an archived agent transcript.
+                    "sha256": if source_kind == EditSource::Pasted {
+                        serde_json::Value::String(hash_text(&inserted))
+                    } else {
+                        serde_json::Value::Null
+                    },
+                }));
+            }
+            addon.last_source = source_kind;
+            record(
+                cx,
+                root,
+                "edit",
+                path,
+                serde_json::json!({ "source": source_kind, "edits": payload_edits }),
+            );
+        }
+        BufferEvent::Reloaded => {
+            let path = editor
+                .addon::<LedgerAddon>()
+                .and_then(|addon| addon.path.clone());
+            // The file changed underneath us: an agent or another process wrote
+            // it. This is the only signal that catches a write made by something
+            // other than the Write/Edit tools.
+            record(
+                cx,
+                root,
+                "external_write",
+                path,
+                serde_json::json!({ "source": EditSource::External }),
+            );
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn enable(root: &Path) {
+        let dir = ledger_dir(root);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join(ENABLED_MARKER), "").unwrap();
+    }
+
+    #[test]
+    fn recording_is_off_until_the_marker_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("paper.md");
+        fs::write(&file, "hello").unwrap();
+        assert_eq!(enabled_root_for(&file), None);
+
+        enable(tmp.path());
+        assert_eq!(
+            enabled_root_for(&file).unwrap().canonicalize().unwrap(),
+            tmp.path().canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn marker_is_found_from_a_nested_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        enable(tmp.path());
+        let nested = tmp.path().join("chapters").join("one");
+        fs::create_dir_all(&nested).unwrap();
+        let file = nested.join("draft.md");
+        fs::write(&file, "x").unwrap();
+        assert_eq!(
+            enabled_root_for(&file).unwrap().canonicalize().unwrap(),
+            tmp.path().canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn records_use_the_claude_code_envelope() {
+        let tmp = tempfile::tempdir().unwrap();
+        enable(tmp.path());
+        let mut writer = SessionWriter::open(tmp.path()).unwrap();
+        writer
+            .write(
+                "edit",
+                Some("paper.md".into()),
+                serde_json::json!({"source":"typed"}),
+            )
+            .unwrap();
+        writer
+            .write("save", Some("paper.md".into()), serde_json::json!({}))
+            .unwrap();
+
+        let path = ledger_dir(tmp.path())
+            .join("sessions")
+            .join(format!("{}.jsonl", writer.session_id()));
+        let contents = fs::read_to_string(path).unwrap();
+        let lines: Vec<serde_json::Value> = contents
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(lines.len(), 2);
+
+        for line in &lines {
+            for field in ["type", "uuid", "timestamp", "sessionId", "cwd", "version"] {
+                assert!(line.get(field).is_some(), "missing {field}");
+            }
+        }
+        // parentUuid chains the records in write order.
+        assert!(lines[0]["parentUuid"].is_null());
+        assert_eq!(lines[1]["parentUuid"], lines[0]["uuid"]);
+        // Timestamps must be UTC with millisecond precision, like Claude Code's.
+        let stamp = lines[0]["timestamp"].as_str().unwrap();
+        assert!(stamp.ends_with('Z'), "not UTC: {stamp}");
+        assert_eq!(stamp.len(), 24, "not millisecond precision: {stamp}");
+    }
+
+    #[test]
+    fn text_is_never_written_to_the_ledger() {
+        let tmp = tempfile::tempdir().unwrap();
+        enable(tmp.path());
+        let mut writer = SessionWriter::open(tmp.path()).unwrap();
+        let secret = "an unpublished sentence";
+        writer
+            .write(
+                "edit",
+                Some("paper.md".into()),
+                serde_json::json!({
+                    "source": "pasted",
+                    "edits": [{"offset": 0, "inserted": secret.len(), "sha256": hash_text(secret)}],
+                }),
+            )
+            .unwrap();
+        let path = ledger_dir(tmp.path())
+            .join("sessions")
+            .join(format!("{}.jsonl", writer.session_id()));
+        let contents = fs::read_to_string(path).unwrap();
+        assert!(!contents.contains(secret));
+        assert!(contents.contains(&hash_text(secret)));
+    }
+}

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -82,6 +82,7 @@ anyhow.workspace = true
 askpass.workspace = true
 assets.workspace = true
 audio.workspace = true
+authoring_ledger.workspace = true
 auto_update.workspace = true
 auto_update_ui.workspace = true
 breadcrumbs.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -785,6 +785,9 @@ fn main() {
         feedback::init(cx);
         markdown_preview::init(cx);
         markdown_live_preview::init(cx);
+        // SUZURI: records how documents were written; off unless a project has
+        // .suzuri/editor-log/enabled
+        authoring_ledger::init(cx);
         tabular_data_preview::init(cx);
         svg_preview::init(cx);
         onboarding::init(cx);

--- a/script/suzuri-agent-log.py
+++ b/script/suzuri-agent-log.py
@@ -72,6 +72,9 @@ GENESIS = "0" * 64
 # archiving them into a project folder must be a decision, never a default.
 HOOK_EVENTS = ("SessionStart", "SessionEnd")
 HOOK_MARKER = "suzuri-agent-log"
+# Read by the authoring_ledger crate; its presence is what turns editor-side
+# recording on. Kept in step with project.json's "enabled" by set_enabled().
+ENABLED_MARKER = "enabled"
 
 
 # --------------------------------------------------------------------------
@@ -348,12 +351,26 @@ def is_enabled(project_root):
 
 
 def set_enabled(project_root, enabled):
+    """Flip the switch for both halves of the record.
+
+    The agent half is this script; the editor half is the `authoring_ledger`
+    crate, which records only while <project>/.suzuri/editor-log/enabled exists.
+    One switch drives both so a project cannot end up with half a trail.
+    """
     ensure_archive(project_root)
     path = os.path.join(archive_root(project_root), "project.json")
     config = project_config(project_root)
     config["enabled"] = bool(enabled)
     config["enabled_changed_at"] = utc_iso()
     write_json(path, config)
+
+    marker = os.path.join(norm(project_root), ".suzuri", "editor-log", ENABLED_MARKER)
+    if enabled:
+        os.makedirs(os.path.dirname(marker), exist_ok=True)
+        with open(marker, "w", encoding="utf-8") as handle:
+            handle.write("")
+    elif os.path.exists(marker):
+        os.remove(marker)
 
 
 # --------------------------------------------------------------------------

--- a/script/suzuri-agent-log.py
+++ b/script/suzuri-agent-log.py
@@ -1,0 +1,749 @@
+#!/usr/bin/env python3
+"""suzuri-agent-log - archive Claude Code agent transcripts into the project they belong to.
+
+Claude Code keeps session transcripts under ~/.claude/projects/ for
+`cleanupPeriodDays` (default 30) and then deletes them. This tool copies the
+complete record into <project>/.suzuri/agent-logs/ before that happens.
+
+A "complete record" is five things, not one file:
+
+  ~/.claude/projects/<slug>/<session>.jsonl              main transcript
+  ~/.claude/projects/<slug>/<session>/subagents/*        subagent transcripts
+  ~/.claude/projects/<slug>/<session>/tool-results/*     externalized large outputs
+  ~/.claude/file-history/<session>/*                     Write/Edit checkpoints
+  (metadata distilled into meta.json)
+
+Routing does NOT use the slug directory name. The slug is a lossy one-way
+transform of the launch cwd - every non-alphanumeric byte becomes '-' - so
+/x/foo-bar and /x/foo/bar collide into one directory. Routing instead reads the
+`cwd` field inside the transcript, treats it as a SET (one session can move
+between worktrees mid-run), and resolves each cwd to a project identity:
+
+  git repo   -> (git-common-dir, root-commit)   identical across all worktrees
+  otherwise  -> containment under the project root realpath
+
+Resolution is frozen into the manifest at sync time, because a cwd that has since
+been deleted can no longer be resolved by git and would otherwise become
+permanently unattributable.
+"""
+
+import argparse
+import calendar
+import fcntl
+import glob
+import gzip
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+
+SCHEMA_VERSION = 1
+ARCHIVE_REL = os.path.join(".suzuri", "agent-logs")
+GENESIS = "0" * 64
+
+
+# --------------------------------------------------------------------------
+# paths and normalization
+
+
+def claude_home():
+    return os.path.expanduser(os.environ.get("CLAUDE_CONFIG_DIR", "~/.claude"))
+
+
+def projects_dir():
+    return os.path.join(claude_home(), "projects")
+
+
+def file_history_dir():
+    return os.path.join(claude_home(), "file-history")
+
+
+def norm(path):
+    """realpath + case-fold.
+
+    /tmp and /private/tmp are the same directory on macOS and APFS is
+    case-insensitive; comparing raw strings silently splits one project into two
+    archives.
+    """
+    if not path:
+        return ""
+    return os.path.normcase(os.path.realpath(os.path.expanduser(path)))
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def utc_iso(epoch=None):
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
+
+
+def parse_iso_utc(stamp):
+    """Transcript timestamps are UTC ISO-8601; return epoch seconds.
+
+    Never round-trip through local time. `time.timezone` is the standard-time
+    offset, so using it during DST shifts every agent timestamp by an hour and
+    silently moves human edits away from the agent activity they correlate with.
+    """
+    if not stamp:
+        return None
+    try:
+        base = stamp.split(".")[0].rstrip("Z")
+        return int(calendar.timegm(time.strptime(base, "%Y-%m-%dT%H:%M:%S")))
+    except (ValueError, TypeError):
+        return None
+
+
+# --------------------------------------------------------------------------
+# project identity
+
+
+def git_out(cwd, *args):
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, *args], capture_output=True, text=True, timeout=15
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def project_identity(root):
+    """Identity of the project rooted at `root`.
+
+    For a git repo this is (common-dir, root-commit). The common dir is shared by
+    the main checkout and every worktree, so worktree sessions fold in
+    automatically, while an unrelated repo that merely shares a path prefix does
+    not. Plain folders and note vaults - the common case for a writing project -
+    fall back to the realpath.
+    """
+    root = norm(root)
+    common = git_out(root, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    if common:
+        return {
+            "kind": "git",
+            "common_dir": norm(common),
+            "root_commit": git_out(root, "rev-list", "--max-parents=0", "HEAD") or None,
+            "root": root,
+        }
+    return {"kind": "path", "common_dir": None, "root_commit": None, "root": root}
+
+
+def cwd_belongs(cwd, identity):
+    """Does a transcript's cwd belong to this project?
+
+    Containment is the fallback, which is also what keeps a session attributable
+    after its worktree has been deleted and git can no longer resolve it.
+    """
+    cwd_n = norm(cwd)
+    if not cwd_n:
+        return False
+    if identity["kind"] == "git" and os.path.isdir(cwd_n):
+        common = git_out(cwd_n, "rev-parse", "--path-format=absolute", "--git-common-dir")
+        if common and norm(common) == identity["common_dir"]:
+            return True
+    root = identity["root"]
+    return cwd_n == root or cwd_n.startswith(root + os.sep)
+
+
+# --------------------------------------------------------------------------
+# transcript reading
+
+
+def read_transcript(path):
+    """Single pass over a transcript.
+
+    Malformed lines are counted, never fatal: a partially written transcript from
+    a killed session must still archive.
+    """
+    info = {
+        "session_id": None,
+        "cwds": [],
+        "branches": [],
+        "versions": [],
+        "entrypoints": [],
+        "session_kinds": [],
+        "permission_modes": [],
+        "first_ts": None,
+        "last_ts": None,
+        "turns_user": 0,
+        "turns_assistant": 0,
+        "tools": {},
+        "models": [],
+        "cost_usd": None,
+        "lines": 0,
+        "unparseable": 0,
+    }
+
+    def note(key, value):
+        if value and value not in info[key]:
+            info[key].append(value)
+
+    try:
+        handle = open(path, encoding="utf-8", errors="replace")
+    except OSError as err:
+        info["error"] = str(err)
+        return info
+
+    with handle:
+        for line in handle:
+            info["lines"] += 1
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except (ValueError, TypeError):
+                info["unparseable"] += 1
+                continue
+            if not isinstance(record, dict):
+                info["unparseable"] += 1
+                continue
+
+            info["session_id"] = info["session_id"] or record.get("sessionId")
+            note("cwds", record.get("cwd"))
+            note("branches", record.get("gitBranch"))
+            note("versions", record.get("version"))
+            note("entrypoints", record.get("entrypoint"))
+            note("session_kinds", record.get("sessionKind"))
+            note("permission_modes", record.get("permissionMode"))
+
+            stamp = record.get("timestamp")
+            if stamp:
+                if info["first_ts"] is None or stamp < info["first_ts"]:
+                    info["first_ts"] = stamp
+                if info["last_ts"] is None or stamp > info["last_ts"]:
+                    info["last_ts"] = stamp
+
+            if record.get("type") == "cost-state":
+                info["cost_usd"] = record.get("totalCostUSD")
+            elif record.get("type") == "user":
+                info["turns_user"] += 1
+            elif record.get("type") == "assistant":
+                info["turns_assistant"] += 1
+
+            message = record.get("message")
+            if isinstance(message, dict):
+                note("models", message.get("model"))
+                content = message.get("content")
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "tool_use":
+                            name = block.get("name") or "?"
+                            info["tools"][name] = info["tools"].get(name, 0) + 1
+    return info
+
+
+def all_transcripts():
+    """Every main transcript under ~/.claude/projects/, across every slug.
+
+    Sessions for one project scatter across slugs - a session launched inside a
+    worktree gets its own - so every slug must be scanned, not just the one whose
+    name resembles the project path.
+    """
+    return sorted(glob.glob(os.path.join(projects_dir(), "*", "*.jsonl")))
+
+
+# --------------------------------------------------------------------------
+# archive layout
+
+
+def archive_root(project_root):
+    return os.path.join(norm(project_root), ARCHIVE_REL)
+
+
+def write_json(path, payload):
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=1, sort_keys=True)
+        handle.write("\n")
+    os.replace(tmp, path)
+
+
+def ensure_archive(project_root):
+    """Create the archive and make it gitignored by default.
+
+    Transcripts are stored by Claude Code in plaintext and contain far more than
+    prompts: every file read (including files outside the project), all shell
+    output, and fetched web pages. Nothing is redacted on disk. Committing them by
+    accident would publish all of it, so the archive ships ignoring itself and
+    committing is an explicit opt-in.
+    """
+    root = archive_root(project_root)
+    os.makedirs(os.path.join(root, "sessions"), exist_ok=True)
+
+    gitignore = os.path.join(root, ".gitignore")
+    if not os.path.exists(gitignore):
+        with open(gitignore, "w", encoding="utf-8") as handle:
+            handle.write(
+                "# Agent transcripts are stored in plaintext and contain every file read,\n"
+                "# all shell output, and fetched pages - not just prompts. Nothing is\n"
+                "# redacted. Committing this directory publishes all of it.\n"
+                "#\n"
+                "# manifest.jsonl carries metadata and hashes only (no prose), so it is the\n"
+                "# safe thing to share. To version it, add an exception below:\n"
+                "#   !manifest.jsonl\n"
+                "*\n"
+            )
+
+    identity_path = os.path.join(root, "project.json")
+    if not os.path.exists(identity_path):
+        identity = project_identity(project_root)
+        identity["project_uuid"] = str(uuid.uuid4())
+        identity["created_at"] = utc_iso()
+        identity["schema"] = SCHEMA_VERSION
+        write_json(identity_path, identity)
+    return root
+
+
+def gzip_copy(src, dst):
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    with open(src, "rb") as fin, gzip.open(dst, "wb") as fout:
+        shutil.copyfileobj(fin, fout)
+
+
+def session_dirname(info, session_id):
+    epoch = parse_iso_utc(info.get("first_ts"))
+    prefix = time.strftime("%Y-%m-%dT%H-%M-%SZ", time.gmtime(epoch)) if epoch else "unknown"
+    return "%s_%s" % (prefix, (session_id or "unknown")[:8])
+
+
+# --------------------------------------------------------------------------
+# manifest (append-only, hash-chained)
+
+
+def manifest_path(project_root):
+    return os.path.join(archive_root(project_root), "manifest.jsonl")
+
+
+def manifest_records(project_root):
+    path = manifest_path(project_root)
+    if not os.path.exists(path):
+        return []
+    records = []
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except ValueError:
+                continue
+    return records
+
+
+def manifest_append(project_root, entry):
+    """Append one chained record.
+
+    Each line carries the sha256 of the previous line, so a retroactive edit or a
+    deletion is detectable. The chain requires read-last-line and append to be
+    serialized, hence the lock - several sessions can end at once. It is held for
+    microseconds and only by this tool.
+    """
+    path = manifest_path(project_root)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            handle.seek(0)
+            previous = GENESIS
+            count = 0
+            for line in handle:
+                line = line.strip()
+                if line:
+                    previous = hashlib.sha256(line.encode("utf-8")).hexdigest()
+                    count += 1
+            entry = dict(entry)
+            entry["v"] = SCHEMA_VERSION
+            entry["seq"] = count
+            entry["prev"] = previous
+            entry["sig"] = None  # reserved: signing arrives with the shadow repo
+            handle.write(json.dumps(entry, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    return entry
+
+
+def verify_chain(project_root):
+    """Recompute the chain. Returns (ok, first_bad_seq)."""
+    path = manifest_path(project_root)
+    if not os.path.exists(path):
+        return True, None
+    previous = GENESIS
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        for index, line in enumerate(handle):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except ValueError:
+                return False, index
+            if record.get("prev") != previous:
+                return False, record.get("seq", index)
+            previous = hashlib.sha256(line.encode("utf-8")).hexdigest()
+    return True, None
+
+
+# --------------------------------------------------------------------------
+# archiving
+
+
+def archive_session(project_root, transcript_path, info, identity, primary):
+    """Copy one session's five locations into the project archive.
+
+    Returns the manifest entry, or None if it is already archived unchanged.
+    Freshness is decided by content hash, never mtime: Claude Code rewrites
+    trailing `cost-state` and `last-prompt` lines while a session stays open, so
+    an mtime-based sync re-copies idle sessions forever.
+    """
+    session_id = info.get("session_id") or os.path.basename(transcript_path)[: -len(".jsonl")]
+    root = ensure_archive(project_root)
+    dest = os.path.join(root, "sessions", session_dirname(info, session_id))
+
+    source_hash = sha256_file(transcript_path)
+    for record in manifest_records(project_root):
+        if (
+            record.get("session_id") == session_id
+            and record.get("transcript_sha256") == source_hash
+        ):
+            return None
+
+    os.makedirs(dest, exist_ok=True)
+    gzip_copy(transcript_path, os.path.join(dest, "transcript.jsonl.gz"))
+
+    slug_dir = os.path.dirname(transcript_path)
+    sidecar = os.path.join(slug_dir, session_id)
+    copied = {"subagents": 0, "tool_results": 0, "file_history": 0}
+
+    for name, key in (("subagents", "subagents"), ("tool-results", "tool_results")):
+        source = os.path.join(sidecar, name)
+        if not os.path.isdir(source):
+            continue
+        for entry in sorted(os.listdir(source)):
+            src = os.path.join(source, entry)
+            if not os.path.isfile(src):
+                continue
+            if entry.endswith(".meta.json"):
+                # tiny, and worth keeping readable: agentType, description, depth
+                os.makedirs(os.path.join(dest, name), exist_ok=True)
+                shutil.copy2(src, os.path.join(dest, name, entry))
+            else:
+                gzip_copy(src, os.path.join(dest, name, entry + ".gz"))
+            copied[key] += 1
+
+    history = os.path.join(file_history_dir(), session_id)
+    if os.path.isdir(history):
+        for entry in sorted(os.listdir(history)):
+            src = os.path.join(history, entry)
+            if os.path.isfile(src):
+                gzip_copy(src, os.path.join(dest, "file-history", entry + ".gz"))
+                copied["file_history"] += 1
+
+    write_json(
+        os.path.join(dest, "meta.json"),
+        {
+            "session_id": session_id,
+            "cwds": info["cwds"],
+            "branches": info["branches"],
+            "versions": info["versions"],
+            "entrypoints": info["entrypoints"],
+            "session_kinds": info["session_kinds"],
+            "permission_modes": info["permission_modes"],
+            "models": info["models"],
+            "first_ts": info["first_ts"],
+            "last_ts": info["last_ts"],
+            "turns_user": info["turns_user"],
+            "turns_assistant": info["turns_assistant"],
+            "tools": info["tools"],
+            "cost_usd": info["cost_usd"],
+            "unparseable_lines": info["unparseable"],
+            "source_slug": os.path.basename(slug_dir),
+            "primary_project": primary,
+            "archived_at": utc_iso(),
+        },
+    )
+
+    return manifest_append(
+        project_root,
+        {
+            "ts": utc_iso(),
+            "session_id": session_id,
+            "archived_dir": os.path.relpath(dest, root),
+            "transcript_sha256": source_hash,
+            "transcript_bytes": os.path.getsize(transcript_path),
+            "cwds": info["cwds"],
+            "primary_project": primary,
+            "is_primary": primary == identity["root"],
+            "first_ts": info["first_ts"],
+            "last_ts": info["last_ts"],
+            "turns": info["turns_user"] + info["turns_assistant"],
+            "tools": info["tools"],
+            "cost_usd": info["cost_usd"],
+            "sidecars": copied,
+            "source_slug": os.path.basename(slug_dir),
+        },
+    )
+
+
+def sync_project(project_root, quiet=False):
+    project_root = norm(project_root)
+    identity = project_identity(project_root)
+    ensure_archive(project_root)
+
+    archived, current, foreign, cross = 0, 0, 0, 0
+    for transcript in all_transcripts():
+        info = read_transcript(transcript)
+        if not info["cwds"]:
+            continue
+        if not any(cwd_belongs(cwd, identity) for cwd in info["cwds"]):
+            foreign += 1
+            continue
+
+        # The launch cwd is the first one seen; that project owns the session.
+        launch = info["cwds"][0]
+        primary = identity["root"] if cwd_belongs(launch, identity) else norm(launch)
+        if primary != identity["root"]:
+            cross += 1
+
+        entry = archive_session(project_root, transcript, info, identity, primary)
+        if entry is None:
+            current += 1
+        else:
+            archived += 1
+            if not quiet:
+                print(
+                    "  archived %s  (%d turns)  %s"
+                    % (entry["session_id"][:8], entry["turns"], entry["archived_dir"])
+                )
+
+    render(project_root)
+    if not quiet:
+        ok, bad = verify_chain(project_root)
+        print(
+            "\n  %d newly archived, %d already current, %d foreign skipped"
+            % (archived, current, foreign)
+        )
+        if cross:
+            print("  %d session(s) started in another project (recorded, not owned)" % cross)
+        print("  manifest chain: %s" % ("intact" if ok else "BROKEN at seq %s" % bad))
+        print("  archive: %s" % archive_root(project_root))
+    return archived
+
+
+# --------------------------------------------------------------------------
+# rendering
+
+
+def render(project_root):
+    """Regenerate AUTHORING.md from the manifest.
+
+    Written on demand rather than on a timer: the project folder is watched by the
+    editor, and rewriting a markdown file inside it while a buffer has it open
+    causes reload churn.
+    """
+    root = archive_root(project_root)
+    records = manifest_records(project_root)
+    latest = {}
+    for record in records:
+        latest[record.get("session_id")] = record
+    sessions = sorted(latest.values(), key=lambda r: r.get("first_ts") or "")
+
+    ok, bad = verify_chain(project_root)
+    lines = [
+        "# Authoring record",
+        "",
+        "Agent sessions archived for `%s`." % os.path.basename(norm(project_root)),
+        "",
+        "Generated by `script/suzuri-agent-log.py`. The authoritative record is",
+        "`manifest.jsonl` (append-only, hash-chained); this file renders it.",
+        "",
+        "- sessions archived: **%d**" % len(sessions),
+        "- manifest integrity: **%s**" % ("intact" if ok else "BROKEN at seq %s" % bad),
+        "- last updated: %s" % utc_iso(),
+        "",
+        "## Sessions",
+        "",
+        "| started (UTC) | session | kind | turns | tools | cost | owned |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+
+    total_cost = 0.0
+    for record in sessions:
+        tools = record.get("tools") or {}
+        tool_text = ", ".join("%s x%d" % (k, v) for k, v in sorted(tools.items())) or "-"
+        cost = record.get("cost_usd")
+        if isinstance(cost, (int, float)):
+            total_cost += cost
+
+        # sessionKind is only present on background sessions; entrypoint is
+        # always there, so it is the more useful fallback.
+        kind = "?"
+        meta_path = os.path.join(root, record.get("archived_dir") or "", "meta.json")
+        if os.path.exists(meta_path):
+            try:
+                with open(meta_path, encoding="utf-8") as handle:
+                    meta = json.load(handle)
+                labels = meta.get("session_kinds") or meta.get("entrypoints") or []
+                kind = ", ".join(labels) if labels else "?"
+            except (OSError, ValueError):
+                pass
+
+        lines.append(
+            "| %s | `%s` | %s | %d | %s | %s | %s |"
+            % (
+                (record.get("first_ts") or "?")[:19].replace("T", " "),
+                (record.get("session_id") or "?")[:8],
+                kind,
+                record.get("turns", 0),
+                tool_text,
+                ("$%.2f" % cost) if isinstance(cost, (int, float)) else "-",
+                "yes" if record.get("is_primary") else "no (started elsewhere)",
+            )
+        )
+
+    lines += ["", "Total recorded cost: $%.2f" % total_cost, ""]
+
+    foreign = [r for r in sessions if not r.get("is_primary")]
+    if foreign:
+        lines += [
+            "## Sessions started in another project",
+            "",
+            "These touched this project but were launched elsewhere, so another",
+            "archive owns the full record. They are listed so the trail is not",
+            "silently incomplete.",
+            "",
+        ]
+        for record in foreign:
+            lines.append(
+                "- `%s` - launched in `%s`"
+                % ((record.get("session_id") or "?")[:8], record.get("primary_project"))
+            )
+        lines.append("")
+
+    lines += [
+        "## What is and is not captured",
+        "",
+        "Captured: every Claude Code session routed to this project, with subagent",
+        "transcripts, externalized tool results, and Write/Edit checkpoints.",
+        "",
+        "Not captured: human keystrokes, paste versus typing, and files written by",
+        "means other than the Write/Edit tools - a `cat > file` heredoc leaves no",
+        "checkpoint and fires no tool hook. Those require editor-side capture.",
+        "",
+    ]
+
+    with open(os.path.join(root, "AUTHORING.md"), "w", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+
+
+# --------------------------------------------------------------------------
+# commands
+
+
+def cmd_sync(args):
+    sync_project(args.project or os.getcwd())
+    return 0
+
+
+def cmd_status(args):
+    project_root = norm(args.project or os.getcwd())
+    identity = project_identity(project_root)
+    print("project : %s" % project_root)
+    print("identity: %s (%s)" % (identity["common_dir"] or identity["root"], identity["kind"]))
+
+    known = {r.get("session_id") for r in manifest_records(project_root)}
+    available, foreign = [], 0
+    for transcript in all_transcripts():
+        info = read_transcript(transcript)
+        if info["cwds"] and any(cwd_belongs(c, identity) for c in info["cwds"]):
+            available.append(info["session_id"])
+        else:
+            foreign += 1
+
+    pending = [s for s in available if s not in known]
+    print("\nsessions on disk for this project : %d" % len(available))
+    print("already archived                  : %d" % len(known))
+    print("pending sync                      : %d" % len(pending))
+    print("other projects' sessions skipped  : %d" % foreign)
+    ok, bad = verify_chain(project_root)
+    print("manifest chain                    : %s" % ("intact" if ok else "BROKEN at seq %s" % bad))
+    return 0
+
+
+def cmd_verify(args):
+    project_root = norm(args.project or os.getcwd())
+    ok, bad = verify_chain(project_root)
+    print("manifest chain: %s" % ("intact" if ok else "BROKEN at seq %s" % bad))
+    return 0 if ok else 1
+
+
+def cmd_render(args):
+    project_root = norm(args.project or os.getcwd())
+    render(project_root)
+    print("wrote %s" % os.path.join(archive_root(project_root), "AUTHORING.md"))
+    return 0
+
+
+def cmd_hook(args):
+    """Hook entry point; reads Claude Code's JSON payload on stdin.
+
+    SessionEnd syncs the session that just finished. SessionStart sweeps, because
+    SessionEnd does not fire when the process is killed or crashes - without the
+    sweep those sessions are never archived and then expire.
+    """
+    payload = {}
+    try:
+        raw = sys.stdin.read()
+        if raw.strip():
+            payload = json.loads(raw)
+    except (ValueError, OSError):
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    project_root = payload.get("cwd") or args.project or os.getcwd()
+    try:
+        sync_project(project_root, quiet=True)
+    except Exception as err:  # a hook must never break the user's session
+        print("suzuri-agent-log: %s" % err, file=sys.stderr)
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="suzuri-agent-log",
+        description="Archive Claude Code transcripts into the project they belong to.",
+    )
+    sub = parser.add_subparsers(dest="command")
+    for name, handler, help_text in (
+        ("sync", cmd_sync, "copy this project's sessions into .suzuri/agent-logs/"),
+        ("status", cmd_status, "show archived vs pending sessions"),
+        ("render", cmd_render, "regenerate AUTHORING.md from the manifest"),
+        ("verify", cmd_verify, "check the manifest hash chain"),
+        ("hook", cmd_hook, "hook entry point (reads JSON on stdin)"),
+    ):
+        child = sub.add_parser(name, help=help_text)
+        child.add_argument("--project", help="project root (default: cwd)")
+        child.set_defaults(func=handler)
+
+    args = parser.parse_args()
+    if not getattr(args, "command", None):
+        parser.print_help()
+        return 2
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/script/suzuri-agent-log.py
+++ b/script/suzuri-agent-log.py
@@ -25,6 +25,28 @@ between worktrees mid-run), and resolves each cwd to a project identity:
 Resolution is frozen into the manifest at sync time, because a cwd that has since
 been deleted can no longer be resolved by git and would otherwise become
 permanently unattributable.
+
+Usage
+-----
+
+Recording is off for every project until it is turned on:
+
+    script/suzuri-agent-log.py enable    # opt in, install hooks, backfill
+    script/suzuri-agent-log.py status    # archived vs pending
+    script/suzuri-agent-log.py verify    # check the manifest hash chain
+    script/suzuri-agent-log.py disable   # opt out, remove hooks, keep archive
+
+`enable` installs SessionStart and SessionEnd hooks into the project's
+.claude/settings.json, preserving any hooks already there. Both events are
+needed: SessionEnd covers a normal exit, SessionStart sweeps sessions that were
+killed before SessionEnd could fire.
+
+What this does not capture: human keystrokes, paste versus typing, and files an
+agent writes by any means other than the Write/Edit tools. A `cat > file <<EOF`
+heredoc leaves no checkpoint and fires no tool hook, so tool-call capture alone
+under-reports; only editor-side observation closes that gap.
+
+Tests: python3 script/test_suzuri_agent_log.py
 """
 
 import argparse
@@ -44,6 +66,12 @@ import uuid
 SCHEMA_VERSION = 1
 ARCHIVE_REL = os.path.join(".suzuri", "agent-logs")
 GENESIS = "0" * 64
+
+# Recording is opt-in per project. Nothing is copied until `enable` is run: the
+# transcripts hold unredacted prompts, file contents, and shell output, so
+# archiving them into a project folder must be a decision, never a default.
+HOOK_EVENTS = ("SessionStart", "SessionEnd")
+HOOK_MARKER = "suzuri-agent-log"
 
 
 # --------------------------------------------------------------------------
@@ -300,8 +328,100 @@ def ensure_archive(project_root):
         identity["project_uuid"] = str(uuid.uuid4())
         identity["created_at"] = utc_iso()
         identity["schema"] = SCHEMA_VERSION
+        identity["enabled"] = False
         write_json(identity_path, identity)
     return root
+
+
+def project_config(project_root):
+    path = os.path.join(archive_root(project_root), "project.json")
+    try:
+        with open(path, encoding="utf-8") as handle:
+            config = json.load(handle)
+    except (OSError, ValueError):
+        return {}
+    return config if isinstance(config, dict) else {}
+
+
+def is_enabled(project_root):
+    return bool(project_config(project_root).get("enabled"))
+
+
+def set_enabled(project_root, enabled):
+    ensure_archive(project_root)
+    path = os.path.join(archive_root(project_root), "project.json")
+    config = project_config(project_root)
+    config["enabled"] = bool(enabled)
+    config["enabled_changed_at"] = utc_iso()
+    write_json(path, config)
+
+
+# --------------------------------------------------------------------------
+# hook installation
+
+
+def settings_path(project_root):
+    return os.path.join(norm(project_root), ".claude", "settings.json")
+
+
+def load_settings(project_root):
+    path = settings_path(project_root)
+    try:
+        with open(path, encoding="utf-8") as handle:
+            settings = json.load(handle)
+    except (OSError, ValueError):
+        return {}
+    return settings if isinstance(settings, dict) else {}
+
+
+def hook_command():
+    return "%s hook" % os.path.abspath(__file__)
+
+
+def install_hooks(project_root):
+    """Add our SessionStart/SessionEnd hooks, preserving anything already there.
+
+    Both events are needed: SessionEnd covers the normal exit, SessionStart
+    sweeps sessions that were killed or crashed before SessionEnd could fire.
+    """
+    settings = load_settings(project_root)
+    hooks = settings.setdefault("hooks", {})
+    added = []
+    for event in HOOK_EVENTS:
+        matchers = hooks.setdefault(event, [])
+        if any(HOOK_MARKER in json.dumps(entry) for entry in matchers):
+            continue
+        matchers.append({"hooks": [{"type": "command", "command": hook_command()}]})
+        added.append(event)
+    path = settings_path(project_root)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    write_json(path, settings)
+    return added
+
+
+def remove_hooks(project_root):
+    """Remove only our entries; leave every other hook untouched."""
+    settings = load_settings(project_root)
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return []
+    removed = []
+    for event in HOOK_EVENTS:
+        matchers = hooks.get(event)
+        if not isinstance(matchers, list):
+            continue
+        kept = [entry for entry in matchers if HOOK_MARKER not in json.dumps(entry)]
+        if len(kept) != len(matchers):
+            removed.append(event)
+        if kept:
+            hooks[event] = kept
+        else:
+            hooks.pop(event, None)
+    if not hooks:
+        settings.pop("hooks", None)
+    if os.path.exists(settings_path(project_root)):
+        write_json(settings_path(project_root), settings)
+    return removed
 
 
 def gzip_copy(src, dst):
@@ -497,8 +617,18 @@ def archive_session(project_root, transcript_path, info, identity, primary):
     )
 
 
-def sync_project(project_root, quiet=False):
+def sync_project(project_root, quiet=False, force=False):
     project_root = norm(project_root)
+    if not force and not is_enabled(project_root):
+        if not quiet:
+            print(
+                "recording is off for %s\n"
+                "nothing was copied. turn it on with:\n"
+                "  %s enable --project %s"
+                % (project_root, os.path.abspath(__file__), project_root)
+            )
+        return 0
+
     identity = project_identity(project_root)
     ensure_archive(project_root)
 
@@ -657,11 +787,43 @@ def cmd_sync(args):
     return 0
 
 
+def cmd_enable(args):
+    project_root = norm(args.project or os.getcwd())
+    set_enabled(project_root, True)
+    added = install_hooks(project_root)
+    print("recording ON for %s" % project_root)
+    print("  archive : %s  (gitignored)" % archive_root(project_root))
+    print("  hooks   : %s" % (", ".join(added) if added else "already installed"))
+    # The hook stores this script's absolute path. A worktree is temporary, so a
+    # path inside one leaves a dangling hook the moment the worktree is removed.
+    if os.path.join(".claude", "worktrees") in os.path.abspath(__file__):
+        print(
+            "\n  warning: hooks now point at a copy of this script inside a git\n"
+            "  worktree, which will break when that worktree is removed. Re-run\n"
+            "  `enable` from your main checkout to repoint them."
+        )
+    print("\nbackfilling sessions already on disk...")
+    sync_project(project_root)
+    return 0
+
+
+def cmd_disable(args):
+    project_root = norm(args.project or os.getcwd())
+    set_enabled(project_root, False)
+    removed = remove_hooks(project_root)
+    print("recording OFF for %s" % project_root)
+    print("  hooks removed: %s" % (", ".join(removed) if removed else "none were installed"))
+    print("  the existing archive was left in place; delete %s to discard it."
+          % archive_root(project_root))
+    return 0
+
+
 def cmd_status(args):
     project_root = norm(args.project or os.getcwd())
     identity = project_identity(project_root)
     print("project : %s" % project_root)
     print("identity: %s (%s)" % (identity["common_dir"] or identity["root"], identity["kind"]))
+    print("recording: %s" % ("ON" if is_enabled(project_root) else "OFF (default)"))
 
     known = {r.get("session_id") for r in manifest_records(project_root)}
     available, foreign = [], 0
@@ -714,6 +876,8 @@ def cmd_hook(args):
         payload = {}
 
     project_root = payload.get("cwd") or args.project or os.getcwd()
+    if not is_enabled(project_root):
+        return 0  # opt-in: a project that never enabled recording is left alone
     try:
         sync_project(project_root, quiet=True)
     except Exception as err:  # a hook must never break the user's session
@@ -728,6 +892,8 @@ def main():
     )
     sub = parser.add_subparsers(dest="command")
     for name, handler, help_text in (
+        ("enable", cmd_enable, "turn recording on for this project and backfill"),
+        ("disable", cmd_disable, "turn recording off and remove the hooks"),
         ("sync", cmd_sync, "copy this project's sessions into .suzuri/agent-logs/"),
         ("status", cmd_status, "show archived vs pending sessions"),
         ("render", cmd_render, "regenerate AUTHORING.md from the manifest"),

--- a/script/test_suzuri_agent_log.py
+++ b/script/test_suzuri_agent_log.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Tests for script/suzuri-agent-log.py.
+
+Run: python3 script/test_suzuri_agent_log.py
+
+These pin the behaviours that were established empirically and are easy to
+regress: routing must not use the slug, a session that moves between worktrees
+must still be attributed, recording must stay off until enabled, and the manifest
+chain must notice a retroactive edit.
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SPEC = importlib.util.spec_from_file_location("sal", os.path.join(HERE, "suzuri-agent-log.py"))
+sal = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(sal)
+
+
+def slug_for(path):
+    """Reproduce Claude Code's slug transform: every non-alphanumeric -> '-'."""
+    import re
+
+    return re.sub(r"[^A-Za-z0-9]", "-", path)
+
+
+class Harness(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.claude = os.path.join(self.tmp, "claude")
+        os.makedirs(os.path.join(self.claude, "projects"))
+        os.makedirs(os.path.join(self.claude, "file-history"))
+        os.environ["CLAUDE_CONFIG_DIR"] = self.claude
+
+    def tearDown(self):
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def make_project(self, name, git=False):
+        root = os.path.join(self.tmp, name)
+        os.makedirs(root, exist_ok=True)
+        with open(os.path.join(root, "README.md"), "w") as handle:
+            handle.write("# %s\n" % name)
+        if git:
+            subprocess.run(["git", "init", "-q", root], check=True)
+            for key, value in (("user.email", "t@t.t"), ("user.name", "t")):
+                subprocess.run(["git", "-C", root, "config", key, value], check=True)
+            subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+            subprocess.run(
+                ["git", "-C", root, "commit", "-q", "-m", "init"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+        return root
+
+    def write_transcript(self, session_id, cwds, launch_cwd=None):
+        """Write a transcript filed under the slug of its launch cwd."""
+        launch = launch_cwd or cwds[0]
+        slug_dir = os.path.join(self.claude, "projects", slug_for(launch))
+        os.makedirs(slug_dir, exist_ok=True)
+        path = os.path.join(slug_dir, "%s.jsonl" % session_id)
+        with open(path, "w") as handle:
+            for index, cwd in enumerate(cwds):
+                handle.write(
+                    json.dumps(
+                        {
+                            "type": "user",
+                            "sessionId": session_id,
+                            "cwd": cwd,
+                            "timestamp": "2026-08-28T2%d:00:00.000Z" % index,
+                            "entrypoint": "cli",
+                            "message": {"role": "user", "content": "hello"},
+                        }
+                    )
+                    + "\n"
+                )
+        return path
+
+
+class TestRouting(Harness):
+    def test_colliding_slugs_are_separated_by_cwd(self):
+        """/x/audit-test-a and /x/audit/test-a collide into one slug directory.
+
+        This is the case that proves routing cannot use the directory name.
+        """
+        a = self.make_project("audit-test-a")
+        os.makedirs(os.path.join(self.tmp, "audit"), exist_ok=True)
+        b = self.make_project(os.path.join("audit", "test-a"))
+        self.assertEqual(slug_for(a), slug_for(b), "test premise: slugs must collide")
+
+        self.write_transcript("aaaaaaaa", [a])
+        self.write_transcript("bbbbbbbb", [b])
+        self.write_transcript("cccccccc", [b])
+
+        sal.set_enabled(a, True)
+        sal.set_enabled(b, True)
+        sal.sync_project(a, quiet=True)
+        sal.sync_project(b, quiet=True)
+
+        ids = lambda root: sorted(r["session_id"] for r in sal.manifest_records(root))
+        self.assertEqual(ids(a), ["aaaaaaaa"])
+        self.assertEqual(ids(b), ["bbbbbbbb", "cccccccc"])
+
+    def test_unrelated_project_sharing_a_path_prefix_is_excluded(self):
+        a = self.make_project("proj")
+        other = self.make_project("proj-testbed")
+        self.write_transcript("aaaaaaaa", [a])
+        self.write_transcript("zzzzzzzz", [other])
+
+        sal.set_enabled(a, True)
+        sal.sync_project(a, quiet=True)
+        self.assertEqual([r["session_id"] for r in sal.manifest_records(a)], ["aaaaaaaa"])
+
+    def test_session_that_moves_between_cwds_is_attributed_to_both(self):
+        """One session can touch several projects; neither may silently drop it."""
+        a = self.make_project("alpha")
+        b = self.make_project("beta")
+        self.write_transcript("mmmmmmmm", [a, b], launch_cwd=a)
+
+        for root in (a, b):
+            sal.set_enabled(root, True)
+            sal.sync_project(root, quiet=True)
+
+        record_a = sal.manifest_records(a)[0]
+        record_b = sal.manifest_records(b)[0]
+        self.assertTrue(record_a["is_primary"], "launch cwd owns the session")
+        self.assertFalse(record_b["is_primary"], "the other project records it as foreign")
+
+    def test_git_worktree_outside_the_root_is_matched(self):
+        """A worktree at ../name is not under the root path, so only the
+        git-common-dir rule can associate it."""
+        root = self.make_project("repo", git=True)
+        worktree = os.path.join(self.tmp, "repo-wt")
+        subprocess.run(
+            ["git", "-C", root, "worktree", "add", "-q", "-b", "wt", worktree],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        self.assertFalse(sal.norm(worktree).startswith(sal.norm(root) + os.sep))
+
+        self.write_transcript("wwwwwwww", [worktree])
+        sal.set_enabled(root, True)
+        sal.sync_project(root, quiet=True)
+        self.assertEqual([r["session_id"] for r in sal.manifest_records(root)], ["wwwwwwww"])
+
+    def test_deleted_cwd_still_attributed_by_containment(self):
+        root = self.make_project("vault")
+        gone = os.path.join(root, "subdir-since-deleted")
+        self.write_transcript("dddddddd", [gone])
+        self.assertFalse(os.path.isdir(gone))
+
+        sal.set_enabled(root, True)
+        sal.sync_project(root, quiet=True)
+        self.assertEqual([r["session_id"] for r in sal.manifest_records(root)], ["dddddddd"])
+
+
+class TestOptIn(Harness):
+    def test_recording_is_off_by_default(self):
+        root = self.make_project("proj")
+        self.write_transcript("aaaaaaaa", [root])
+        self.assertFalse(sal.is_enabled(root))
+        sal.sync_project(root, quiet=True)
+        self.assertEqual(sal.manifest_records(root), [])
+
+    def test_enable_then_disable(self):
+        root = self.make_project("proj")
+        self.write_transcript("aaaaaaaa", [root])
+        sal.set_enabled(root, True)
+        sal.sync_project(root, quiet=True)
+        self.assertEqual(len(sal.manifest_records(root)), 1)
+        sal.set_enabled(root, False)
+        self.assertFalse(sal.is_enabled(root))
+
+    def test_archive_is_gitignored_on_creation(self):
+        root = self.make_project("proj")
+        sal.ensure_archive(root)
+        with open(os.path.join(sal.archive_root(root), ".gitignore")) as handle:
+            self.assertIn("*", handle.read())
+
+    def test_hooks_install_and_remove_preserve_foreign_entries(self):
+        root = self.make_project("proj")
+        os.makedirs(os.path.join(root, ".claude"), exist_ok=True)
+        sal.write_json(
+            sal.settings_path(root),
+            {"hooks": {"SessionEnd": [{"hooks": [{"type": "command", "command": "echo mine"}]}]}},
+        )
+        sal.install_hooks(root)
+        settings = sal.load_settings(root)
+        self.assertEqual(len(settings["hooks"]["SessionEnd"]), 2)
+
+        sal.remove_hooks(root)
+        settings = sal.load_settings(root)
+        self.assertEqual(len(settings["hooks"]["SessionEnd"]), 1)
+        self.assertIn("echo mine", json.dumps(settings))
+
+
+class TestManifest(Harness):
+    def test_chain_detects_a_retroactive_edit(self):
+        root = self.make_project("proj")
+        self.write_transcript("aaaaaaaa", [root])
+        self.write_transcript("bbbbbbbb", [root])
+        sal.set_enabled(root, True)
+        sal.sync_project(root, quiet=True)
+        self.assertEqual(sal.verify_chain(root), (True, None))
+
+        path = sal.manifest_path(root)
+        with open(path) as handle:
+            lines = handle.read().splitlines()
+        record = json.loads(lines[0])
+        record["turns"] = 999
+        lines[0] = json.dumps(record, sort_keys=True)
+        with open(path, "w") as handle:
+            handle.write("\n".join(lines) + "\n")
+
+        ok, _ = sal.verify_chain(root)
+        self.assertFalse(ok)
+
+    def test_sync_is_idempotent(self):
+        root = self.make_project("proj")
+        self.write_transcript("aaaaaaaa", [root])
+        sal.set_enabled(root, True)
+        self.assertEqual(sal.sync_project(root, quiet=True), 1)
+        self.assertEqual(sal.sync_project(root, quiet=True), 0)
+
+    def test_resync_after_transcript_grows(self):
+        """Freshness is by content hash: an appended turn must re-archive."""
+        root = self.make_project("proj")
+        path = self.write_transcript("aaaaaaaa", [root])
+        sal.set_enabled(root, True)
+        sal.sync_project(root, quiet=True)
+        with open(path, "a") as handle:
+            handle.write(
+                json.dumps(
+                    {"type": "user", "sessionId": "aaaaaaaa", "cwd": root,
+                     "timestamp": "2026-08-28T23:00:00.000Z"}
+                )
+                + "\n"
+            )
+        self.assertEqual(sal.sync_project(root, quiet=True), 1)
+
+
+class TestSidecars(Harness):
+    def test_subagents_tool_results_and_file_history_are_copied(self):
+        root = self.make_project("proj")
+        path = self.write_transcript("aaaaaaaa", [root])
+        sidecar = os.path.join(os.path.dirname(path), "aaaaaaaa")
+        os.makedirs(os.path.join(sidecar, "subagents"))
+        os.makedirs(os.path.join(sidecar, "tool-results"))
+        history = os.path.join(self.claude, "file-history", "aaaaaaaa")
+        os.makedirs(history)
+        for rel, body in (
+            (os.path.join(sidecar, "subagents", "agent-1.jsonl"), "{}\n"),
+            (os.path.join(sidecar, "subagents", "agent-1.meta.json"), '{"agentType":"x"}'),
+            (os.path.join(sidecar, "tool-results", "r1.txt"), "big output"),
+            (os.path.join(history, "abc@v1"), "before"),
+        ):
+            with open(rel, "w") as handle:
+                handle.write(body)
+
+        sal.set_enabled(root, True)
+        sal.sync_project(root, quiet=True)
+
+        dest = os.path.join(sal.archive_root(root), sal.manifest_records(root)[0]["archived_dir"])
+        for rel in (
+            "subagents/agent-1.jsonl.gz",
+            "subagents/agent-1.meta.json",
+            "tool-results/r1.txt.gz",
+            "file-history/abc@v1.gz",
+        ):
+            self.assertTrue(os.path.exists(os.path.join(dest, rel)), rel)
+
+
+class TestTime(Harness):
+    def test_utc_parsing_is_dst_independent(self):
+        """Transcripts are UTC; a DST-sensitive conversion silently shifts every
+        agent timestamp by an hour."""
+        self.assertEqual(sal.parse_iso_utc("1970-01-01T00:00:00.000Z"), 0)
+        self.assertEqual(sal.parse_iso_utc("2026-08-28T21:28:58.025Z"), 1787952538)
+        self.assertIsNone(sal.parse_iso_utc(None))
+        self.assertIsNone(sal.parse_iso_utc("not a timestamp"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/script/test_suzuri_agent_log.py
+++ b/script/test_suzuri_agent_log.py
@@ -179,6 +179,17 @@ class TestOptIn(Harness):
         sal.set_enabled(root, False)
         self.assertFalse(sal.is_enabled(root))
 
+    def test_switch_drives_the_editor_ledger_too(self):
+        """One switch must turn on both halves, or a project ends up with half a
+        trail: agent turns recorded but no human edits, or the reverse."""
+        root = self.make_project("proj")
+        marker = os.path.join(root, ".suzuri", "editor-log", "enabled")
+        self.assertFalse(os.path.exists(marker))
+        sal.set_enabled(root, True)
+        self.assertTrue(os.path.exists(marker))
+        sal.set_enabled(root, False)
+        self.assertFalse(os.path.exists(marker))
+
     def test_archive_is_gitignored_on_creation(self):
         root = self.make_project("proj")
         sal.ensure_archive(root)


### PR DESCRIPTION
Claude Code deletes local session transcripts after `cleanupPeriodDays` (default 30), so a project's agent history silently expires. The oldest transcript on my disk is exactly 30 days old, and two slug directories vanished during the session that produced this branch, so the loss is not hypothetical.

This adds `script/suzuri-agent-log.py`, which copies the complete record into `<project>/.suzuri/agent-logs/` before that happens. A complete session is five locations, not one file: the main transcript, subagent transcripts, externalized `tool-results`, `file-history` checkpoints, and distilled metadata.

## Routing

Routing deliberately ignores the `~/.claude/projects` slug directory name. The slug is a lossy transform of the launch cwd — every non-alphanumeric byte becomes `-` — so `/x/foo-bar` and `/x/foo/bar` collide into one directory. Sessions are routed instead by the `cwd` recorded inside the transcript, treated as a set because one session can move between worktrees mid-run, resolved to `(git-common-dir, root-commit)` for repos and to realpath containment for plain folders and note vaults.

Verified against two non-git folders whose slugs collide byte-for-byte: three sessions separated with no mixing. On this repo it matches 47 sessions across four slugs, including a worktree outside the repo root that only the git-common-dir rule can associate, while excluding three unrelated repos that share a path prefix.

## Opt-in

Recording is off for every project until `enable` is run. The transcripts hold unredacted prompts, file contents, and shell output, so archiving them into a project folder must be a decision. The archive gitignores itself on creation; `manifest.jsonl` carries metadata and hashes only, so it is the part that is safe to share.

## Known limits

Tool-call capture alone under-reports. Both files in the verification run were written with a `cat > file <<EOF` heredoc, which fires no `Write`/`Edit` hook and leaves no `file-history` checkpoint — a `PostToolUse Edit|Write` hook would have recorded zero writes while two files were created. Human keystrokes and paste-versus-typing are likewise invisible. Closing those needs editor-side capture, which is not in this change.

## Tests

`python3 script/test_suzuri_agent_log.py` — 14 tests, no dependencies.

Release Notes:

- N/A