### PR TITLE
README: Credit TinyTeX instead of Tectonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Suzuri adds a writing environment to Zed without giving up the code editor: Obsi
 
 - **Reading** — A native PDF viewer with continuous scroll, zoom, and real text selection, built on [hayro](https://github.com/LaurenzV/hayro). PDFs reload in place when they change on disk.
 
-- **Typesetting** — Write [Typst](https://typst.app) or LaTeX in one pane and watch the PDF update in the other, a second after you stop typing. Compilers install themselves on first use.
+- **Typesetting** — Write [Typst](https://typst.app) or LaTeX in one pane and watch the PDF update in the other, a second after you stop typing. If you have no compiler installed, the first preview offers to fetch one.
 
 - **Linking** — `[[wikilinks]]` with completion, ⌘-click follow, backlinks, and broken-link diagnostics, built in with no extension to install.
 
@@ -49,7 +49,8 @@ Suzuri stands on generous shoulders:
 - [David Turnbull](https://github.com/dsturnbull) — the PDF viewer ([zed#51040](https://github.com/zed-industries/zed/pull/51040)) and the hayro text-extraction work it builds on
 - [hayro](https://github.com/LaurenzV/hayro) by Laurenz Stampfl — pure-Rust PDF rendering
 - [markdown-oxide](https://github.com/Feel-ix-343/markdown-oxide) by Felix Zeller — the PKM language server behind wikilinks, backlinks, and link diagnostics
-- [Typst](https://github.com/typst/typst) and [Tectonic](https://github.com/tectonic-typesetting/tectonic) — the typesetting engines behind live preview
+- [Typst](https://github.com/typst/typst) — the compiler behind Typst live preview
+- [TinyTeX](https://github.com/rstudio/tinytex) by Yihui Xie — the relocatable TeX Live behind LaTeX live preview
 
 ## Relationship to Zed
 


### PR DESCRIPTION
Two README claims went stale when 29b8af8c9b ("typeset_preview: Choose the LaTeX engine, and manage a real TeX Live") replaced Tectonic with a managed TinyTeX.

**The credits named the wrong project.** That commit deleted `ensure_tectonic`, `TECTONIC_TAG`, `TECTONIC_REPOSITORY` and the archive-kind logic, because `aaai2027.sty` calls `\RequirePDFTeX` and Tectonic is XeTeX. TinyTeX — a prebuilt relocatable TeX Live shipping pdflatex, xelatex, lualatex and latexmk — is what the build provisions now, so the acknowledgements credited a project Suzuri no longer ships and omitted the one it does. Split into two entries, since Typst is a compiler and TinyTeX is a distribution, and the section credits authors.

**Provisioning is no longer automatic.** "Compilers install themselves on first use" described behavior that same commit deliberately removed: downloads are now offered rather than performed, because a silent download is what made the original AAAI failure unactionable — the user never learned an engine had been chosen for them.

Tectonic still appears twice in the tree, and both are intentional and left alone:

- `assets/settings/default.json:156` — the worked example for `latex_engine`'s `external` form. That option exists precisely to name a compiler Suzuri does not manage, so illustrating it with an unbundled binary is the point; substituting a bundled engine would blur options 3 and 4 in that comment.
- `crates/typeset_preview/src/typeset_preview.rs:1213,1295` — test fixtures exercising the external-command path with an arbitrary command string.

Docs only; no code, no build or test impact. `script/prettier` covers `assets/settings/default.json` and `docs/` only, so `README.md` is not in its scope — the file's pre-existing Prettier warning is unchanged by this and reformatting it would have buried a two-line fix in an unrelated diff.

Release Notes:

- N/A
