### PR TITLE
markdown_live_preview: Let an image be dragged to a new place in the note

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7268,30 +7268,60 @@ impl Editor {
     }
 
     /// SUZURI: markdown live preview lets the reader drag an image widget to
-    /// another line, which means turning a pointer position into the row the
-    /// image should land above. The position map that answers that is private
-    /// to the element, so expose just this much of it. Returns one past the
-    /// last row when the pointer is below every line, and `None` when it is
-    /// outside the text area entirely.
-    pub fn buffer_row_at_position(&self, position: gpui::Point<Pixels>) -> Option<MultiBufferRow> {
+    /// another line, which means turning a pointer position into the row
+    /// boundary the image should land at. The position map that answers that
+    /// is private to the element, so expose just this much of it.
+    ///
+    /// Returns the boundary nearest the pointer, with half-line precision:
+    /// the upper half of a line maps to the boundary above it, the lower half
+    /// to the boundary below, so hovering a tall block widget targets the
+    /// seam the pointer is closest to rather than always the widget's own
+    /// line. A boundary of `b` means "lands above buffer row `b`", where `b`
+    /// may be one past the last row; `None` means the pointer is outside the
+    /// text area entirely.
+    pub fn buffer_row_boundary_at_position(
+        &self,
+        position: gpui::Point<Pixels>,
+    ) -> Option<MultiBufferRow> {
         let position_map = self.last_position_map.as_ref()?;
         if !position_map.text_hitbox.bounds.contains(&position) {
             return None;
         }
         let snapshot = &position_map.snapshot;
-        let rows_above_content = snapshot.display_snapshot.max_point().row().0 as f64 + 1.
-            - position_map.scroll_position.y;
-        let content_bottom = position_map.text_hitbox.bounds.origin.y
-            + position_map.line_height * rows_above_content as f32;
-        if position.y >= content_bottom {
-            return Some(MultiBufferRow(
-                snapshot.buffer_snapshot().max_point().row + 1,
-            ));
+        let buffer_max_row = snapshot.buffer_snapshot().max_point().row;
+        // The pointer's display row, kept fractional so the half-line test
+        // below can tell which side of a row's midline it is on.
+        let pointer_row = ((position.y - position_map.text_hitbox.bounds.origin.y)
+            / position_map.line_height) as f64
+            + position_map.scroll_position.y;
+        let max_display_row = snapshot.display_snapshot.max_point().row().0;
+        if pointer_row >= max_display_row as f64 + 1. {
+            return Some(MultiBufferRow(buffer_max_row + 1));
         }
-        let point = position_map.point_for_position(position).nearest_valid;
-        Some(MultiBufferRow(
-            snapshot.display_point_to_point(point, Bias::Left).row,
-        ))
+        let display_row = (pointer_row.max(0.) as u32).min(max_display_row);
+        let row = snapshot
+            .display_point_to_point(DisplayPoint::new(DisplayRow(display_row), 0), Bias::Left)
+            .row;
+        // The buffer row's full display extent: a block widget spans many
+        // display rows, and the midline of that whole span is what divides
+        // "above it" from "below it".
+        let span_start = snapshot
+            .point_to_display_point(Point::new(row, 0), Bias::Left)
+            .row()
+            .0;
+        let span_end = if row >= buffer_max_row {
+            max_display_row + 1
+        } else {
+            snapshot
+                .point_to_display_point(Point::new(row + 1, 0), Bias::Left)
+                .row()
+                .0
+        };
+        if pointer_row < (span_start + span_end) as f64 / 2. {
+            Some(MultiBufferRow(row))
+        } else {
+            Some(MultiBufferRow(row + 1))
+        }
     }
 
     pub fn duplicate(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7267,6 +7267,33 @@ impl Editor {
         self.selection_drag_state = SelectionDragState::None;
     }
 
+    /// SUZURI: markdown live preview lets the reader drag an image widget to
+    /// another line, which means turning a pointer position into the row the
+    /// image should land above. The position map that answers that is private
+    /// to the element, so expose just this much of it. Returns one past the
+    /// last row when the pointer is below every line, and `None` when it is
+    /// outside the text area entirely.
+    pub fn buffer_row_at_position(&self, position: gpui::Point<Pixels>) -> Option<MultiBufferRow> {
+        let position_map = self.last_position_map.as_ref()?;
+        if !position_map.text_hitbox.bounds.contains(&position) {
+            return None;
+        }
+        let snapshot = &position_map.snapshot;
+        let rows_above_content = snapshot.display_snapshot.max_point().row().0 as f64 + 1.
+            - position_map.scroll_position.y;
+        let content_bottom = position_map.text_hitbox.bounds.origin.y
+            + position_map.line_height * rows_above_content as f32;
+        if position.y >= content_bottom {
+            return Some(MultiBufferRow(
+                snapshot.buffer_snapshot().max_point().row + 1,
+            ));
+        }
+        let point = position_map.point_for_position(position).nearest_valid;
+        Some(MultiBufferRow(
+            snapshot.display_point_to_point(point, Bias::Left).row,
+        ))
+    }
+
     pub fn duplicate(
         &mut self,
         upwards: bool,

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -19,7 +19,7 @@ use std::{
 
 use collections::{HashMap, HashSet};
 use editor::{
-    Addon, Editor, EditorEvent, FoldPlaceholder, HighlightKey,
+    Addon, Editor, EditorEvent, FoldPlaceholder, HighlightKey, RowHighlightOptions,
     display_map::{
         BlockPlacement, BlockProperties, BlockStyle, Concealment, CustomBlockId, RenderBlock,
     },
@@ -265,6 +265,7 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
         handle_press: None,
         source_revealed: None,
         last_resize_at: None,
+        image_move: None,
         callout_collapse: Vec::new(),
         _subscriptions: subscriptions,
     });
@@ -315,6 +316,10 @@ struct LivePreviewAddon {
     /// When a resize drag last wrote a width, so selection isn't cleared by
     /// the selection refresh that buffer edits trigger mid-drag.
     last_resize_at: Option<std::time::Instant>,
+    /// The image widget currently being dragged to a new position, with the
+    /// row its line will land above (`None` while the pointer is outside the
+    /// text area). Set from `on_drag_move`, consumed on mouse up.
+    image_move: Option<(Range<Anchor>, Option<u32>)>,
     /// Callouts the reader has expanded or collapsed by clicking their title,
     /// overriding the `+`/`-` their syntax asks for. Anchored, so the state
     /// follows the callout as text above it changes.
@@ -3606,11 +3611,49 @@ struct ImageResizeDrag {
     content_left_offset: gpui::Pixels,
 }
 
+/// Drag payload for moving an image to another line. Carries the marker range
+/// of the image being moved, which is its whole line — `push_block_rows`
+/// anchors block markers to full lines, and an image only becomes a block
+/// widget when it is alone on its line.
+struct ImageMoveDrag {
+    range: Range<Anchor>,
+}
+
+/// Type tag scoping the row highlight that marks where a dragged image will
+/// land, so clearing it cannot disturb any other row highlight.
+struct ImageDropTarget;
+
 struct EmptyDragPreview;
 
 impl gpui::Render for EmptyDragPreview {
     fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
         Empty
+    }
+}
+
+/// The thumbnail that follows the pointer while an image is being dragged.
+struct ImageDragPreview {
+    source: Option<ImageSource>,
+    alt: SharedString,
+}
+
+impl gpui::Render for ImageDragPreview {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let colors = cx.theme().colors();
+        div()
+            .rounded_sm()
+            .border_1()
+            .border_color(colors.border)
+            .bg(colors.elevated_surface_background)
+            .shadow_md()
+            .p_1()
+            .map(|this| match self.source.clone() {
+                Some(source) => this.child(img(source).w(px(160.)).rounded_sm()),
+                None => this
+                    .px_2()
+                    .text_color(colors.text_muted)
+                    .child(self.alt.clone()),
+            })
     }
 }
 
@@ -3693,6 +3736,8 @@ fn render_image_block(
         let reveal_range = range.clone();
         let drag_editor = editor.clone();
         let drag_range = range.clone();
+        let move_editor = editor.clone();
+        let move_drag_range = range.clone();
 
         // A direct image element lets the selection border hug the image
         // exactly; reference-style images (no inline destination) fall back
@@ -3701,6 +3746,13 @@ fn render_image_block(
             resolve_image_source(destination, base_directory.as_deref(), &image_cache)
         });
         let muted = block_cx.app.theme().colors().text_muted;
+        let preview_source = resolved.clone();
+        let preview_alt: SharedString = if alt.is_empty() {
+            destination.clone().unwrap_or_default().into()
+        } else {
+            alt.clone()
+        };
+        let move_range = range.clone();
         let image_content: gpui::AnyElement = match (&destination, resolved) {
             (Some(_), Some(source)) => {
                 let fallback_alt = alt.clone();
@@ -3737,6 +3789,9 @@ fn render_image_block(
         };
 
         let mut content = div()
+            // Only so the image itself can start a drag; `on_drag` is a
+            // stateful-element API.
+            .id("mdlp-image-body")
             .relative()
             .border_2()
             .rounded_sm()
@@ -3748,7 +3803,13 @@ fn render_image_block(
                 }
             })
             .when(content_width.is_none(), |this| this.max_w(max_width * 0.66))
-            .child(image_content);
+            .child(image_content)
+            .on_drag(ImageMoveDrag { range: move_range }, move |_, _, _, cx| {
+                cx.new(|_| ImageDragPreview {
+                    source: preview_source.clone(),
+                    alt: preview_alt.clone(),
+                })
+            });
 
         if selected {
             content = content
@@ -3834,6 +3895,47 @@ fn render_image_block(
                     })
                     .log_err();
             })
+            // `on_drag_move` fires for every pointer move while the drag is
+            // live, not just those over this block, which is what lets one
+            // image widget follow the pointer across the whole document. Every
+            // image block hears every move, so each only handles its own.
+            .on_drag_move::<ImageMoveDrag>({
+                let editor = move_editor.clone();
+                let range = move_drag_range;
+                move |event, _window, cx| {
+                    if event.drag(cx).range != range {
+                        return;
+                    }
+                    let position = event.event.position;
+                    editor
+                        .update(cx, |editor, cx| {
+                            let target_row =
+                                editor.buffer_row_at_position(position).map(|row| row.0);
+                            track_image_drop_target(editor, &range, target_row, cx);
+                        })
+                        .log_err();
+                }
+            })
+            // The drop can land anywhere, so it is caught on mouse up rather
+            // than through `on_drop`, which only fires over this block.
+            .on_mouse_up(MouseButton::Left, {
+                let editor = move_editor.clone();
+                move |_, _window, cx| {
+                    let dropped = cx.has_active_drag();
+                    editor
+                        .update(cx, |editor, cx| finish_image_move(editor, dropped, cx))
+                        .log_err();
+                }
+            })
+            .on_mouse_up_out(MouseButton::Left, {
+                let editor = move_editor;
+                move |_, _window, cx| {
+                    let dropped = cx.has_active_drag();
+                    editor
+                        .update(cx, |editor, cx| finish_image_move(editor, dropped, cx))
+                        .log_err();
+                }
+            })
             // `flex()` is load-bearing: gpui's `div()` is `display: block`, so a
             // block child fills its parent's width and the bordered container
             // would stretch to its own `max_w` cap — leaving the selection
@@ -3876,6 +3978,175 @@ fn resize_image_to_width(
     editor.buffer().update(cx, |multibuffer, cx| {
         multibuffer.edit([(start..end, updated)], None, cx);
     });
+}
+
+/// Records where a dragged image would land and highlights that row, so the
+/// drop point is visible while the pointer moves. `target_row` is `None` when
+/// the pointer is outside the text area, and may be one past the last row,
+/// which highlights the last row instead — the image lands below it.
+fn track_image_drop_target(
+    editor: &mut Editor,
+    range: &Range<Anchor>,
+    target_row: Option<u32>,
+    cx: &mut Context<Editor>,
+) {
+    let unchanged = editor.addon::<LivePreviewAddon>().is_some_and(|addon| {
+        addon
+            .image_move
+            .as_ref()
+            .is_some_and(|(_, row)| *row == target_row)
+    });
+    if unchanged {
+        return;
+    }
+    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+        addon.image_move = Some((range.clone(), target_row));
+    }
+    editor.clear_row_highlights::<ImageDropTarget>();
+    if let Some(target_row) = target_row {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let row = target_row.min(snapshot.max_point().row);
+        let start = snapshot.anchor_before(Point::new(row, 0));
+        let end = snapshot.anchor_after(Point::new(row, snapshot.line_len(MultiBufferRow(row))));
+        editor.highlight_rows::<ImageDropTarget>(
+            start..end,
+            |cx| cx.theme().colors().drop_target_background,
+            RowHighlightOptions {
+                autoscroll: false,
+                include_gutter: true,
+            },
+            cx,
+        );
+    }
+    cx.notify();
+}
+
+/// Completes an image move: drops the image on the row the pointer last
+/// indicated, and clears the drag's highlight either way. Runs on every mouse
+/// up, so it must be a no-op when no image is being dragged. `dropped` is
+/// false when the gesture ended without a live drag — the pointer was released
+/// after Escape cancelled it — and the tracked position is then only cleared,
+/// never acted on.
+fn finish_image_move(editor: &mut Editor, dropped: bool, cx: &mut Context<Editor>) {
+    let Some((range, target_row)) = editor
+        .addon_mut::<LivePreviewAddon>()
+        .and_then(|addon| addon.image_move.take())
+    else {
+        return;
+    };
+    editor.clear_row_highlights::<ImageDropTarget>();
+    if let Some(target_row) = target_row
+        && dropped
+    {
+        move_image_to_row(editor, &range, target_row, cx);
+    }
+    cx.notify();
+}
+
+/// Moves an image's whole line so it lands above `target_row`, as one undo
+/// step; `target_row` may be one past the last row, meaning the end of the
+/// document. Moving the line rather than the image span is safe because an
+/// image only becomes a block widget when it is alone on its line.
+///
+/// Blank lines are adjusted around both ends so the image stays a block of its
+/// own: dropped against a paragraph it would otherwise join that paragraph, and
+/// lifted out from between two blank lines it would otherwise leave a widening
+/// gap behind.
+fn move_image_to_row(
+    editor: &mut Editor,
+    range: &Range<Anchor>,
+    target_row: u32,
+    cx: &mut Context<Editor>,
+) {
+    if editor.read_only(cx) {
+        return;
+    }
+    let snapshot = editor.buffer().read(cx).snapshot(cx);
+    let row = range.start.to_point(&snapshot).row;
+    let max_row = snapshot.max_point().row;
+    let target_row = target_row.min(max_row + 1);
+    // Landing above its own line, or above the line under it, leaves the image
+    // exactly where it already is.
+    if target_row == row || target_row == row + 1 {
+        return;
+    }
+
+    let line = |row: u32| -> String {
+        let start = Point::new(row, 0);
+        let end = Point::new(row, snapshot.line_len(MultiBufferRow(row)));
+        snapshot.text_for_range(start..end).collect()
+    };
+    let is_blank = |row: u32| line(row).trim().is_empty();
+    let line_text = line(row);
+
+    // The line's own newline travels with it, or the one in front of it when
+    // the image is the last line in the buffer.
+    let cut = if row < max_row {
+        // An image sitting alone between two blank lines takes one of them
+        // with it, so repeated moves do not widen the gap it leaves behind.
+        let stranded_blank = row > 0 && row + 1 < max_row && is_blank(row - 1) && is_blank(row + 1);
+        let cut_end_row = if stranded_blank { row + 2 } else { row + 1 };
+        Point::new(row, 0)..Point::new(cut_end_row, 0)
+    } else if row > 0 {
+        Point::new(row - 1, snapshot.line_len(MultiBufferRow(row - 1)))
+            ..Point::new(row, snapshot.line_len(MultiBufferRow(row)))
+    } else {
+        Point::new(row, 0)..Point::new(row, snapshot.line_len(MultiBufferRow(row)))
+    };
+
+    let (insert_at, insert_text, prefix_len) = if target_row > max_row {
+        let prefix = if is_blank(max_row) { "\n" } else { "\n\n" };
+        (
+            snapshot.max_point(),
+            format!("{prefix}{line_text}"),
+            prefix.len(),
+        )
+    } else {
+        let prefix = if target_row > 0 && !is_blank(target_row - 1) {
+            "\n"
+        } else {
+            ""
+        };
+        let suffix = if is_blank(target_row) { "" } else { "\n" };
+        (
+            Point::new(target_row, 0),
+            format!("{prefix}{line_text}\n{suffix}"),
+            prefix.len(),
+        )
+    };
+
+    let cut = snapshot.point_to_offset(cut.start)..snapshot.point_to_offset(cut.end);
+    let insert_at = snapshot.point_to_offset(insert_at);
+    // Where the image ends up, in the edited buffer: the insertion point, past
+    // any blank line added in front of it, less whatever the cut removed from
+    // above it.
+    let landed_offset = if cut.end <= insert_at {
+        insert_at + prefix_len - (cut.end - cut.start)
+    } else {
+        insert_at + prefix_len
+    };
+    let mut edits = vec![(cut, String::new()), (insert_at..insert_at, insert_text)];
+    edits.sort_by_key(|(range, _)| range.start);
+
+    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+        // The edit refreshes selections, which would otherwise deselect the
+        // widget the reader just dropped.
+        addon.last_resize_at = Some(std::time::Instant::now());
+    }
+    editor.buffer().update(cx, |multibuffer, cx| {
+        multibuffer.edit(edits, None, cx);
+    });
+
+    let snapshot = editor.buffer().read(cx).snapshot(cx);
+    let landed_row = landed_offset.to_point(&snapshot).row;
+    let start = snapshot.anchor_before(Point::new(landed_row, 0));
+    let end = snapshot.anchor_after(Point::new(
+        landed_row,
+        snapshot.line_len(MultiBufferRow(landed_row)),
+    ));
+    if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+        addon.selected_image = Some(start..end);
+    }
 }
 
 fn render_rule_block(

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -3631,29 +3631,47 @@ impl gpui::Render for EmptyDragPreview {
     }
 }
 
-/// The thumbnail that follows the pointer while an image is being dragged.
+/// The chip that trails the pointer while an image is being dragged,
+/// Obsidian-style: a comfortable distance below-right of the mouse, with the
+/// drop cursor and tinted line marking where the image will land.
+///
+/// gpui paints the drag element at `pointer - grab_offset` and ignores
+/// margins on its root, so the chip is placed with an absolutely-positioned
+/// child offset by `grab_offset` plus the trailing distance, which puts it at
+/// a fixed offset from the live pointer.
 struct ImageDragPreview {
-    source: Option<ImageSource>,
-    alt: SharedString,
+    name: SharedString,
+    grab_offset: gpui::Point<gpui::Pixels>,
 }
 
 impl gpui::Render for ImageDragPreview {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let colors = cx.theme().colors();
-        div()
-            .rounded_sm()
-            .border_1()
-            .border_color(colors.border)
-            .bg(colors.elevated_surface_background)
-            .shadow_md()
-            .p_1()
-            .map(|this| match self.source.clone() {
-                Some(source) => this.child(img(source).w(px(160.)).rounded_sm()),
-                None => this
-                    .px_2()
-                    .text_color(colors.text_muted)
-                    .child(self.alt.clone()),
-            })
+        div().size_0().child(
+            div()
+                .absolute()
+                .left(self.grab_offset.x + px(16.))
+                // Vertically centered on the pointer: half the chip's height.
+                .top(self.grab_offset.y - px(13.))
+                .occlude()
+                .child(
+                    h_flex()
+                        .gap_1p5()
+                        .px_2()
+                        .py_1()
+                        .rounded_md()
+                        .border_1()
+                        .border_color(colors.border)
+                        .bg(colors.elevated_surface_background)
+                        .shadow_md()
+                        .child(
+                            Icon::new(IconName::Image)
+                                .size(IconSize::Small)
+                                .color(Color::Muted),
+                        )
+                        .child(Label::new(self.name.clone()).size(LabelSize::Small)),
+                ),
+        )
     }
 }
 
@@ -3746,12 +3764,22 @@ fn render_image_block(
             resolve_image_source(destination, base_directory.as_deref(), &image_cache)
         });
         let muted = block_cx.app.theme().colors().text_muted;
-        let preview_source = resolved.clone();
-        let preview_alt: SharedString = if alt.is_empty() {
-            destination.clone().unwrap_or_default().into()
-        } else {
-            alt.clone()
-        };
+        let preview_name: SharedString = destination
+            .as_deref()
+            .and_then(|destination| {
+                Path::new(destination)
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+            })
+            .map(SharedString::from)
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| {
+                if alt.is_empty() {
+                    SharedString::from("image")
+                } else {
+                    alt.clone()
+                }
+            });
         let move_range = range.clone();
         let image_content: gpui::AnyElement = match (&destination, resolved) {
             (Some(_), Some(source)) => {
@@ -3789,9 +3817,20 @@ fn render_image_block(
         };
 
         let mut content = div()
-            // Only so the image itself can start a drag; `on_drag` is a
-            // stateful-element API.
-            .id("mdlp-image-body")
+            // `on_drag` is a stateful-element API, and the id must be unique
+            // per block: `Block::Custom` renders this closure with no id scope
+            // of its own, so a shared static id here would make every image
+            // block share one element-state entry — including the pending
+            // mouse-down that arms a drag, letting a different image's
+            // listener claim the gesture and drag the wrong image.
+            .id(block_cx.block_id)
+            // A no-op outside test builds.
+            .debug_selector(|| {
+                format!(
+                    "MDLP-IMAGE-{}",
+                    destination.as_deref().unwrap_or(alt.as_ref())
+                )
+            })
             .relative()
             .border_2()
             .rounded_sm()
@@ -3804,12 +3843,15 @@ fn render_image_block(
             })
             .when(content_width.is_none(), |this| this.max_w(max_width * 0.66))
             .child(image_content)
-            .on_drag(ImageMoveDrag { range: move_range }, move |_, _, _, cx| {
-                cx.new(|_| ImageDragPreview {
-                    source: preview_source.clone(),
-                    alt: preview_alt.clone(),
-                })
-            });
+            .on_drag(
+                ImageMoveDrag { range: move_range },
+                move |_, grab_offset, _, cx| {
+                    cx.new(|_| ImageDragPreview {
+                        name: preview_name.clone(),
+                        grab_offset,
+                    })
+                },
+            );
 
         if selected {
             content = content
@@ -3902,16 +3944,17 @@ fn render_image_block(
             .on_drag_move::<ImageMoveDrag>({
                 let editor = move_editor.clone();
                 let range = move_drag_range;
-                move |event, _window, cx| {
+                move |event, window, cx| {
                     if event.drag(cx).range != range {
                         return;
                     }
                     let position = event.event.position;
                     editor
                         .update(cx, |editor, cx| {
-                            let target_row =
-                                editor.buffer_row_at_position(position).map(|row| row.0);
-                            track_image_drop_target(editor, &range, target_row, cx);
+                            let boundary = editor
+                                .buffer_row_boundary_at_position(position)
+                                .map(|row| row.0);
+                            track_image_drop_target(editor, &range, boundary, window, cx);
                         })
                         .log_err();
                 }
@@ -3980,42 +4023,64 @@ fn resize_image_to_width(
     });
 }
 
-/// Records where a dragged image would land and highlights that row, so the
-/// drop point is visible while the pointer moves. `target_row` is `None` when
-/// the pointer is outside the text area, and may be one past the last row,
-/// which highlights the last row instead — the image lands below it.
+/// Records the boundary a dragged image would land at and shows it two ways:
+/// the editor's own cursor moves to the drop point — a caret walking through
+/// the text as the reader drags, the same feedback dragging text gives — and
+/// the line the image will land above is tinted. `boundary` means "lands
+/// above this row"; it is `None` when the pointer is outside the text area,
+/// and may be one past the last row.
 fn track_image_drop_target(
     editor: &mut Editor,
     range: &Range<Anchor>,
-    target_row: Option<u32>,
+    boundary: Option<u32>,
+    window: &mut Window,
     cx: &mut Context<Editor>,
 ) {
     let unchanged = editor.addon::<LivePreviewAddon>().is_some_and(|addon| {
         addon
             .image_move
             .as_ref()
-            .is_some_and(|(_, row)| *row == target_row)
+            .is_some_and(|(_, row)| *row == boundary)
     });
     if unchanged {
         return;
     }
     if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
-        addon.image_move = Some((range.clone(), target_row));
+        addon.image_move = Some((range.clone(), boundary));
     }
     editor.clear_row_highlights::<ImageDropTarget>();
-    if let Some(target_row) = target_row {
+    if let Some(boundary) = boundary {
         let snapshot = editor.buffer().read(cx).snapshot(cx);
-        let row = target_row.min(snapshot.max_point().row);
+        let max_row = snapshot.max_point().row;
+        let cursor = if boundary > max_row {
+            snapshot.max_point()
+        } else {
+            Point::new(boundary, 0)
+        };
+        let cursor = snapshot.point_to_offset(cursor);
+        let row = boundary.min(max_row);
         let start = snapshot.anchor_before(Point::new(row, 0));
         let end = snapshot.anchor_after(Point::new(row, snapshot.line_len(MultiBufferRow(row))));
         editor.highlight_rows::<ImageDropTarget>(
             start..end,
-            |cx| cx.theme().colors().drop_target_background,
+            |cx| {
+                let mut color = cx.theme().colors().text_accent;
+                color.a = 0.2;
+                color
+            },
             RowHighlightOptions {
                 autoscroll: false,
                 include_gutter: true,
             },
             cx,
+        );
+        editor.change_selections(
+            editor::SelectionEffects::default().nav_history(false),
+            window,
+            cx,
+            |selections| {
+                selections.select_ranges([cursor..cursor]);
+            },
         );
     }
     cx.notify();

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -871,6 +871,185 @@ async fn test_image_size_syntax(cx: &mut TestAppContext) {
     assert_eq!(widths, vec![Some(640.), Some(320.), None]);
 }
 
+/// Drives the drop half of an image drag: moves the image on `row` so it lands
+/// above `target_row`, which is what `finish_image_move` does on mouse up.
+fn drop_image_on_row(cx: &mut EditorTestContext, row: u32, target_row: u32) {
+    cx.update_editor(|editor, _, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let range = snapshot.anchor_before(Point::new(row, 0))
+            ..snapshot.anchor_after(Point::new(row, snapshot.line_len(MultiBufferRow(row))));
+        move_image_to_row(editor, &range, target_row, cx);
+    });
+    cx.executor().run_until_parked();
+}
+
+/// The pointer-to-row mapping that decides where a dragged image lands, driven
+/// against a really painted editor. It is the one piece of the drag built on
+/// hand-rolled geometry, and nothing else would catch it drifting.
+#[gpui::test]
+async fn test_the_pointer_maps_to_the_row_under_it(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state("ˇone\ntwo\nthree\n");
+    cx.executor().run_until_parked();
+
+    // `pixel_position_for` reports the middle of the row, not its top.
+    let row_center = |cx: &mut EditorTestContext, row: u32| {
+        cx.pixel_position_for(editor::DisplayPoint::new(
+            editor::display_map::DisplayRow(row),
+            0,
+        ))
+    };
+    let line_height = row_center(&mut cx, 1).y - row_center(&mut cx, 0).y;
+
+    for row in 0..4 {
+        let position = row_center(&mut cx, row);
+        let mapped = cx.update_editor(|editor, _, _| editor.buffer_row_at_position(position));
+        assert_eq!(
+            mapped.map(|row| row.0),
+            Some(row),
+            "a pointer inside row {row} mapped elsewhere, so an image dropped \
+             there would land on the wrong line"
+        );
+    }
+
+    // Below every line, so an image can be dropped past the end of the
+    // document rather than only ever above some existing line.
+    let below = row_center(&mut cx, 3);
+    let below = gpui::point(below.x, below.y + line_height * 2.);
+    let mapped = cx.update_editor(|editor, _, _| editor.buffer_row_at_position(below));
+    assert_eq!(mapped.map(|row| row.0), Some(4));
+}
+
+#[gpui::test]
+async fn test_dragging_an_image_moves_its_whole_line(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇfirst
+
+        ![shot](a.png)
+
+        last
+    "});
+    cx.executor().run_until_parked();
+
+    drop_image_on_row(&mut cx, 2, 0);
+
+    pretty_assertions::assert_eq!(
+        cx.buffer_text(),
+        indoc::indoc! {"
+            ![shot](a.png)
+
+            first
+
+            last
+        "},
+        "the image should have moved above the first line, taking one of the \
+         blank lines that surrounded it rather than leaving both behind"
+    );
+}
+
+#[gpui::test]
+async fn test_dragging_an_image_down_lands_above_the_target_line(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇ![shot](a.png)
+        one
+        two
+        three
+    "});
+    cx.executor().run_until_parked();
+
+    // Rows shift up by one once the image line is cut, which the move has to
+    // account for or the image lands a line short.
+    drop_image_on_row(&mut cx, 0, 3);
+
+    pretty_assertions::assert_eq!(
+        cx.buffer_text(),
+        indoc::indoc! {"
+            one
+            two
+
+            ![shot](a.png)
+
+            three
+        "},
+        "the image landed against its neighbours, which in markdown makes it \
+         part of their paragraph instead of a block of its own"
+    );
+}
+
+#[gpui::test]
+async fn test_dragging_an_image_past_the_last_line_appends_it(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state("ˇ![shot](a.png)\none\ntwo");
+    cx.executor().run_until_parked();
+
+    // One past the last row is what `buffer_row_at_position` reports when the
+    // pointer is below every line.
+    drop_image_on_row(&mut cx, 0, 3);
+
+    pretty_assertions::assert_eq!(cx.buffer_text(), "one\ntwo\n\n![shot](a.png)");
+}
+
+#[gpui::test]
+async fn test_dragging_the_last_line_image_up_leaves_no_blank_line(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    // No trailing newline, so the image's line has no newline of its own to
+    // travel with; the one in front of it has to move instead.
+    cx.set_state("ˇone\ntwo\n![shot](a.png)");
+    cx.executor().run_until_parked();
+
+    drop_image_on_row(&mut cx, 2, 0);
+
+    pretty_assertions::assert_eq!(cx.buffer_text(), "![shot](a.png)\n\none\ntwo");
+}
+
+#[gpui::test]
+async fn test_dropping_an_image_where_it_already_is_changes_nothing(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    let original = indoc::indoc! {"
+        one
+        ![shot](a.png)
+        two
+    "};
+    cx.set_state(&format!("ˇ{original}"));
+    cx.executor().run_until_parked();
+
+    // Landing above its own line, and above the line under it, are both where
+    // the image already sits.
+    drop_image_on_row(&mut cx, 1, 1);
+    pretty_assertions::assert_eq!(cx.buffer_text(), original);
+    drop_image_on_row(&mut cx, 1, 2);
+    pretty_assertions::assert_eq!(cx.buffer_text(), original);
+}
+
+#[gpui::test]
+async fn test_a_moved_image_stays_selected(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇone
+        two
+        ![shot](a.png)
+    "});
+    cx.executor().run_until_parked();
+
+    drop_image_on_row(&mut cx, 2, 0);
+
+    let selected_row = cx.update_editor(|editor, _, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        editor
+            .addon::<LivePreviewAddon>()
+            .and_then(|addon| addon.selected_image.clone())
+            .map(|range| range.start.to_point(&snapshot).row)
+    });
+    assert_eq!(
+        selected_row,
+        Some(0),
+        "the widget lost its selection border on drop, so its handles vanish \
+         the moment it lands"
+    );
+}
+
 #[test]
 fn test_with_image_width_rewrites_alt() {
     assert_eq!(
@@ -3315,4 +3494,73 @@ async fn test_expanded_diff_hunks_reveal_plain_source(cx: &mut TestAppContext) {
         "collapsing the hunks brings the preview back"
     );
     assert!(cx.display_text().contains("some bold text"));
+}
+
+/// The image drag follows the pointer across the whole document, which only
+/// works because gpui delivers `on_drag_move` to every painted listener of the
+/// dragged type, not just those under the pointer. If upstream started gating
+/// it on the element's bounds, dragging an image would stop tracking the moment
+/// the pointer left the image itself.
+#[gpui::test]
+fn test_drag_move_fires_outside_the_element(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    struct Dragged;
+
+    struct DragSource(Rc<Cell<usize>>);
+
+    impl Render for DragSource {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let moves = self.0.clone();
+            div().size_full().child(
+                div()
+                    .id("source")
+                    .debug_selector(|| "SOURCE".into())
+                    .w(gpui::px(20.))
+                    .h(gpui::px(20.))
+                    .on_drag(Dragged, |_, _, _, cx| cx.new(|_| EmptyDragPreview))
+                    .on_drag_move::<Dragged>(move |_, _, _| {
+                        moves.set(moves.get() + 1);
+                    }),
+            )
+        }
+    }
+
+    let moves = Rc::new(Cell::new(0));
+    let (_view, cx) = cx.add_window_view({
+        let moves = moves.clone();
+        move |_window, _cx| DragSource(moves)
+    });
+    cx.run_until_parked();
+
+    let bounds = cx
+        .debug_bounds("SOURCE")
+        .expect("the drag source should have been laid out");
+    cx.simulate_event(MouseDownEvent {
+        position: bounds.center(),
+        button: MouseButton::Left,
+        modifiers: Modifiers::default(),
+        click_count: 1,
+        first_mouse: false,
+    });
+    // Past the drag threshold, but still over the source, so the drag starts.
+    cx.simulate_event(gpui::MouseMoveEvent {
+        position: bounds.center() + gpui::point(gpui::px(8.), gpui::px(0.)),
+        pressed_button: Some(MouseButton::Left),
+        modifiers: Modifiers::default(),
+    });
+    cx.run_until_parked();
+
+    let moves_before = moves.get();
+    cx.simulate_event(gpui::MouseMoveEvent {
+        position: bounds.center() + gpui::point(gpui::px(300.), gpui::px(300.)),
+        pressed_button: Some(MouseButton::Left),
+        modifiers: Modifiers::default(),
+    });
+
+    assert!(
+        moves.get() > moves_before,
+        "gpui stopped delivering `on_drag_move` for pointer moves outside the \
+         dragged element, so an image drag can no longer track the pointer"
+    );
 }

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -883,11 +883,133 @@ fn drop_image_on_row(cx: &mut EditorTestContext, row: u32, target_row: u32) {
     cx.executor().run_until_parked();
 }
 
-/// The pointer-to-row mapping that decides where a dragged image lands, driven
-/// against a really painted editor. It is the one piece of the drag built on
-/// hand-rolled geometry, and nothing else would catch it drifting.
+/// The whole gesture, end to end, through real event dispatch: press on one
+/// of two image widgets, drag past the arming threshold, cross the document,
+/// release. This is what catches wiring bugs the unit tests cannot — most
+/// importantly that the image that moves is the one that was pressed, which
+/// broke in the field when every image block shared one element id and any
+/// block's listener could claim the gesture.
 #[gpui::test]
-async fn test_the_pointer_maps_to_the_row_under_it(cx: &mut TestAppContext) {
+async fn test_the_full_drag_gesture_moves_the_pressed_image(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state("ˇtop\n\n![first](a.png)\n\n![second](b.png)\n\nbottom");
+    cx.executor().run_until_parked();
+
+    let first = cx
+        .cx
+        .debug_bounds("MDLP-IMAGE-a.png")
+        .expect("the first image widget should have been laid out");
+
+    // Press the first image and move past gpui's drag-arming threshold.
+    cx.cx.simulate_event(MouseDownEvent {
+        position: first.center(),
+        button: MouseButton::Left,
+        modifiers: Modifiers::default(),
+        click_count: 1,
+        first_mouse: false,
+    });
+    cx.cx.simulate_event(gpui::MouseMoveEvent {
+        position: first.center() + gpui::point(gpui::px(8.), gpui::px(8.)),
+        pressed_button: Some(MouseButton::Left),
+        modifiers: Modifiers::default(),
+    });
+    cx.executor().run_until_parked();
+
+    // Drag to the upper half of the last line, targeting the boundary above
+    // it, and release there.
+    let last_display_row =
+        cx.update_editor(|editor, _, cx| editor.display_snapshot(cx).max_point().row());
+    let last_line = cx.pixel_position_for(editor::DisplayPoint::new(last_display_row, 0));
+    let drop_position = gpui::point(last_line.x, last_line.y - gpui::px(2.));
+    cx.cx.simulate_event(gpui::MouseMoveEvent {
+        position: drop_position,
+        pressed_button: Some(MouseButton::Left),
+        modifiers: Modifiers::default(),
+    });
+    cx.executor().run_until_parked();
+    cx.cx.simulate_event(gpui::MouseUpEvent {
+        position: drop_position,
+        button: MouseButton::Left,
+        modifiers: Modifiers::default(),
+        click_count: 1,
+    });
+    cx.executor().run_until_parked();
+
+    pretty_assertions::assert_eq!(
+        cx.buffer_text(),
+        "top\n\n![second](b.png)\n\n![first](a.png)\n\nbottom",
+        "the image that moves must be the one that was pressed"
+    );
+}
+
+/// Sweeping a drag across heading widgets and other image widgets must keep
+/// the drop cursor tracking the pointer the whole way; in the field the caret
+/// froze partway through such a sweep while the pointer kept moving.
+#[gpui::test]
+async fn test_drop_tracking_survives_a_sweep_across_widgets(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(
+        "ˇ# Title\n\nintro paragraph\n\n## Section\n\nfirst\n\n![a](a.png)\n\n![b](b.png)\n\nbottom",
+    );
+    cx.executor().run_until_parked();
+
+    let second = cx
+        .cx
+        .debug_bounds("MDLP-IMAGE-b.png")
+        .expect("the second image widget should have been laid out");
+    let first = cx
+        .cx
+        .debug_bounds("MDLP-IMAGE-a.png")
+        .expect("the first image widget should have been laid out");
+
+    cx.cx.simulate_event(MouseDownEvent {
+        position: second.center(),
+        button: MouseButton::Left,
+        modifiers: Modifiers::default(),
+        click_count: 1,
+        first_mouse: false,
+    });
+    cx.cx.simulate_event(gpui::MouseMoveEvent {
+        position: second.center() + gpui::point(gpui::px(8.), gpui::px(8.)),
+        pressed_button: Some(MouseButton::Left),
+        modifiers: Modifiers::default(),
+    });
+    cx.executor().run_until_parked();
+
+    // Sweep upward through the first image widget and the headings to the
+    // very top of the document, in small steps like a real pointer.
+    let x = first.center().x;
+    let mut y = second.center().y;
+    let top = gpui::px(4.);
+    while y > top {
+        y -= gpui::px(20.);
+        cx.cx.simulate_event(gpui::MouseMoveEvent {
+            position: gpui::point(x, y.max(top)),
+            pressed_button: Some(MouseButton::Left),
+            modifiers: Modifiers::default(),
+        });
+        cx.executor().run_until_parked();
+    }
+
+    let cursor_row = cx.update_editor(|editor, _, cx| {
+        editor
+            .selections
+            .newest::<Point>(&editor.display_snapshot(cx))
+            .head()
+            .row
+    });
+    assert_eq!(
+        cursor_row, 0,
+        "after sweeping to the top of the document the drop cursor should \
+         have followed the pointer to row 0, not frozen partway"
+    );
+}
+
+/// The pointer-to-boundary mapping that decides where a dragged image lands,
+/// driven against a really painted editor. It is the one piece of the drag
+/// built on hand-rolled geometry, and nothing else would catch it drifting.
+#[gpui::test]
+async fn test_the_pointer_maps_to_the_nearest_row_boundary(cx: &mut TestAppContext) {
     let mut cx = markdown_test_context(cx).await;
     cx.set_state("ˇone\ntwo\nthree\n");
     cx.executor().run_until_parked();
@@ -901,14 +1023,29 @@ async fn test_the_pointer_maps_to_the_row_under_it(cx: &mut TestAppContext) {
     };
     let line_height = row_center(&mut cx, 1).y - row_center(&mut cx, 0).y;
 
+    let boundary_at = |cx: &mut EditorTestContext, position: gpui::Point<gpui::Pixels>| {
+        cx.update_editor(|editor, _, _| {
+            editor
+                .buffer_row_boundary_at_position(position)
+                .map(|row| row.0)
+        })
+    };
+
+    // The upper half of a line maps to the boundary above it, the lower half
+    // to the boundary below.
     for row in 0..4 {
-        let position = row_center(&mut cx, row);
-        let mapped = cx.update_editor(|editor, _, _| editor.buffer_row_at_position(position));
+        let center = row_center(&mut cx, row);
+        let upper = gpui::point(center.x, center.y - line_height / 4.);
+        let lower = gpui::point(center.x, center.y + line_height / 4.);
         assert_eq!(
-            mapped.map(|row| row.0),
+            boundary_at(&mut cx, upper),
             Some(row),
-            "a pointer inside row {row} mapped elsewhere, so an image dropped \
-             there would land on the wrong line"
+            "the upper half of row {row} should target the boundary above it"
+        );
+        assert_eq!(
+            boundary_at(&mut cx, lower),
+            Some(row + 1),
+            "the lower half of row {row} should target the boundary below it"
         );
     }
 
@@ -916,8 +1053,7 @@ async fn test_the_pointer_maps_to_the_row_under_it(cx: &mut TestAppContext) {
     // document rather than only ever above some existing line.
     let below = row_center(&mut cx, 3);
     let below = gpui::point(below.x, below.y + line_height * 2.);
-    let mapped = cx.update_editor(|editor, _, _| editor.buffer_row_at_position(below));
-    assert_eq!(mapped.map(|row| row.0), Some(4));
+    assert_eq!(boundary_at(&mut cx, below), Some(4));
 }
 
 #[gpui::test]

--- a/crates/suzuri_update/src/suzuri_update.rs
+++ b/crates/suzuri_update/src/suzuri_update.rs
@@ -52,7 +52,7 @@ use workspace::{
 /// Bump it in the same commit that gets tagged `suzuri-v<this version>`; the
 /// `check-version` job in `.github/workflows/suzuri-release.yml` enforces that
 /// the two agree.
-pub const SUZURI_VERSION: &str = "0.4.0";
+pub const SUZURI_VERSION: &str = "0.4.1";
 
 /// The repository whose releases describe newer Suzuri builds.
 const RELEASE_REPOSITORY: &str = "harrywang/suzuri";


### PR DESCRIPTION
An inserted image could be selected, resized, and reverted to source, but not moved — repositioning one meant cutting and pasting its markdown by hand. Dragging the widget now picks it up, Obsidian-style: a chip with the file name trails the pointer, the editor's cursor walks through the text to the exact drop point, the landing line is tinted, and releasing drops the image there. Escape cancels; each move is one undo step, and the widget stays selected where it lands.

## How it works

- The gesture rides gpui's own drag machinery rather than the editor's character-granular text drag. `on_drag_move` is delivered to every painted listener of the dragged type, which is what lets one image block track the pointer across the whole document; a contract test pins that behavior.
- Mapping the pointer to a drop target needs the editor's private position map, so `Editor` gains one `SUZURI:`-tagged accessor (`buffer_row_boundary_at_position`) with half-line precision: the upper half of a line — or of a tall image widget — targets the seam above it, the lower half the seam below. One past the last row means "append at the end".
- The move takes the image's whole line (safe: an image only becomes a widget when alone on its line) and normalizes blank lines at both ends, so a drop against a paragraph doesn't get absorbed into it and repeated moves don't widen the gap left behind.

## Field-tested fixes worth reviewer attention

- **`Block::Custom` renders with no element-id scope**, so a static id on the drag container made every image block share one element-state entry — including the pending mouse-down that arms a drag — letting a different image's listener claim the gesture and move the wrong image. The container is now keyed by its block id, and an end-to-end test drives the full gesture through real event dispatch (it fails on the shared id).
- **gpui ignores margins on the drag overlay's root**, so the chip is positioned with an absolutely-placed child offset from the grab point instead.

## Tests

- 6 behavior tests for the move semantics (direction correction, append-at-end, blank-line handling, no-op drops, selection retention)
- A painted-geometry test for the pointer-to-boundary mapping
- An end-to-end gesture test through real mouse-event dispatch
- Contract tests pinning the upstream gpui behaviors this leans on

`cargo nextest run -p markdown_live_preview -p editor`: 1019 passed. Manually tested through several rounds with real dragging.

## Suggested .rules additions

Two gpui traps bitten (twice each) during this work, for reviewer consideration:

- `Block::Custom` render closures get no element-id scope from the editor, unlike every other block kind — any stateful element (`.id(...)`) inside a custom block must derive its id from `BlockContext::block_id`, or all instances of that widget share one element-state entry (drag arming, click state).
- gpui paints the drag overlay at `pointer - grab_offset` and ignores margins on the overlay's root element — position drag-preview content with an absolutely-placed child, never root margins.

Release Notes:

- Added Obsidian-style drag-to-move for image widgets in markdown live preview: drag an image to any line, guided by a pointer chip, a drop cursor, and a tinted landing line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125fSTvsVw36hQ11XX64JLP
