### PR TITLE
markdown_live_preview: Add bibliography-backed citation pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10762,8 +10762,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "biblatex",
+ "clock",
  "collections",
  "editor",
+ "futures 0.3.32",
  "fuzzy",
  "gpui",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23372,6 +23372,7 @@ dependencies = [
  "title_bar",
  "toolchain_selector",
  "tracing",
+ "tree-sitter-md",
  "typeset_preview",
  "ui",
  "ui_prompt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,6 +2180,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "biblatex"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591eba69b7c085632e22ca03606f0bbea68d53bbe26c8962e2d549af20c6a561"
+dependencies = [
+ "paste",
+ "roman-numerals-rs",
+ "strum 0.27.2",
+ "unicode-normalization",
+ "unscanny",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10748,13 +10761,16 @@ name = "markdown_live_preview"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "biblatex",
  "collections",
  "editor",
+ "fuzzy",
  "gpui",
  "image",
  "indoc",
  "language",
  "log",
+ "lsp",
  "markdown",
  "math_render",
  "multi_buffer",
@@ -15736,6 +15752,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roman-numerals-rs"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
+
+[[package]]
 name = "rope"
 version = "0.1.0"
 dependencies = [
@@ -17827,6 +17849,15 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
 
 [[package]]
 name = "strum"
@@ -20008,6 +20039,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -573,6 +573,7 @@ aws-smithy-types = { version = "1.3.4", features = ["http-body-1-x"] }
 backtrace = "0.3"
 base64 = "0.22"
 betlang = "0.1.1"
+biblatex = "0.12"
 bitflags = "2.6.0"
 block = "0.1"
 block2 = "0.6"

--- a/crates/markdown_live_preview/Cargo.toml
+++ b/crates/markdown_live_preview/Cargo.toml
@@ -13,8 +13,10 @@ path = "src/markdown_live_preview.rs"
 
 [dependencies]
 anyhow.workspace = true
+biblatex.workspace = true
 collections.workspace = true
 editor.workspace = true
+fuzzy.workspace = true
 gpui.workspace = true
 log.workspace = true
 language.workspace = true
@@ -38,6 +40,7 @@ gpui = { workspace = true, features = ["test-support"] }
 image.workspace = true
 indoc.workspace = true
 language = { workspace = true, features = ["test-support"] }
+lsp.workspace = true
 pretty_assertions.workspace = true
 project = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }

--- a/crates/markdown_live_preview/Cargo.toml
+++ b/crates/markdown_live_preview/Cargo.toml
@@ -14,8 +14,10 @@ path = "src/markdown_live_preview.rs"
 [dependencies]
 anyhow.workspace = true
 biblatex.workspace = true
+clock.workspace = true
 collections.workspace = true
 editor.workspace = true
+futures.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
 log.workspace = true

--- a/crates/markdown_live_preview/src/bibliography.rs
+++ b/crates/markdown_live_preview/src/bibliography.rs
@@ -356,7 +356,11 @@ impl CompletionProvider for CitationCompletionProvider {
                     .collect();
                 return Task::ready(Ok(vec![CompletionResponse {
                     completions,
-                    display_options: CompletionDisplayOptions::default(),
+                    // Cite keys are short; without dynamic width the menu
+                    // pads out to the stock LSP width and dwarfs its rows.
+                    display_options: CompletionDisplayOptions {
+                        dynamic_width: true,
+                    },
                     is_incomplete: false,
                 }]));
             }

--- a/crates/markdown_live_preview/src/bibliography.rs
+++ b/crates/markdown_live_preview/src/bibliography.rs
@@ -73,6 +73,10 @@ pub struct Bibliography {
     /// Parsed entries per absolute `.bib` path. A file that fails to parse
     /// holds an empty list, which also serves as its tombstone on deletion.
     files: HashMap<PathBuf, Vec<BibEntry>>,
+    /// Every key across `files`. The highlight pass resolves each citation
+    /// in a note on every keystroke, so membership has to be O(1) rather
+    /// than a scan over what may be a Zotero-sized library.
+    keys: HashSet<SharedString>,
     /// Projects whose worktrees have already been walked, so each is scanned
     /// once; later changes arrive through `WorktreeUpdatedEntries`.
     scanned_projects: HashSet<EntityId>,
@@ -89,6 +93,7 @@ impl Bibliography {
         }
         let bibliography = cx.new(|_| Bibliography {
             files: HashMap::default(),
+            keys: HashSet::default(),
             scanned_projects: HashSet::default(),
         });
         cx.set_global(GlobalBibliography(bibliography.clone()));
@@ -99,8 +104,21 @@ impl Bibliography {
         self.files.values().any(|entries| !entries.is_empty())
     }
 
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.keys.contains(key)
+    }
+
     pub fn resolve(&self, key: &str) -> Option<&BibEntry> {
         self.entries().find(|entry| entry.key.as_ref() == key)
+    }
+
+    fn rebuild_keys(&mut self) {
+        self.keys = self
+            .files
+            .values()
+            .flatten()
+            .map(|entry| entry.key.clone())
+            .collect();
     }
 
     pub fn entries(&self) -> impl Iterator<Item = &BibEntry> {
@@ -163,6 +181,7 @@ impl Bibliography {
                 for (path, entries) in results {
                     bibliography.files.insert(path, entries);
                 }
+                bibliography.rebuild_keys();
                 cx.notify();
             })
         })
@@ -172,6 +191,7 @@ impl Bibliography {
     pub fn remove_path(bibliography: &Entity<Bibliography>, path: &Path, cx: &mut App) {
         bibliography.update(cx, |bibliography, cx| {
             if bibliography.files.remove(path).is_some() {
+                bibliography.rebuild_keys();
                 cx.notify();
             }
         });

--- a/crates/markdown_live_preview/src/bibliography.rs
+++ b/crates/markdown_live_preview/src/bibliography.rs
@@ -332,8 +332,13 @@ impl CompletionProvider for CitationCompletionProvider {
         if let Some(replace_range) = citation {
             let bibliography = self.bibliography.read(cx);
             if bibliography.has_entries() {
+                // The same key routinely appears in several `.bib` files
+                // (per-paper copies of one master bibliography); the menu
+                // wants one row per key, not one per file.
+                let mut seen = HashSet::default();
                 let completions = bibliography
                     .entries()
+                    .filter(|entry| seen.insert(entry.key.clone()))
                     .map(|entry| Completion {
                         replace_range: replace_range.clone(),
                         new_text: entry.key.to_string(),

--- a/crates/markdown_live_preview/src/bibliography.rs
+++ b/crates/markdown_live_preview/src/bibliography.rs
@@ -1,0 +1,494 @@
+//! Bibliography index backing Pandoc-style `[@key]` citations.
+//!
+//! Every `.bib` file in the project's worktrees is parsed (off the main
+//! thread, via `biblatex`) into a process-wide [`Bibliography`] entity. Two
+//! consumers hang off it: [`CitationCompletionProvider`] serves cite-key
+//! completions when the cursor sits in an `@key` context, and
+//! `apply_emphasis_highlights` styles keys that resolve to no entry as
+//! unresolved — but only once at least one entry exists, so vaults that never
+//! use a bibliography see no red ink.
+//!
+//! The index is global rather than per-editor because `.bib` files are shared
+//! state: every open markdown editor should agree on whether a key resolves,
+//! and a file should be parsed once, not once per editor.
+
+use std::{
+    path::{Path, PathBuf},
+    rc::Rc,
+};
+
+use collections::{HashMap, HashSet};
+use editor::{CompletionProvider, Editor};
+use gpui::{App, AppContext as _, Context, Entity, EntityId, SharedString, Task, Window};
+use language::{Buffer, CodeLabel, LanguageName, ToOffset as _};
+use project::{
+    Completion, CompletionDisplayOptions, CompletionResponse, CompletionSource, Project,
+    lsp_store::CompletionDocumentation,
+};
+use util::ResultExt as _;
+
+/// One entry parsed out of a `.bib` file, reduced to the fields the citation
+/// pipeline shows: enough to pick the right entry from a completion menu and
+/// to recognize it on hover, not a full reference model.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BibEntry {
+    pub key: SharedString,
+    pub title: Option<SharedString>,
+    pub authors: Option<SharedString>,
+    pub year: Option<SharedString>,
+    pub entry_type: SharedString,
+}
+
+impl BibEntry {
+    fn documentation(&self) -> Option<CompletionDocumentation> {
+        let mut text = String::new();
+        if let Some(title) = &self.title {
+            text.push_str(&format!("**{title}**"));
+        }
+        let mut line = String::new();
+        if let Some(authors) = &self.authors {
+            line.push_str(authors);
+        }
+        if let Some(year) = &self.year {
+            if !line.is_empty() {
+                line.push_str(", ");
+            }
+            line.push_str(year);
+        }
+        if !line.is_empty() {
+            if !text.is_empty() {
+                text.push_str("\n\n");
+            }
+            text.push_str(&line);
+        }
+        if text.is_empty() {
+            return None;
+        }
+        text.push_str(&format!("\n\n*{}*", self.entry_type));
+        Some(CompletionDocumentation::MultiLineMarkdown(text.into()))
+    }
+}
+
+pub struct Bibliography {
+    /// Parsed entries per absolute `.bib` path. A file that fails to parse
+    /// holds an empty list, which also serves as its tombstone on deletion.
+    files: HashMap<PathBuf, Vec<BibEntry>>,
+    /// Projects whose worktrees have already been walked, so each is scanned
+    /// once; later changes arrive through `WorktreeUpdatedEntries`.
+    scanned_projects: HashSet<EntityId>,
+}
+
+struct GlobalBibliography(Entity<Bibliography>);
+
+impl gpui::Global for GlobalBibliography {}
+
+impl Bibliography {
+    pub fn global(cx: &mut App) -> Entity<Bibliography> {
+        if let Some(global) = cx.try_global::<GlobalBibliography>() {
+            return global.0.clone();
+        }
+        let bibliography = cx.new(|_| Bibliography {
+            files: HashMap::default(),
+            scanned_projects: HashSet::default(),
+        });
+        cx.set_global(GlobalBibliography(bibliography.clone()));
+        bibliography
+    }
+
+    pub fn has_entries(&self) -> bool {
+        self.files.values().any(|entries| !entries.is_empty())
+    }
+
+    pub fn resolve(&self, key: &str) -> Option<&BibEntry> {
+        self.entries().find(|entry| entry.key.as_ref() == key)
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = &BibEntry> {
+        self.files.values().flatten()
+    }
+
+    /// Walks the project's worktrees for `.bib` files the first time this
+    /// project is seen and queues them for parsing.
+    pub fn ensure_project(
+        bibliography: &Entity<Bibliography>,
+        project: &Entity<Project>,
+        cx: &mut App,
+    ) {
+        let newly_seen = bibliography.update(cx, |bibliography, _| {
+            bibliography.scanned_projects.insert(project.entity_id())
+        });
+        if !newly_seen {
+            return;
+        }
+        let mut paths = Vec::new();
+        for worktree in project.read(cx).worktrees(cx) {
+            let worktree = worktree.read(cx);
+            for entry in worktree.entries(false, 0) {
+                if entry
+                    .path
+                    .extension()
+                    .is_some_and(|extension| extension == "bib")
+                {
+                    paths.push(worktree.absolutize(&entry.path));
+                }
+            }
+        }
+        Self::reload_paths(bibliography, project, paths, cx);
+    }
+
+    /// Loads and parses the given `.bib` paths off the main thread, then
+    /// publishes the results so observers restyle. Paths that no longer load
+    /// (deleted, unreadable) drop their entries instead.
+    pub fn reload_paths(
+        bibliography: &Entity<Bibliography>,
+        project: &Entity<Project>,
+        paths: Vec<PathBuf>,
+        cx: &mut App,
+    ) {
+        if paths.is_empty() {
+            return;
+        }
+        let fs = project.read(cx).fs().clone();
+        let bibliography = bibliography.clone();
+        cx.spawn(async move |cx| {
+            let mut results = Vec::with_capacity(paths.len());
+            for path in paths {
+                let entries = match fs.load(&path).await {
+                    Ok(source) => cx.background_spawn(async move { parse_bib(&source) }).await,
+                    Err(_) => Vec::new(),
+                };
+                results.push((path, entries));
+            }
+            bibliography.update(cx, |bibliography, cx| {
+                for (path, entries) in results {
+                    bibliography.files.insert(path, entries);
+                }
+                cx.notify();
+            })
+        })
+        .detach();
+    }
+
+    pub fn remove_path(bibliography: &Entity<Bibliography>, path: &Path, cx: &mut App) {
+        bibliography.update(cx, |bibliography, cx| {
+            if bibliography.files.remove(path).is_some() {
+                cx.notify();
+            }
+        });
+    }
+}
+
+/// Reduces a BibTeX/BibLaTeX source to the entries' displayable fields. A
+/// source that fails to parse yields nothing: while the user is mid-edit on
+/// their `.bib`, flagging every citation in every note as unresolved would be
+/// noise, so the previous parse (if any) simply goes stale until the file
+/// parses again.
+fn parse_bib(source: &str) -> Vec<BibEntry> {
+    use biblatex::ChunksExt as _;
+
+    let Some(parsed) = biblatex::Bibliography::parse(source).log_err() else {
+        return Vec::new();
+    };
+    parsed
+        .iter()
+        .map(|entry| {
+            let title = entry
+                .title()
+                .ok()
+                .map(|chunks| collapse_whitespace(&chunks.format_verbatim()))
+                .filter(|title| !title.is_empty());
+            let authors = entry.author().ok().map(|people| {
+                people
+                    .iter()
+                    .map(|person| {
+                        let mut name = String::new();
+                        if !person.given_name.is_empty() {
+                            name.push_str(&person.given_name);
+                            name.push(' ');
+                        }
+                        name.push_str(&person.name);
+                        name
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            });
+            let year = entry
+                .get("year")
+                .or_else(|| entry.get("date"))
+                .map(|chunks| chunks.format_verbatim())
+                .and_then(|value| first_year(&value));
+            BibEntry {
+                key: SharedString::from(entry.key.clone()),
+                title: title.map(SharedString::from),
+                authors: authors
+                    .filter(|authors| !authors.is_empty())
+                    .map(SharedString::from),
+                year: year.map(SharedString::from),
+                entry_type: SharedString::from(entry.entry_type.to_string()),
+            }
+        })
+        .collect()
+}
+
+/// `.bib` titles often carry the file's own line wrapping; a completion
+/// menu wants them on one line.
+fn collapse_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// First run of four consecutive digits, so both `2024` and `2024-03-01`
+/// (BibLaTeX `date`) yield a year.
+fn first_year(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut run_start = None;
+    for (index, byte) in bytes.iter().enumerate() {
+        if byte.is_ascii_digit() {
+            let start = *run_start.get_or_insert(index);
+            if index - start + 1 == 4 {
+                return Some(value[start..=index].to_string());
+            }
+        } else {
+            run_start = None;
+        }
+    }
+    None
+}
+
+/// Wraps the editor's stock (project-backed) completion provider, serving
+/// cite keys when the cursor sits in a Pandoc `@key` context in a markdown
+/// buffer and delegating everything else untouched — LSP completions from
+/// markdown-oxide and friends keep working.
+pub struct CitationCompletionProvider {
+    inner: Rc<dyn CompletionProvider>,
+    bibliography: Entity<Bibliography>,
+}
+
+impl CitationCompletionProvider {
+    pub fn new(project: Entity<Project>, cx: &mut App) -> Self {
+        Self {
+            inner: Rc::new(project),
+            bibliography: Bibliography::global(cx),
+        }
+    }
+}
+
+/// Where the key being typed starts (just after the `@`), if `offset` sits in
+/// a citation context: an `@` preceded by a Pandoc citation boundary, with
+/// nothing but key characters between it and the cursor. Mirrors the
+/// tolerances of `citation_keys`, which decides what ultimately renders as a
+/// citation chip.
+pub(crate) fn citation_key_start(buffer: &Buffer, offset: usize) -> Option<usize> {
+    let is_key_char = |character: char| {
+        character.is_ascii_alphanumeric()
+            || matches!(
+                character,
+                '_' | ':' | '.' | '#' | '$' | '%' | '&' | '-' | '+' | '?' | '<' | '>' | '~' | '/'
+            )
+    };
+    let mut walked = 0;
+    let mut characters = buffer.reversed_chars_at(offset);
+    loop {
+        let character = characters.next()?;
+        if character == '@' {
+            break;
+        }
+        if !is_key_char(character) || walked > 128 {
+            return None;
+        }
+        walked += character.len_utf8();
+    }
+    let boundary = match characters.next() {
+        None => true,
+        Some(character) => character.is_whitespace() || matches!(character, ';' | '-' | '['),
+    };
+    boundary.then_some(offset - walked)
+}
+
+fn buffer_is_markdown(buffer: &Buffer) -> bool {
+    buffer
+        .language()
+        .is_some_and(|language| language.name() == LanguageName::new(crate::MARKDOWN))
+}
+
+impl CompletionProvider for CitationCompletionProvider {
+    fn completions(
+        &self,
+        buffer: &Entity<Buffer>,
+        buffer_position: text::Anchor,
+        trigger: editor::CompletionContext,
+        window: &mut Window,
+        cx: &mut Context<Editor>,
+    ) -> Task<anyhow::Result<Vec<CompletionResponse>>> {
+        let citation = {
+            let buffer = buffer.read(cx);
+            if buffer_is_markdown(buffer) {
+                let offset = buffer_position.to_offset(buffer);
+                citation_key_start(buffer, offset)
+                    .map(|key_start| buffer.anchor_before(key_start)..buffer_position)
+            } else {
+                None
+            }
+        };
+        if let Some(replace_range) = citation {
+            let bibliography = self.bibliography.read(cx);
+            if bibliography.has_entries() {
+                let completions = bibliography
+                    .entries()
+                    .map(|entry| Completion {
+                        replace_range: replace_range.clone(),
+                        new_text: entry.key.to_string(),
+                        label: CodeLabel::plain(entry.key.to_string(), None),
+                        documentation: entry.documentation(),
+                        source: CompletionSource::Custom,
+                        icon_path: None,
+                        icon_color: None,
+                        match_start: Some(replace_range.start),
+                        snippet_deduplication_key: None,
+                        insert_text_mode: None,
+                        confirm: None,
+                        group: None,
+                    })
+                    .collect();
+                return Task::ready(Ok(vec![CompletionResponse {
+                    completions,
+                    display_options: CompletionDisplayOptions::default(),
+                    is_incomplete: false,
+                }]));
+            }
+        }
+        self.inner
+            .completions(buffer, buffer_position, trigger, window, cx)
+    }
+
+    fn resolve_completions(
+        &self,
+        buffer: Entity<Buffer>,
+        completion_indices: Vec<usize>,
+        completions: Rc<std::cell::RefCell<Box<[Completion]>>>,
+        cx: &mut Context<Editor>,
+    ) -> Task<anyhow::Result<bool>> {
+        self.inner
+            .resolve_completions(buffer, completion_indices, completions, cx)
+    }
+
+    fn apply_additional_edits_for_completion(
+        &self,
+        buffer: Entity<Buffer>,
+        completions: Rc<std::cell::RefCell<Box<[Completion]>>>,
+        completion_index: usize,
+        push_to_history: bool,
+        all_commit_ranges: Vec<std::ops::Range<language::Anchor>>,
+        cx: &mut Context<Editor>,
+    ) -> Task<anyhow::Result<Option<language::Transaction>>> {
+        self.inner.apply_additional_edits_for_completion(
+            buffer,
+            completions,
+            completion_index,
+            push_to_history,
+            all_commit_ranges,
+            cx,
+        )
+    }
+
+    fn is_completion_trigger(
+        &self,
+        buffer: &Entity<Buffer>,
+        position: language::Anchor,
+        text: &str,
+        trigger_in_words: bool,
+        cx: &mut Context<Editor>,
+    ) -> bool {
+        if text.ends_with('@')
+            && buffer_is_markdown(buffer.read(cx))
+            && self.bibliography.read(cx).has_entries()
+        {
+            return true;
+        }
+        self.inner
+            .is_completion_trigger(buffer, position, text, trigger_in_words, cx)
+    }
+
+    fn selection_changed(
+        &self,
+        mat: Option<&fuzzy::StringMatch>,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        self.inner.selection_changed(mat, window, cx);
+    }
+
+    fn sort_completions(&self) -> bool {
+        self.inner.sort_completions()
+    }
+
+    fn filter_completions(&self) -> bool {
+        self.inner.filter_completions()
+    }
+
+    fn show_snippets(&self) -> bool {
+        self.inner.show_snippets()
+    }
+}
+
+#[cfg(test)]
+mod bibliography_tests {
+    use super::*;
+
+    #[test]
+    fn parses_entries_with_display_fields() {
+        let entries = parse_bib(
+            r#"
+@article{smith2020,
+  title = {A Study of
+           Wrapped Titles},
+  author = {Smith, Jane and Doe, John},
+  year = {2020},
+  journal = {Journal of Tests},
+}
+
+@book{knuth1984,
+  title = {The {\TeX}book},
+  author = {Knuth, Donald E.},
+  date = {1984-01-01},
+}
+"#,
+        );
+        assert_eq!(entries.len(), 2);
+        let smith = entries
+            .iter()
+            .find(|entry| entry.key.as_ref() == "smith2020")
+            .expect("smith2020 parsed");
+        assert_eq!(
+            smith.title.as_deref(),
+            Some("A Study of Wrapped Titles"),
+            "wrapped title collapses to one line"
+        );
+        assert_eq!(smith.authors.as_deref(), Some("Jane Smith, John Doe"));
+        assert_eq!(smith.year.as_deref(), Some("2020"));
+        assert_eq!(smith.entry_type.as_ref(), "article");
+        let knuth = entries
+            .iter()
+            .find(|entry| entry.key.as_ref() == "knuth1984")
+            .expect("knuth1984 parsed");
+        assert_eq!(
+            knuth.year.as_deref(),
+            Some("1984"),
+            "date field yields a year"
+        );
+    }
+
+    #[test]
+    fn malformed_bib_parses_to_nothing() {
+        assert_eq!(parse_bib("@article{unclosed,"), Vec::new());
+        assert_eq!(parse_bib(""), Vec::new());
+    }
+
+    #[test]
+    fn first_year_finds_four_digit_runs() {
+        assert_eq!(first_year("2024"), Some("2024".to_string()));
+        assert_eq!(first_year("2024-03-01"), Some("2024".to_string()));
+        assert_eq!(first_year("about 1984, maybe"), Some("1984".to_string()));
+        assert_eq!(first_year("no digits"), None);
+        assert_eq!(first_year("123"), None);
+    }
+}

--- a/crates/markdown_live_preview/src/bibliography.rs
+++ b/crates/markdown_live_preview/src/bibliography.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use collections::{HashMap, HashSet};
-use editor::{CompletionProvider, Editor};
+use editor::{CompletionProvider, Editor, SemanticsProvider};
 use gpui::{App, AppContext as _, Context, Entity, EntityId, SharedString, Task, Window};
 use language::{Buffer, CodeLabel, LanguageName, ToOffset as _};
 use project::{
@@ -40,7 +40,9 @@ pub struct BibEntry {
 }
 
 impl BibEntry {
-    fn documentation(&self) -> Option<CompletionDocumentation> {
+    /// The reference as markdown — bolded title, authors and year, entry
+    /// type — shared by the completion card and the hover card.
+    fn reference_markdown(&self) -> Option<String> {
         let mut text = String::new();
         if let Some(title) = &self.title {
             text.push_str(&format!("**{title}**"));
@@ -65,7 +67,13 @@ impl BibEntry {
             return None;
         }
         text.push_str(&format!("\n\n*{}*", self.entry_type));
-        Some(CompletionDocumentation::MultiLineMarkdown(text.into()))
+        Some(text)
+    }
+
+    fn documentation(&self) -> Option<CompletionDocumentation> {
+        Some(CompletionDocumentation::MultiLineMarkdown(
+            self.reference_markdown()?.into(),
+        ))
     }
 }
 
@@ -297,14 +305,24 @@ impl CitationCompletionProvider {
 /// nothing but key characters between it and the cursor. Mirrors the
 /// tolerances of `citation_keys`, which decides what ultimately renders as a
 /// citation chip.
+fn is_citation_key_char(character: char) -> bool {
+    character.is_ascii_alphanumeric()
+        || matches!(
+            character,
+            '_' | ':' | '.' | '#' | '$' | '%' | '&' | '-' | '+' | '?' | '<' | '>' | '~' | '/'
+        )
+}
+
+/// Whether a citation boundary precedes the `@` the reversed iterator has
+/// stopped on: start of text, whitespace, a group separator, or `[`.
+fn citation_boundary(before_at: Option<char>) -> bool {
+    match before_at {
+        None => true,
+        Some(character) => character.is_whitespace() || matches!(character, ';' | '-' | '['),
+    }
+}
+
 pub(crate) fn citation_key_start(buffer: &Buffer, offset: usize) -> Option<usize> {
-    let is_key_char = |character: char| {
-        character.is_ascii_alphanumeric()
-            || matches!(
-                character,
-                '_' | ':' | '.' | '#' | '$' | '%' | '&' | '-' | '+' | '?' | '<' | '>' | '~' | '/'
-            )
-    };
     let mut walked = 0;
     let mut characters = buffer.reversed_chars_at(offset);
     loop {
@@ -312,16 +330,64 @@ pub(crate) fn citation_key_start(buffer: &Buffer, offset: usize) -> Option<usize
         if character == '@' {
             break;
         }
-        if !is_key_char(character) || walked > 128 {
+        if !is_citation_key_char(character) || walked > 128 {
             return None;
         }
         walked += character.len_utf8();
     }
-    let boundary = match characters.next() {
-        None => true,
-        Some(character) => character.is_whitespace() || matches!(character, ';' | '-' | '['),
-    };
-    boundary.then_some(offset - walked)
+    citation_boundary(characters.next()).then_some(offset - walked)
+}
+
+/// The citation key containing `offset`, if any: its full range including
+/// the `@`, plus the key text without it. Bracketed and bare citations look
+/// identical from here — an `@` after a boundary followed by key characters.
+pub(crate) fn citation_key_at(
+    buffer: &Buffer,
+    offset: usize,
+) -> Option<(std::ops::Range<usize>, SharedString)> {
+    let mut start = offset;
+    let mut characters = buffer.reversed_chars_at(offset);
+    let mut at_found = false;
+    while let Some(character) = characters.next() {
+        if character == '@' {
+            at_found = true;
+            start -= character.len_utf8();
+            break;
+        }
+        if !is_citation_key_char(character) || offset - start > 128 {
+            return None;
+        }
+        start -= character.len_utf8();
+    }
+    if !at_found || !citation_boundary(characters.next()) {
+        return None;
+    }
+    let mut end = offset;
+    for character in buffer.chars_at(offset) {
+        if !is_citation_key_char(character) || end - start > 256 {
+            break;
+        }
+        end += character.len_utf8();
+    }
+    let text: String = buffer.text_for_range(start..end).collect();
+    let key = text.strip_prefix('@')?;
+    // Punctuation is only valid inside a key, not at its edges, matching
+    // `citation_keys`.
+    let key = key
+        .trim_end_matches(|character: char| !(character.is_ascii_alphanumeric() || character == '_'));
+    if key.is_empty()
+        || !key
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_alphanumeric() || character == '_')
+    {
+        return None;
+    }
+    let end = start + 1 + key.len();
+    if offset > end {
+        return None;
+    }
+    Some((start..end, SharedString::from(key.to_string())))
 }
 
 fn buffer_is_markdown(buffer: &Buffer) -> bool {
@@ -456,6 +522,165 @@ impl CompletionProvider for CitationCompletionProvider {
 
     fn show_snippets(&self) -> bool {
         self.inner.show_snippets()
+    }
+}
+
+/// Wraps the editor's stock (project-backed) semantics provider so hovering
+/// a resolved cite key shows the reference card; every other request — LSP
+/// hovers, definitions, rename, inlay hints — delegates untouched.
+pub struct CitationSemanticsProvider {
+    inner: Rc<dyn SemanticsProvider>,
+    bibliography: Entity<Bibliography>,
+}
+
+impl CitationSemanticsProvider {
+    pub fn new(inner: Rc<dyn SemanticsProvider>, cx: &mut App) -> Self {
+        Self {
+            inner,
+            bibliography: Bibliography::global(cx),
+        }
+    }
+}
+
+impl SemanticsProvider for CitationSemanticsProvider {
+    fn hover(
+        &self,
+        buffer: &Entity<Buffer>,
+        position: text::Anchor,
+        cx: &mut App,
+    ) -> Option<Task<Option<Vec<project::Hover>>>> {
+        {
+            let buffer_ref = buffer.read(cx);
+            if buffer_is_markdown(buffer_ref) {
+                let offset = position.to_offset(buffer_ref);
+                if let Some((range, key)) = citation_key_at(buffer_ref, offset)
+                    && let Some(entry) = self.bibliography.read(cx).resolve(&key)
+                    && let Some(markdown) = entry.reference_markdown()
+                {
+                    let range =
+                        buffer_ref.anchor_before(range.start)..buffer_ref.anchor_after(range.end);
+                    return Some(Task::ready(Some(vec![project::Hover {
+                        contents: vec![project::HoverBlock {
+                            text: markdown,
+                            kind: project::HoverBlockKind::Markdown,
+                        }],
+                        range: Some(range),
+                        language: None,
+                    }])));
+                }
+            }
+        }
+        self.inner.hover(buffer, position, cx)
+    }
+
+    fn inline_values(
+        &self,
+        buffer_handle: Entity<Buffer>,
+        range: std::ops::Range<text::Anchor>,
+        cx: &mut App,
+    ) -> Option<Task<anyhow::Result<Vec<project::InlayHint>>>> {
+        self.inner.inline_values(buffer_handle, range, cx)
+    }
+
+    fn applicable_inlay_chunks(
+        &self,
+        buffer: &Entity<Buffer>,
+        ranges: &[std::ops::Range<text::Anchor>],
+        cx: &mut App,
+    ) -> Vec<std::ops::Range<language::BufferRow>> {
+        self.inner.applicable_inlay_chunks(buffer, ranges, cx)
+    }
+
+    fn invalidate_inlay_hints(
+        &self,
+        for_buffers: &HashSet<language::BufferId>,
+        cx: &mut App,
+    ) {
+        self.inner.invalidate_inlay_hints(for_buffers, cx)
+    }
+
+    fn inlay_hints(
+        &self,
+        invalidate: project::InvalidationStrategy,
+        buffer: Entity<Buffer>,
+        ranges: Vec<std::ops::Range<text::Anchor>>,
+        known_chunks: Option<(
+            clock::Global,
+            HashSet<std::ops::Range<language::BufferRow>>,
+        )>,
+        cx: &mut App,
+    ) -> Option<
+        HashMap<
+            std::ops::Range<language::BufferRow>,
+            Task<anyhow::Result<project::lsp_store::CacheInlayHints>>,
+        >,
+    > {
+        self.inner
+            .inlay_hints(invalidate, buffer, ranges, known_chunks, cx)
+    }
+
+    fn semantic_tokens(
+        &self,
+        buffer: Entity<Buffer>,
+        cx: &mut App,
+    ) -> Option<
+        futures::future::Shared<
+            Task<
+                std::result::Result<
+                    project::lsp_store::BufferSemanticTokens,
+                    std::sync::Arc<anyhow::Error>,
+                >,
+            >,
+        >,
+    > {
+        self.inner.semantic_tokens(buffer, cx)
+    }
+
+    fn supports_inlay_hints(&self, buffer: &Entity<Buffer>, cx: &mut App) -> bool {
+        self.inner.supports_inlay_hints(buffer, cx)
+    }
+
+    fn supports_semantic_tokens(&self, buffer: &Entity<Buffer>, cx: &mut App) -> bool {
+        self.inner.supports_semantic_tokens(buffer, cx)
+    }
+
+    fn document_highlights(
+        &self,
+        buffer: &Entity<Buffer>,
+        position: text::Anchor,
+        cx: &mut App,
+    ) -> Option<Task<anyhow::Result<Vec<project::DocumentHighlight>>>> {
+        self.inner.document_highlights(buffer, position, cx)
+    }
+
+    fn definitions(
+        &self,
+        buffer: &Entity<Buffer>,
+        position: text::Anchor,
+        kind: editor::GotoDefinitionKind,
+        cx: &mut App,
+    ) -> Option<Task<anyhow::Result<Option<Vec<project::LocationLink>>>>> {
+        self.inner.definitions(buffer, position, kind, cx)
+    }
+
+    fn range_for_rename(
+        &self,
+        buffer: &Entity<Buffer>,
+        position: text::Anchor,
+        cx: &mut App,
+    ) -> Task<anyhow::Result<Option<std::ops::Range<text::Anchor>>>> {
+        self.inner.range_for_rename(buffer, position, cx)
+    }
+
+    fn perform_rename(
+        &self,
+        buffer: &Entity<Buffer>,
+        position: text::Anchor,
+        new_name: String,
+        cx: &mut App,
+    ) -> Option<Task<anyhow::Result<project::ProjectTransaction>>> {
+        self.inner
+            .perform_rename(buffer, position, new_name, cx)
     }
 }
 

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -405,6 +405,11 @@ struct MarkerSet {
     /// Pandoc-style citation keys (`@key` including the `@`), styled as
     /// reference chips once the surrounding brackets are concealed.
     citations: Vec<Range<Anchor>>,
+    /// Bare in-text citation keys (`@key` outside any brackets). Pandoc
+    /// treats these as citations too, but prose is full of `@handles` that
+    /// cite nothing, so they only chip when the key resolves against the
+    /// bibliography — and are never flagged unresolved.
+    bare_citations: Vec<Range<Anchor>>,
     /// Bodies of Obsidian `==highlight==` marks, painted with a highlighter
     /// background once the `==` delimiters are concealed.
     highlights: Vec<Range<Anchor>>,
@@ -796,24 +801,34 @@ fn apply_emphasis_highlights(
     let bibliography = Bibliography::global(cx);
     let mut resolved_citations = markers.map(|markers| markers.citations.clone());
     let mut unknown_citations = markers.map(|_| Vec::new());
-    if let Some(citations) = resolved_citations.as_mut()
-        && !citations.is_empty()
+    if let Some(markers) = markers
+        && (!markers.citations.is_empty() || !markers.bare_citations.is_empty())
         && bibliography.read(cx).has_entries()
     {
         let snapshot = editor.buffer().read(cx).snapshot(cx);
         let bibliography = bibliography.read(cx);
-        let mut known = Vec::with_capacity(citations.len());
-        let mut unknown = Vec::new();
-        for range in citations.drain(..) {
+        let resolves = |range: &Range<Anchor>| {
             let text: String = snapshot.text_for_range(range.clone()).collect();
             let key = text.strip_prefix('@').unwrap_or(&text);
-            if bibliography.resolve(key).is_some() {
-                known.push(range);
+            bibliography.resolve(key).is_some()
+        };
+        let mut known = Vec::with_capacity(markers.citations.len());
+        let mut unknown = Vec::new();
+        for range in &markers.citations {
+            if resolves(range) {
+                known.push(range.clone());
             } else {
-                unknown.push(range);
+                unknown.push(range.clone());
             }
         }
-        *citations = known;
+        // A bare key is only a citation if it cites something; an
+        // unresolved one is somebody's `@handle` and stays prose.
+        for range in &markers.bare_citations {
+            if resolves(range) {
+                known.push(range.clone());
+            }
+        }
+        resolved_citations = Some(known);
         unknown_citations = Some(unknown);
     }
 
@@ -5498,6 +5513,7 @@ fn extract_markers(editor: &Editor, cx: &App) -> Option<MarkerSet> {
         definition_ranges: Vec::new(),
         ordered_markers: Vec::new(),
         citations: Vec::new(),
+        bare_citations: Vec::new(),
         highlights: Vec::new(),
         tags: Vec::new(),
     };
@@ -5528,6 +5544,7 @@ fn extract_markers(editor: &Editor, cx: &App) -> Option<MarkerSet> {
         definition_ranges,
         ordered_markers,
         citations,
+        bare_citations,
         highlights,
         tags,
         ..
@@ -5568,6 +5585,7 @@ fn extract_markers(editor: &Editor, cx: &App) -> Option<MarkerSet> {
         definition_ranges,
         ordered_markers,
         citations,
+        bare_citations,
         highlights,
         tags,
     })
@@ -5593,6 +5611,7 @@ struct Extraction<'a> {
     definition_ranges: Vec<Range<Anchor>>,
     ordered_markers: Vec<Range<Anchor>>,
     citations: Vec<Range<Anchor>>,
+    bare_citations: Vec<Range<Anchor>>,
     highlights: Vec<Range<Anchor>>,
     tags: Vec<Range<Anchor>>,
 }
@@ -6217,6 +6236,10 @@ impl Extraction<'_> {
                 continue;
             };
             let mut search_from = 0;
+            // Every `[...]` span seen, kept or not, so the bare pass below
+            // never claims a key inside a bracket construct (a rejected
+            // group, a link label, a wikilink).
+            let mut bracket_spans: Vec<Range<usize>> = Vec::new();
             while let Some(open_offset) = region_text[search_from..].find('[') {
                 let open = search_from + open_offset;
                 search_from = open + 1;
@@ -6224,6 +6247,7 @@ impl Extraction<'_> {
                     break;
                 };
                 let close = open + 1 + close_offset;
+                bracket_spans.push(open..close + 1);
                 let inner = &region_text[open + 1..close];
                 if inner.is_empty() || inner.contains('\n') || inner.contains('[') {
                     continue;
@@ -6265,6 +6289,29 @@ impl Extraction<'_> {
                     self.citations.push(range);
                 }
                 search_from = close + 1;
+            }
+
+            // Pandoc also allows in-text citations with no brackets
+            // (`@hayashi2003 argues`), which is what accepting a bare `@`
+            // completion produces. `citation_keys`'s boundary rules already
+            // reject an email's or URL's infix `@`.
+            for key in citation_keys(region_text) {
+                if bracket_spans
+                    .iter()
+                    .any(|span| span.start < key.end && key.start < span.end)
+                {
+                    continue;
+                }
+                let start = region.start + key.start;
+                let end = region.start + key.end;
+                if self
+                    .code_spans
+                    .iter()
+                    .any(|span| span.start < end && start < span.end)
+                {
+                    continue;
+                }
+                self.bare_citations.push(self.anchor_range(start..end));
             }
         }
         self.prose_regions = regions;

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -14,6 +14,7 @@ use std::{
     borrow::Cow,
     ops::Range,
     path::{Path, PathBuf},
+    rc::Rc,
     sync::Arc,
 };
 
@@ -28,7 +29,7 @@ use gpui::{
     App, AppContext as _, Context, ElementId, Empty, Entity, Focusable as _, FontWeight,
     HighlightStyle, Hsla, ImageSource, IntoElement, MouseButton, MouseDownEvent, Resource,
     RetainAllImageCache, SharedString, SharedUri, StrikethroughStyle, Subscription,
-    TextStyleRefinement, WeakEntity, Window, actions, img, rems,
+    TextStyleRefinement, UnderlineStyle, WeakEntity, Window, actions, img, rems,
 };
 use language::LanguageName;
 use markdown::{HeadingLevelStyles, Markdown, MarkdownElement, MarkdownFont, MarkdownStyle};
@@ -56,6 +57,9 @@ struct LivePreviewFoldTag;
 
 const MARKDOWN: &str = "Markdown";
 const MARKDOWN_INLINE: &str = "Markdown-Inline";
+
+mod bibliography;
+pub use bibliography::{Bibliography, CitationCompletionProvider};
 
 #[derive(Clone, Copy, Debug, Default, RegisterSetting)]
 pub struct MarkdownLivePreviewSettings {
@@ -186,8 +190,23 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
     // editor release every image it decoded.
     let image_cache = RetainAllImageCache::new(cx);
     if let Some(project) = editor.project().cloned() {
+        let bibliography = Bibliography::global(cx);
+        Bibliography::ensure_project(&bibliography, &project, cx);
+        // Restyle citations when a `.bib` finishes parsing, so keys resolve
+        // (or stop resolving) without waiting for the next edit.
+        subscriptions.push(cx.observe(&bibliography, |editor, _, cx| {
+            let markers = editor
+                .addon::<LivePreviewAddon>()
+                .and_then(|addon| addon.markers.clone());
+            apply_emphasis_highlights(editor, markers.as_deref(), cx);
+        }));
+        editor.set_completion_provider(Some(Rc::new(CitationCompletionProvider::new(
+            project.clone(),
+            cx,
+        ))));
         subscriptions.push(cx.subscribe_in(&project, window, {
             let image_cache = image_cache.clone();
+            let bibliography = bibliography.clone();
             move |editor, project, event, window, cx| {
                 let project::Event::WorktreeUpdatedEntries(worktree_id, changes) = event else {
                     return;
@@ -195,12 +214,28 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
                 let Some(worktree) = project.read(cx).worktree_for_id(*worktree_id, cx) else {
                     return;
                 };
-                let (changed_images, changed_notes, note_created) = {
+                let (changed_images, changed_notes, note_created, changed_bibs, removed_bibs) = {
                     let worktree = worktree.read(cx);
                     let mut images = Vec::new();
                     let mut notes = Vec::new();
                     let mut created = false;
+                    let mut bibs = Vec::new();
+                    let mut removed_bibs = Vec::new();
                     for (path, _, change) in changes.iter() {
+                        // Unlike images and notes below, `.bib` files do want
+                        // the initial scan's `Loaded`: a worktree that
+                        // finishes scanning after the editor opened is how its
+                        // bibliography gets discovered at all, and reparsing
+                        // one already indexed is idempotent.
+                        if path.extension().is_some_and(|extension| extension == "bib") {
+                            let absolute = worktree.absolutize(path);
+                            if *change == PathChange::Removed {
+                                removed_bibs.push(absolute);
+                            } else {
+                                bibs.push(absolute);
+                            }
+                            continue;
+                        }
                         // `Loaded` is the initial scan reporting what was
                         // already there, not a change; acting on it would
                         // re-decode every image in the project on open.
@@ -223,8 +258,15 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
                             notes.push(absolute);
                         }
                     }
-                    (images, notes, created)
+                    (images, notes, created, bibs, removed_bibs)
                 };
+
+                if !changed_bibs.is_empty() {
+                    Bibliography::reload_paths(&bibliography, project, changed_bibs, cx);
+                }
+                for path in removed_bibs {
+                    Bibliography::remove_path(&bibliography, &path, cx);
+                }
 
                 if !changed_images.is_empty() {
                     image_cache.update(cx, |image_cache, cx| {
@@ -720,6 +762,7 @@ const ORDERED_MARKER: usize = 5;
 const CITATION: usize = 6;
 const HIGHLIGHT: usize = 7;
 const TAG: usize = 8;
+const CITATION_UNKNOWN: usize = 9;
 
 /// Emphasis spans get preview-like typography: the plain text color with true
 /// bold/italic styling, overriding the theme's source-mode markup colors
@@ -744,6 +787,36 @@ fn apply_emphasis_highlights(
     // works in one.
     let highlight_background = cx.theme().status().warning.opacity(0.28);
     let tag_background = cx.theme().status().info_background;
+    let error_color = cx.theme().status().error;
+
+    // A cite key that resolves to no `.bib` entry is the kind of silent error
+    // a submitted paper pays for, so it gets diagnostic styling. Only once
+    // the project has a bibliography with entries, though: someone writing
+    // `[@handle]` in a vault with no `.bib` is not citing anything.
+    let bibliography = Bibliography::global(cx);
+    let mut resolved_citations = markers.map(|markers| markers.citations.clone());
+    let mut unknown_citations = markers.map(|_| Vec::new());
+    if let Some(citations) = resolved_citations.as_mut()
+        && !citations.is_empty()
+        && bibliography.read(cx).has_entries()
+    {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let bibliography = bibliography.read(cx);
+        let mut known = Vec::with_capacity(citations.len());
+        let mut unknown = Vec::new();
+        for range in citations.drain(..) {
+            let text: String = snapshot.text_for_range(range.clone()).collect();
+            let key = text.strip_prefix('@').unwrap_or(&text);
+            if bibliography.resolve(key).is_some() {
+                known.push(range);
+            } else {
+                unknown.push(range);
+            }
+        }
+        *citations = known;
+        unknown_citations = Some(unknown);
+    }
+
     let sets = [
         (
             STRIKE,
@@ -802,11 +875,26 @@ fn apply_emphasis_highlights(
         ),
         (
             CITATION,
-            markers.map(|markers| markers.citations.clone()),
+            resolved_citations,
             HighlightStyle {
                 color: Some(accent_color),
                 background_color: Some(citation_background),
                 font_style: Some(gpui::FontStyle::Normal),
+                ..Default::default()
+            },
+        ),
+        (
+            CITATION_UNKNOWN,
+            unknown_citations,
+            HighlightStyle {
+                color: Some(error_color),
+                background_color: Some(citation_background),
+                font_style: Some(gpui::FontStyle::Normal),
+                underline: Some(UnderlineStyle {
+                    thickness: gpui::px(1.),
+                    color: Some(error_color),
+                    wavy: true,
+                }),
                 ..Default::default()
             },
         ),

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -59,7 +59,7 @@ const MARKDOWN: &str = "Markdown";
 const MARKDOWN_INLINE: &str = "Markdown-Inline";
 
 mod bibliography;
-pub use bibliography::{Bibliography, CitationCompletionProvider};
+pub use bibliography::{Bibliography, CitationCompletionProvider, CitationSemanticsProvider};
 
 #[derive(Clone, Copy, Debug, Default, RegisterSetting)]
 pub struct MarkdownLivePreviewSettings {
@@ -206,6 +206,14 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
             project.clone(),
             cx,
         ))));
+        // Hovering a resolved cite key shows the reference card; wrapping
+        // (rather than replacing) keeps LSP hovers and the rest of the
+        // semantics surface working.
+        if let Some(semantics) = editor.semantics_provider() {
+            editor.set_semantics_provider(Some(Rc::new(CitationSemanticsProvider::new(
+                semantics, cx,
+            ))));
+        }
         subscriptions.push(cx.subscribe_in(&project, window, {
             let image_cache = image_cache.clone();
             let bibliography = bibliography.clone();

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -412,9 +412,10 @@ struct MarkerSet {
     /// end (or forward-deleting at its start) removes the whole group.
     citation_groups: Vec<Range<Anchor>>,
     /// Bare in-text citation keys (`@key` outside any brackets). Pandoc
-    /// treats these as citations too, but prose is full of `@handles` that
-    /// cite nothing, so they only chip when the key resolves against the
-    /// bibliography — and are never flagged unresolved.
+    /// treats these as citations exactly like bracketed ones, and so does
+    /// the styling: chip when the key resolves, red flag when it does not.
+    /// The flagging only starts once the vault has a bibliography with
+    /// entries, which is what keeps `@handles` in bib-less prose unflagged.
     bare_citations: Vec<Range<Anchor>>,
     /// Bodies of Obsidian `==highlight==` marks, painted with a highlighter
     /// background once the `==` delimiters are concealed.
@@ -827,11 +828,11 @@ fn apply_emphasis_highlights(
                 unknown.push(range.clone());
             }
         }
-        // A bare key is only a citation if it cites something; an
-        // unresolved one is somebody's `@handle` and stays prose.
         for range in &markers.bare_citations {
             if resolves(range) {
                 known.push(range.clone());
+            } else {
+                unknown.push(range.clone());
             }
         }
         resolved_citations = Some(known);

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -165,6 +165,7 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
     subscriptions.push(editor.register_action::<editor::actions::Backspace>(
         move |_, _window, cx| {
             if !delete_selected_table_unit(&weak_editor, cx)
+                && !delete_adjacent_citation(&weak_editor, false, cx)
                 && !delete_adjacent_to_block(&weak_editor, false, cx)
             {
                 cx.propagate();
@@ -175,6 +176,7 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
     subscriptions.push(
         editor.register_action::<editor::actions::Delete>(move |_, _window, cx| {
             if !delete_selected_table_unit(&weak_editor, cx)
+                && !delete_adjacent_citation(&weak_editor, true, cx)
                 && !delete_adjacent_to_block(&weak_editor, true, cx)
             {
                 cx.propagate();
@@ -405,6 +407,10 @@ struct MarkerSet {
     /// Pandoc-style citation keys (`@key` including the `@`), styled as
     /// reference chips once the surrounding brackets are concealed.
     citations: Vec<Range<Anchor>>,
+    /// Whole bracketed citation groups (`[...]` inclusive). A citation is
+    /// inserted as one token through completion, so backspacing at a group's
+    /// end (or forward-deleting at its start) removes the whole group.
+    citation_groups: Vec<Range<Anchor>>,
     /// Bare in-text citation keys (`@key` outside any brackets). Pandoc
     /// treats these as citations too, but prose is full of `@handles` that
     /// cite nothing, so they only chip when the key resolves against the
@@ -2531,6 +2537,58 @@ fn delete_adjacent_to_block(weak_editor: &WeakEntity<Editor>, forward: bool, cx:
                 None,
                 cx,
             );
+        });
+        true
+    })
+}
+
+/// Deletes a whole bracketed citation group when a single caret backspaces
+/// at its end or forward-deletes at its start. A citation arrives as one
+/// token through completion, so it should leave the same way; editing a key
+/// letter by letter stays available by moving the cursor inside the group.
+/// Returns false when no caret borders a group so the caller can propagate.
+fn delete_adjacent_citation(weak_editor: &WeakEntity<Editor>, forward: bool, cx: &mut App) -> bool {
+    let Some(editor) = weak_editor.upgrade() else {
+        return false;
+    };
+    editor.update(cx, |editor, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let groups: Vec<Range<usize>> = editor
+            .addon::<LivePreviewAddon>()
+            .and_then(|addon| addon.markers.as_ref())
+            .map(|markers| {
+                markers
+                    .citation_groups
+                    .iter()
+                    .map(|range| {
+                        range.start.to_offset(&snapshot).0..range.end.to_offset(&snapshot).0
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        if groups.is_empty() {
+            return false;
+        }
+        let selections = selection_offset_ranges(editor, &snapshot);
+        let [caret] = selections.as_slice() else {
+            return false;
+        };
+        if caret.start != caret.end {
+            return false;
+        }
+        let head = caret.start;
+        let Some(group) = groups.iter().find(|group| {
+            if forward {
+                group.start == head
+            } else {
+                group.end == head
+            }
+        }) else {
+            return false;
+        };
+        let deletion = MultiBufferOffset(group.start)..MultiBufferOffset(group.end);
+        editor.buffer().update(cx, |multibuffer, cx| {
+            multibuffer.edit([(deletion, "")], None, cx);
         });
         true
     })
@@ -5513,6 +5571,7 @@ fn extract_markers(editor: &Editor, cx: &App) -> Option<MarkerSet> {
         definition_ranges: Vec::new(),
         ordered_markers: Vec::new(),
         citations: Vec::new(),
+        citation_groups: Vec::new(),
         bare_citations: Vec::new(),
         highlights: Vec::new(),
         tags: Vec::new(),
@@ -5544,6 +5603,7 @@ fn extract_markers(editor: &Editor, cx: &App) -> Option<MarkerSet> {
         definition_ranges,
         ordered_markers,
         citations,
+        citation_groups,
         bare_citations,
         highlights,
         tags,
@@ -5585,6 +5645,7 @@ fn extract_markers(editor: &Editor, cx: &App) -> Option<MarkerSet> {
         definition_ranges,
         ordered_markers,
         citations,
+        citation_groups,
         bare_citations,
         highlights,
         tags,
@@ -5611,6 +5672,7 @@ struct Extraction<'a> {
     definition_ranges: Vec<Range<Anchor>>,
     ordered_markers: Vec<Range<Anchor>>,
     citations: Vec<Range<Anchor>>,
+    citation_groups: Vec<Range<Anchor>>,
     bare_citations: Vec<Range<Anchor>>,
     highlights: Vec<Range<Anchor>>,
     tags: Vec<Range<Anchor>>,
@@ -6284,6 +6346,7 @@ impl Extraction<'_> {
                 let reveal = start..end;
                 self.hide(start..start + 1, reveal.clone());
                 self.hide(end - 1..end, reveal.clone());
+                self.citation_groups.push(self.anchor_range(start..end));
                 for key in keys {
                     let range = self.anchor_range(start + 1 + key.start..start + 1 + key.end);
                     self.citations.push(range);

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -817,7 +817,7 @@ fn apply_emphasis_highlights(
         let resolves = |range: &Range<Anchor>| {
             let text: String = snapshot.text_for_range(range.clone()).collect();
             let key = text.strip_prefix('@').unwrap_or(&text);
-            bibliography.resolve(key).is_some()
+            bibliography.contains_key(key)
         };
         let mut known = Vec::with_capacity(markers.citations.len());
         let mut unknown = Vec::new();

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -3199,11 +3199,11 @@ async fn test_duplicate_bib_keys_complete_once(cx: &mut TestAppContext) {
 }
 
 /// Pandoc also allows in-text citations with no brackets (`@key argues`),
-/// which is what accepting a bare `@` completion produces. Prose is full of
-/// `@handles` that cite nothing, so a bare key chips only when it resolves —
-/// and is never flagged unresolved.
+/// which is what accepting a bare `@` completion produces. They verify
+/// exactly like bracketed ones — chip when resolved, red flag when not —
+/// while emails, infix `@`, and code spans never register at all.
 #[gpui::test]
-async fn test_bare_in_text_citations_chip_only_when_resolved(cx: &mut TestAppContext) {
+async fn test_bare_in_text_citations_chip_and_flag_like_bracketed(cx: &mut TestAppContext) {
     let (editor, _fs, cx) = markdown_vault_test_context(
         cx,
         &[
@@ -3225,12 +3225,12 @@ async fn test_bare_in_text_citations_chip_only_when_resolved(cx: &mut TestAppCon
     assert_eq!(
         highlighted_texts(&editor, CITATION, cx),
         vec!["@smith2020"],
-        "only the bare key that resolves chips"
+        "the bare key that resolves chips"
     );
     assert_eq!(
         highlighted_texts(&editor, CITATION_UNKNOWN, cx),
-        Vec::<String>::new(),
-        "an unresolved bare key is prose, never a red flag"
+        vec!["@somehandle"],
+        "the bare key that resolves to nothing flags, like a bracketed one"
     );
 }
 

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -3234,6 +3234,150 @@ async fn test_bare_in_text_citations_chip_and_flag_like_bracketed(cx: &mut TestA
     );
 }
 
+/// Outside markdown the provider is a pass-through: `@` never triggers the
+/// citation menu, and a completion request yields no cite keys even with a
+/// populated bibliography — code buffers must feel exactly as before.
+#[gpui::test]
+async fn test_citation_provider_delegates_outside_markdown(cx: &mut TestAppContext) {
+    use editor::CompletionProvider as _;
+
+    let (editor, _fs, cx) = markdown_vault_test_context(
+        cx,
+        &[
+            ("notes.txt", "plain text @"),
+            (
+                "refs.bib",
+                "@article{smith2020,\n  title = {A Study},\n  year = {2020},\n}\n",
+            ),
+        ],
+        "notes.txt",
+    )
+    .await;
+    cx.run_until_parked();
+
+    let (triggers, task) = editor.update_in(cx, |editor, window, cx| {
+        let project = editor.project().expect("has project").clone();
+        let provider = CitationCompletionProvider::new(project, cx);
+        let buffer = editor
+            .buffer()
+            .read(cx)
+            .as_singleton()
+            .expect("single buffer");
+        let position = buffer.read(cx).anchor_before("plain text @".len());
+        let triggers = provider.is_completion_trigger(&buffer, position, "@", false, cx);
+        let task = provider.completions(
+            &buffer,
+            position,
+            editor::CompletionContext {
+                trigger_kind: lsp::CompletionTriggerKind::INVOKED,
+                trigger_character: None,
+            },
+            window,
+            cx,
+        );
+        (triggers, task)
+    });
+    assert!(!triggers, "@ in a non-markdown buffer must not open the menu");
+
+    let responses = task.await.expect("delegated completions succeed");
+    let cite_keys: Vec<_> = responses
+        .into_iter()
+        .flat_map(|response| response.completions)
+        .filter(|completion| completion.new_text == "smith2020")
+        .collect();
+    assert!(
+        cite_keys.is_empty(),
+        "a non-markdown buffer must get no cite-key completions"
+    );
+}
+
+/// Deleting a whole `.bib` file drops its keys from the index the way
+/// deleting one entry does: keys only it provided flag red, keys other
+/// files still carry keep their chips.
+#[gpui::test]
+async fn test_deleting_a_bib_file_flags_its_keys(cx: &mut TestAppContext) {
+    use project::Fs as _;
+
+    let (editor, fs, cx) = markdown_vault_test_context(
+        cx,
+        &[
+            ("Note.md", "Both chip: [@kept2020] and [@doomed2021].\n"),
+            (
+                "kept.bib",
+                "@article{kept2020,\n  title = {Kept},\n  year = {2020},\n}\n",
+            ),
+            (
+                "doomed.bib",
+                "@article{doomed2021,\n  title = {Doomed},\n  year = {2021},\n}\n",
+            ),
+        ],
+        "Note.md",
+    )
+    .await;
+    cx.run_until_parked();
+
+    let mut resolved = highlighted_texts(&editor, CITATION, cx);
+    resolved.sort();
+    assert_eq!(resolved, vec!["@doomed2021", "@kept2020"]);
+
+    fs.remove_file("/vault/doomed.bib".as_ref(), Default::default())
+        .await
+        .expect("failed to delete doomed.bib");
+    cx.run_until_parked();
+
+    assert_eq!(
+        highlighted_texts(&editor, CITATION, cx),
+        vec!["@kept2020"],
+        "the surviving bib's key keeps its chip"
+    );
+    assert_eq!(
+        highlighted_texts(&editor, CITATION_UNKNOWN, cx),
+        vec!["@doomed2021"],
+        "the deleted bib's key flags red"
+    );
+}
+
+/// A `.bib` created after the project opened is discovered through the
+/// worktree change event, not the initial scan — and its arrival also turns
+/// verification on, so a key that sat unflagged in a bib-less vault gets its
+/// verdict once entries exist.
+#[gpui::test]
+async fn test_a_bib_created_later_starts_resolving(cx: &mut TestAppContext) {
+    let (editor, fs, cx) = markdown_vault_test_context(
+        cx,
+        &[("Note.md", "Cite [@late2020] and [@never2021].\n")],
+        "Note.md",
+    )
+    .await;
+    cx.run_until_parked();
+
+    let mut unverified = highlighted_texts(&editor, CITATION, cx);
+    unverified.sort();
+    assert_eq!(
+        unverified,
+        vec!["@late2020", "@never2021"],
+        "with no bibliography, citations chip without verification"
+    );
+
+    fs.insert_file(
+        "/vault/new.bib",
+        b"@article{late2020,\n  title = {Late Arrival},\n  year = {2020},\n}\n".to_vec(),
+    )
+    .await;
+    cx.run_until_parked();
+
+    assert_eq!(
+        highlighted_texts(&editor, CITATION, cx),
+        vec!["@late2020"],
+        "the new bib's key resolves"
+    );
+    assert_eq!(
+        highlighted_texts(&editor, CITATION_UNKNOWN, cx),
+        vec!["@never2021"],
+        "verification turns on with the first entries"
+    );
+}
+
 /// A citation arrives as one token through completion, so backspacing right
 /// after `]` (or forward-deleting right before `[`) removes the whole group,
 /// like the block widgets do. With the cursor inside the group, deletion
@@ -3244,6 +3388,12 @@ async fn test_backspace_after_a_citation_deletes_the_whole_group(cx: &mut TestAp
 
     cx.set_state("A claim [@doe2020]ˇ stands\n");
     cx.executor().run_until_parked();
+    cx.dispatch_action(editor::actions::Backspace);
+    cx.assert_editor_state("A claim ˇ stands\n");
+
+    // One undo brings the whole citation back as one step.
+    cx.dispatch_action(editor::actions::Undo);
+    cx.assert_editor_state("A claim [@doe2020]ˇ stands\n");
     cx.dispatch_action(editor::actions::Backspace);
     cx.assert_editor_state("A claim ˇ stands\n");
 

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -3198,6 +3198,42 @@ async fn test_duplicate_bib_keys_complete_once(cx: &mut TestAppContext) {
     );
 }
 
+/// Pandoc also allows in-text citations with no brackets (`@key argues`),
+/// which is what accepting a bare `@` completion produces. Prose is full of
+/// `@handles` that cite nothing, so a bare key chips only when it resolves —
+/// and is never flagged unresolved.
+#[gpui::test]
+async fn test_bare_in_text_citations_chip_only_when_resolved(cx: &mut TestAppContext) {
+    let (editor, _fs, cx) = markdown_vault_test_context(
+        cx,
+        &[
+            (
+                "Note.md",
+                "Bare: @smith2020 argues this, though @somehandle disagrees, \
+                 and me@example.com or `@smith2020` never chip.\n",
+            ),
+            (
+                "refs.bib",
+                "@article{smith2020,\n  title = {A Study},\n  year = {2020},\n}\n",
+            ),
+        ],
+        "Note.md",
+    )
+    .await;
+    cx.run_until_parked();
+
+    assert_eq!(
+        highlighted_texts(&editor, CITATION, cx),
+        vec!["@smith2020"],
+        "only the bare key that resolves chips"
+    );
+    assert_eq!(
+        highlighted_texts(&editor, CITATION_UNKNOWN, cx),
+        Vec::<String>::new(),
+        "an unresolved bare key is prose, never a red flag"
+    );
+}
+
 #[gpui::test]
 async fn test_citation_key_start_finds_pandoc_contexts(cx: &mut TestAppContext) {
     let cases: &[(&str, Option<usize>)] = &[

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -3291,6 +3291,79 @@ async fn test_citation_provider_delegates_outside_markdown(cx: &mut TestAppConte
     );
 }
 
+/// Hovering a resolved cite key serves the reference card through the
+/// wrapped semantics provider; anywhere else the provider delegates, so LSP
+/// hovers keep working.
+#[gpui::test]
+async fn test_hovering_a_cite_key_shows_the_reference_card(cx: &mut TestAppContext) {
+    let (editor, _fs, cx) = markdown_vault_test_context(
+        cx,
+        &[
+            ("Note.md", "See [@smith2020] and email me@smith2020 here.\n"),
+            (
+                "refs.bib",
+                "@article{smith2020,\n  title = {A Study of Things},\n  author = {Smith, Jane},\n  year = {2020},\n}\n",
+            ),
+        ],
+        "Note.md",
+    )
+    .await;
+    cx.run_until_parked();
+
+    let hover_on = |editor: &Entity<Editor>, cx: &mut gpui::VisualTestContext, offset: usize| {
+        editor.update(cx, |editor, cx| {
+            let provider = editor
+                .semantics_provider()
+                .expect("editor has a semantics provider");
+            let buffer = editor
+                .buffer()
+                .read(cx)
+                .as_singleton()
+                .expect("single buffer");
+            let position = buffer.read(cx).anchor_before(offset);
+            provider.hover(&buffer, position, cx)
+        })
+    };
+
+    // On the key: the reference card, immediately.
+    let task = hover_on(&editor, cx, "See [@smi".len()).expect("citation hover produced");
+    let hovers = task.await.expect("citation hover resolves");
+    let text = hovers
+        .first()
+        .and_then(|hover| hover.contents.first())
+        .map(|block| block.text.clone())
+        .unwrap_or_default();
+    assert!(
+        text.contains("A Study of Things") && text.contains("Jane Smith") && text.contains("2020"),
+        "hover card should carry the reference, got {text:?}"
+    );
+
+    // On the email's lookalike key: no card (the request delegates).
+    if let Some(task) = hover_on(&editor, cx, "See [@smith2020] and email me@smi".len()) {
+        let hovers = task.await.unwrap_or_default();
+        assert!(
+            hovers.iter().all(|hover| {
+                hover
+                    .contents
+                    .iter()
+                    .all(|block| !block.text.contains("A Study of Things"))
+            }),
+            "an email must not get a reference card"
+        );
+    }
+
+    // End to end: the editor's own hover pipeline pops the card.
+    editor.update_in(cx, |editor, window, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        let anchor = snapshot.anchor_before(MultiBufferOffset("See [@smi".len()));
+        editor::hover_popover::hover_at(editor, Some(anchor), None, window, cx);
+    });
+    cx.executor().advance_clock(std::time::Duration::from_millis(700));
+    cx.run_until_parked();
+    let popovers = editor.update(cx, |editor, _| editor.hover_state.info_popovers.len());
+    assert_eq!(popovers, 1, "the hover popover should be on screen");
+}
+
 /// Deleting a whole `.bib` file drops its keys from the index the way
 /// deleting one entry does: keys only it provided flag red, keys other
 /// files still carry keep their chips.

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -2958,6 +2958,212 @@ async fn test_an_unresolved_embed_reports_itself(cx: &mut TestAppContext) {
     );
 }
 
+/// The keys carried by a highlight namespace, as buffer text, so citation
+/// tests can assert which keys resolved rather than counting ranges.
+fn highlighted_texts(
+    editor: &Entity<Editor>,
+    key: usize,
+    cx: &mut gpui::VisualTestContext,
+) -> Vec<String> {
+    editor.update(cx, |editor, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        editor
+            .text_highlights(HighlightKey::MarkdownLivePreview(key), cx)
+            .map_or(Vec::new(), |(_, ranges)| {
+                ranges
+                    .iter()
+                    .map(|range| snapshot.text_for_range(range.clone()).collect())
+                    .collect()
+            })
+    })
+}
+
+#[gpui::test]
+async fn test_cite_keys_resolve_against_the_vault_bibliography(cx: &mut TestAppContext) {
+    use project::Fs as _;
+
+    let (editor, fs, cx) = markdown_vault_test_context(
+        cx,
+        &[
+            (
+                "Note.md",
+                "As shown in [@smith2020] and [@missing2024].\n",
+            ),
+            (
+                "refs.bib",
+                "@article{smith2020,\n  title = {A Study},\n  author = {Smith, Jane},\n  year = {2020},\n}\n",
+            ),
+        ],
+        "Note.md",
+    )
+    .await;
+    cx.run_until_parked();
+
+    assert_eq!(
+        highlighted_texts(&editor, CITATION, cx),
+        vec!["@smith2020"],
+        "the key present in refs.bib keeps the citation chip"
+    );
+    assert_eq!(
+        highlighted_texts(&editor, CITATION_UNKNOWN, cx),
+        vec!["@missing2024"],
+        "the key absent from refs.bib is flagged unresolved"
+    );
+
+    // Adding the missing entry to the `.bib` clears the flag without
+    // touching the note: the worktree change reloads the index and the
+    // bibliography observer restyles.
+    fs.save(
+        "/vault/refs.bib".as_ref(),
+        &concat!(
+            "@article{smith2020,\n  title = {A Study},\n  author = {Smith, Jane},\n  year = {2020},\n}\n",
+            "@article{missing2024,\n  title = {Found},\n  year = {2024},\n}\n"
+        )
+        .into(),
+        Default::default(),
+    )
+    .await
+    .expect("failed to update refs.bib");
+    cx.run_until_parked();
+
+    let mut resolved = highlighted_texts(&editor, CITATION, cx);
+    resolved.sort();
+    assert_eq!(
+        resolved,
+        vec!["@missing2024", "@smith2020"],
+        "both keys resolve after the bib gains the entry"
+    );
+    assert_eq!(
+        highlighted_texts(&editor, CITATION_UNKNOWN, cx),
+        Vec::<String>::new()
+    );
+}
+
+#[gpui::test]
+async fn test_citations_stay_plain_without_a_bibliography(cx: &mut TestAppContext) {
+    let (editor, _fs, cx) = markdown_vault_test_context(
+        cx,
+        &[("Note.md", "A hunch [@unverified] in a vault with no bib.\n")],
+        "Note.md",
+    )
+    .await;
+    cx.run_until_parked();
+
+    assert_eq!(
+        highlighted_texts(&editor, CITATION, cx),
+        vec!["@unverified"],
+        "citations keep the ordinary chip"
+    );
+    assert_eq!(
+        highlighted_texts(&editor, CITATION_UNKNOWN, cx),
+        Vec::<String>::new(),
+        "no bibliography means no unresolved flags"
+    );
+}
+
+#[gpui::test]
+async fn test_citation_completion_offers_bib_keys(cx: &mut TestAppContext) {
+    use editor::CompletionProvider as _;
+
+    let (editor, _fs, cx) = markdown_vault_test_context(
+        cx,
+        &[
+            ("Note.md", "cite [@smi"),
+            (
+                "refs.bib",
+                concat!(
+                    "@article{smith2020,\n  title = {A Study of Things},\n  author = {Smith, Jane},\n  year = {2020},\n}\n",
+                    "@book{knuth1984,\n  title = {The Book},\n  year = {1984},\n}\n"
+                ),
+            ),
+        ],
+        "Note.md",
+    )
+    .await;
+    cx.run_until_parked();
+
+    let task = editor.update_in(cx, |editor, window, cx| {
+        let project = editor
+            .project()
+            .expect("vault editor has a project")
+            .clone();
+        let provider = CitationCompletionProvider::new(project, cx);
+        let buffer = editor
+            .buffer()
+            .read(cx)
+            .as_singleton()
+            .expect("single buffer");
+        let position = buffer.read(cx).anchor_before("cite [@smi".len());
+        provider.completions(
+            &buffer,
+            position,
+            editor::CompletionContext {
+                trigger_kind: lsp::CompletionTriggerKind::INVOKED,
+                trigger_character: None,
+            },
+            window,
+            cx,
+        )
+    });
+    let responses = task.await.expect("completions succeed");
+
+    let completions: Vec<_> = responses
+        .into_iter()
+        .flat_map(|response| response.completions)
+        .collect();
+    let mut keys: Vec<_> = completions
+        .iter()
+        .map(|completion| completion.new_text.clone())
+        .collect();
+    keys.sort();
+    assert_eq!(
+        keys,
+        vec!["knuth1984", "smith2020"],
+        "every bib entry is offered; the menu filters as the user types"
+    );
+
+    // The replacement covers only the typed key fragment, not the `@`, so
+    // accepting a completion yields `[@smith2020` rather than doubling up.
+    let smith = completions
+        .iter()
+        .find(|completion| completion.new_text == "smith2020")
+        .expect("smith2020 offered");
+    editor.update(cx, |editor, cx| {
+        let buffer = editor
+            .buffer()
+            .read(cx)
+            .as_singleton()
+            .expect("single buffer");
+        let buffer = buffer.read(cx);
+        let replaced = {
+            use text::ToOffset as _;
+            smith.replace_range.start.to_offset(buffer)..smith.replace_range.end.to_offset(buffer)
+        };
+        assert_eq!(&buffer.text()[replaced], "smi");
+    });
+}
+
+#[gpui::test]
+async fn test_citation_key_start_finds_pandoc_contexts(cx: &mut TestAppContext) {
+    let cases: &[(&str, Option<usize>)] = &[
+        // Bracketed and bare citations complete after their `@`.
+        ("see [@smi", Some("see [@".len())),
+        ("see @smi", Some("see @".len())),
+        ("@smi", Some(1)),
+        ("[@a; @b", Some("[@a; @".len())),
+        // An email address or infix `@` is not a citation.
+        ("write me@exa", None),
+        // No `@` at all.
+        ("see [smi", None),
+    ];
+    for (text, expected) in cases {
+        let buffer = cx.new(|cx| language::Buffer::local(*text, cx));
+        let start =
+            cx.update(|cx| crate::bibliography::citation_key_start(buffer.read(cx), text.len()));
+        assert_eq!(start, *expected, "context detection for {text:?}");
+    }
+}
+
 // --- Contract tests ---
 //
 // These pin behavior this crate relies on from `editor` and `gpui` rather than

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -3234,6 +3234,31 @@ async fn test_bare_in_text_citations_chip_only_when_resolved(cx: &mut TestAppCon
     );
 }
 
+/// A citation arrives as one token through completion, so backspacing right
+/// after `]` (or forward-deleting right before `[`) removes the whole group,
+/// like the block widgets do. With the cursor inside the group, deletion
+/// stays per-character so a key can still be edited.
+#[gpui::test]
+async fn test_backspace_after_a_citation_deletes_the_whole_group(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+
+    cx.set_state("A claim [@doe2020]ˇ stands\n");
+    cx.executor().run_until_parked();
+    cx.dispatch_action(editor::actions::Backspace);
+    cx.assert_editor_state("A claim ˇ stands\n");
+
+    cx.set_state("A claim ˇ[@doe2020] stands\n");
+    cx.executor().run_until_parked();
+    cx.dispatch_action(editor::actions::Delete);
+    cx.assert_editor_state("A claim ˇ stands\n");
+
+    // Inside the group the ordinary one-character deletion still applies.
+    cx.set_state("A claim [@doe2020ˇ] stands\n");
+    cx.executor().run_until_parked();
+    cx.dispatch_action(editor::actions::Backspace);
+    cx.assert_editor_state("A claim [@doe202ˇ] stands\n");
+}
+
 #[gpui::test]
 async fn test_citation_key_start_finds_pandoc_contexts(cx: &mut TestAppContext) {
     let cases: &[(&str, Option<usize>)] = &[

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -3143,6 +3143,61 @@ async fn test_citation_completion_offers_bib_keys(cx: &mut TestAppContext) {
     });
 }
 
+/// A vault often holds several copies of one master bibliography (a
+/// `references.bib` per paper); a key defined in many files is still one
+/// citation and must appear once in the menu.
+#[gpui::test]
+async fn test_duplicate_bib_keys_complete_once(cx: &mut TestAppContext) {
+    use editor::CompletionProvider as _;
+
+    let shared = "@article{smith2020,\n  title = {A Study},\n  year = {2020},\n}\n";
+    let (editor, _fs, cx) = markdown_vault_test_context(
+        cx,
+        &[
+            ("Note.md", "cite [@smi"),
+            ("refs.bib", shared),
+            ("paper-copy.bib", shared),
+            ("another-copy.bib", shared),
+        ],
+        "Note.md",
+    )
+    .await;
+    cx.run_until_parked();
+
+    let task = editor.update_in(cx, |editor, window, cx| {
+        let project = editor.project().expect("vault editor has a project").clone();
+        let provider = CitationCompletionProvider::new(project, cx);
+        let buffer = editor
+            .buffer()
+            .read(cx)
+            .as_singleton()
+            .expect("single buffer");
+        let position = buffer.read(cx).anchor_before("cite [@smi".len());
+        provider.completions(
+            &buffer,
+            position,
+            editor::CompletionContext {
+                trigger_kind: lsp::CompletionTriggerKind::INVOKED,
+                trigger_character: None,
+            },
+            window,
+            cx,
+        )
+    });
+    let responses = task.await.expect("completions succeed");
+
+    let keys: Vec<_> = responses
+        .into_iter()
+        .flat_map(|response| response.completions)
+        .map(|completion| completion.new_text)
+        .collect();
+    assert_eq!(
+        keys,
+        vec!["smith2020"],
+        "a key defined in three .bib files is offered exactly once"
+    );
+}
+
 #[gpui::test]
 async fn test_citation_key_start_finds_pandoc_contexts(cx: &mut TestAppContext) {
     let cases: &[(&str, Option<usize>)] = &[

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -56,6 +56,7 @@ visual-tests = [
     "fs/test-support",
     "recent_projects/test-support",
     "title_bar/test-support",
+    "dep:tree-sitter-md",
 ]
 
 [[bin]]
@@ -141,6 +142,7 @@ semver.workspace = true
 system_specs.workspace = true
 tabular_data_preview.workspace = true
 tempfile = { workspace = true, optional = true }
+tree-sitter-md = { workspace = true, optional = true }
 
 edit_prediction.workspace = true
 edit_prediction_ui.workspace = true

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -103,8 +103,8 @@ use {
     feature_flags::FeatureFlagAppExt as _,
     git_ui::project_diff::ProjectDiff,
     gpui::{
-        App, AppContext as _, Bounds, Entity, KeyBinding, Modifiers, VisualTestAppContext,
-        WindowBounds, WindowHandle, WindowOptions, point, px, size,
+        App, AppContext as _, Bounds, Entity, Focusable as _, KeyBinding, Modifiers,
+        VisualTestAppContext, WindowBounds, WindowHandle, WindowOptions, point, px, size,
     },
     image::RgbaImage,
     project::{AgentId, Project},
@@ -224,6 +224,7 @@ fn run_visual_tests(project_path: PathBuf, update_baseline: bool) -> Result<()> 
             cx,
         );
         settings_ui::init(cx);
+        markdown_live_preview::init(cx);
 
         // Load default keymaps so tooltips can show keybindings like "f9" for ToggleBreakpoint
         // We load a minimal set of editor keybindings needed for visual tests
@@ -243,6 +244,20 @@ fn run_visual_tests(project_path: PathBuf, update_baseline: bool) -> Result<()> 
             cx,
         );
     });
+
+    // The citation pipeline test renders live preview, which needs both real
+    // markdown grammars. Registered after init so no earlier test's file
+    // (main.rs, panels) picks up a language it did not have when its
+    // baseline was recorded.
+    app_state.languages.add(language::markdown_lang());
+    app_state.languages.add(Arc::new(language::Language::new(
+        language::LanguageConfig {
+            name: "Markdown-Inline".into(),
+            hidden: true,
+            ..language::LanguageConfig::default()
+        },
+        Some(tree_sitter_md::INLINE_LANGUAGE.into()),
+    )));
 
     // Run until all initialization tasks complete
     cx.run_until_parked();
@@ -621,6 +636,23 @@ fn run_visual_tests(project_path: PathBuf, update_baseline: bool) -> Result<()> 
         }
         Err(e) => {
             eprintln!("✗ settings_ui_subpage_auto_open: FAILED - {}", e);
+            failed += 1;
+        }
+    }
+
+    // Run Test 11: Citation pipeline (live preview chips + completion menu)
+    println!("\n--- Test 11: citation_pipeline (2 variants) ---");
+    match run_citation_pipeline_visual_tests(app_state.clone(), &mut cx, update_baseline) {
+        Ok(TestResult::Passed) => {
+            println!("✓ citation_pipeline: PASSED");
+            passed += 1;
+        }
+        Ok(TestResult::BaselineUpdated(_)) => {
+            println!("✓ citation_pipeline: Baselines updated");
+            updated += 1;
+        }
+        Err(e) => {
+            eprintln!("✗ citation_pipeline: FAILED - {}", e);
             failed += 1;
         }
     }
@@ -2531,6 +2563,192 @@ fn run_tool_permissions_visual_tests(
 
     // Return success - we're just capturing screenshots, not comparing baselines
     Ok(TestResult::Passed)
+}
+
+/// Drives the citation pipeline in a real rendered window: opens a vault
+/// carrying a `.bib` and a note, waits for the bibliography to index, and
+/// captures two baselines — the note's citation styling (resolved chips, a
+/// red-flagged bracketed unknown, a bare unresolved key left as prose) and
+/// the cite-key completion menu opened by typing `@` at the end of the note.
+#[cfg(target_os = "macos")]
+fn run_citation_pipeline_visual_tests(
+    app_state: Arc<AppState>,
+    cx: &mut VisualTestAppContext,
+    update_baseline: bool,
+) -> Result<TestResult> {
+    use markdown_live_preview::Bibliography;
+
+    let temp_dir = tempfile::tempdir()?;
+    let temp_path = temp_dir.keep();
+    let canonical_temp = temp_path.canonicalize()?;
+    let vault_dir = canonical_temp.join("vault");
+    std::fs::create_dir_all(&vault_dir)?;
+    std::fs::write(
+        vault_dir.join("refs.bib"),
+        r#"@article{hayashi2003,
+  author  = {Hayashi, Noriko and Duan, Wei},
+  title   = {Water Retention in Fine-Grained Slate},
+  journal = {Studies in Calligraphic Materials},
+  year    = {2003},
+}
+
+@book{wong1987,
+  author = {Wong, Mei-Ling},
+  title  = {Grinding Slow: A Practical Manual for the Inkstone},
+  date   = {1987-05-01},
+}
+"#,
+    )?;
+    std::fs::write(
+        vault_dir.join("citations.md"),
+        "# Citation check\n\n\
+         Resolved keys chip: [@hayashi2003], grouped [@wong1987; @hayashi2003].\n\n\
+         A bracketed unknown flags red: [@phantom1999].\n\n\
+         Bare resolved chips: @hayashi2003 argues. Bare unresolved stays prose: \
+         @somehandle. Emails never chip: curator@example.com.\n\n\
+         Type below:\n\n",
+    )?;
+
+    let project = cx.update(|cx| {
+        project::Project::local(
+            app_state.client.clone(),
+            app_state.node_runtime.clone(),
+            app_state.user_store.clone(),
+            app_state.languages.clone(),
+            app_state.fs.clone(),
+            None,
+            project::LocalProjectFlags {
+                init_worktree_trust: false,
+                ..Default::default()
+            },
+            cx,
+        )
+    });
+
+    let bounds = Bounds {
+        origin: point(px(0.0), px(0.0)),
+        size: size(px(1280.0), px(800.0)),
+    };
+    let workspace_window: WindowHandle<Workspace> = cx.update(|cx| {
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                focus: false,
+                show: false,
+                ..Default::default()
+            },
+            |window, cx| {
+                cx.new(|cx| Workspace::new(None, project.clone(), app_state.clone(), window, cx))
+            },
+        )
+    })?;
+    cx.run_until_parked();
+
+    let add_worktree_task = workspace_window.update(cx, |workspace, _window, cx| {
+        workspace.project().update(cx, |project, cx| {
+            project.find_or_create_worktree(&vault_dir, true, cx)
+        })
+    })?;
+    cx.background_executor.allow_parking();
+    cx.foreground_executor
+        .block_test(add_worktree_task)
+        .context("Failed to add vault worktree")?;
+    cx.background_executor.forbid_parking();
+    cx.run_until_parked();
+
+    let open_task = workspace_window.update(cx, |workspace, window, cx| {
+        let worktree = workspace
+            .project()
+            .read(cx)
+            .worktrees(cx)
+            .next()
+            .context("vault worktree missing")?;
+        let worktree_id = worktree.read(cx).id();
+        let rel_path: std::sync::Arc<util::rel_path::RelPath> =
+            util::rel_path::rel_path("citations.md").into();
+        let project_path: project::ProjectPath = (worktree_id, rel_path).into();
+        anyhow::Ok(workspace.open_path(project_path, None, true, window, cx))
+    })??;
+    cx.background_executor.allow_parking();
+    let opened = cx.foreground_executor.block_test(open_task);
+    cx.background_executor.forbid_parking();
+    let item = opened.context("Failed to open citations.md")?;
+    cx.run_until_parked();
+
+    // The bibliography loads off the real filesystem on a detached task the
+    // test dispatcher cannot see the end of; poll it with parking allowed.
+    cx.background_executor.allow_parking();
+    for _ in 0..200 {
+        cx.run_until_parked();
+        let ready = cx.update(|cx| Bibliography::global(cx).read(cx).has_entries());
+        if ready {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    cx.background_executor.forbid_parking();
+    let ready = cx.update(|cx| Bibliography::global(cx).read(cx).has_entries());
+    anyhow::ensure!(ready, "bibliography never indexed refs.bib");
+    cx.run_until_parked();
+
+    let rendering = run_visual_test(
+        "citation_rendering",
+        workspace_window.into(),
+        cx,
+        update_baseline,
+    );
+
+    // Park the cursor at the end of the note and type a bare `@`, which must
+    // pop the cite-key completion menu.
+    let editor = item
+        .downcast::<editor::Editor>()
+        .context("citations.md did not open in an editor")?;
+    workspace_window.update(cx, |_workspace, window, cx| {
+        editor.update(cx, |editor, cx| {
+            editor.move_to_end(&editor::actions::MoveToEnd, window, cx);
+        });
+        let focus_handle = editor.read(cx).focus_handle(cx);
+        window.focus(&focus_handle, cx);
+    })?;
+    cx.run_until_parked();
+    cx.simulate_input(workspace_window.into(), "@");
+    cx.run_until_parked();
+
+    let menu_open = cx.update_window(workspace_window.into(), |_, _, cx| {
+        editor.read(cx).context_menu_visible()
+    })?;
+    anyhow::ensure!(menu_open, "typing @ did not open the completion menu");
+
+    let completion = run_visual_test(
+        "citation_completion_menu",
+        workspace_window.into(),
+        cx,
+        update_baseline,
+    );
+
+    workspace_window
+        .update(cx, |workspace, _window, cx| {
+            workspace.project().update(cx, |project, cx| {
+                let worktree_ids: Vec<_> =
+                    project.worktrees(cx).map(|wt| wt.read(cx).id()).collect();
+                for id in worktree_ids {
+                    project.remove_worktree(id, cx);
+                }
+            });
+        })
+        .log_err();
+    cx.update_window(workspace_window.into(), |_, window, _cx| {
+        window.remove_window();
+    })
+    .log_err();
+    cx.run_until_parked();
+
+    match (rendering?, completion?) {
+        (TestResult::Passed, TestResult::Passed) => Ok(TestResult::Passed),
+        (TestResult::BaselineUpdated(path), _) | (_, TestResult::BaselineUpdated(path)) => {
+            Ok(TestResult::BaselineUpdated(path))
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -2567,8 +2567,8 @@ fn run_tool_permissions_visual_tests(
 
 /// Drives the citation pipeline in a real rendered window: opens a vault
 /// carrying a `.bib` and a note, waits for the bibliography to index, and
-/// captures two baselines — the note's citation styling (resolved chips, a
-/// red-flagged bracketed unknown, a bare unresolved key left as prose) and
+/// captures two baselines — the note's citation styling (resolved chips
+/// bracketed and bare, red-flagged unknowns, an email left as prose) and
 /// the cite-key completion menu opened by typing `@` at the end of the note.
 #[cfg(target_os = "macos")]
 fn run_citation_pipeline_visual_tests(
@@ -2604,7 +2604,7 @@ fn run_citation_pipeline_visual_tests(
         "# Citation check\n\n\
          Resolved keys chip: [@hayashi2003], grouped [@wong1987; @hayashi2003].\n\n\
          A bracketed unknown flags red: [@phantom1999].\n\n\
-         Bare resolved chips: @hayashi2003 argues. Bare unresolved stays prose: \
+         Bare resolved chips: @hayashi2003 argues. Bare unresolved flags too: \
          @somehandle. Emails never chip: curator@example.com.\n\n\
          Type below:\n\n",
     )?;


### PR DESCRIPTION
Grounds Pandoc-style citations in the vault's `.bib` files — previously `[@key]` was a styled chip that resolved against nothing. This is the paper-writing feature picked over the other Obsidian/LaTeX gaps (backlinks panel, graph view, macros, eq numbering), which wait for user demand. All behavior was shaped by a live dogfooding session on suzuri-testbed; every finding from it is fixed and covered here.

## What's in it

- **Bibliography index** (`crates/markdown_live_preview/src/bibliography.rs`, new): a process-wide entity indexing every `.bib` in the project's worktrees, parsed with [`biblatex`](https://crates.io/crates/biblatex) on the background executor. Reloads on worktree changes — including files created or deleted after the project opened — and treats a mid-edit unparsable `.bib` as stale-not-empty so notes don't flash red while the user types in it. Resolution during the highlight pass is O(1) via a key set rebuilt on bib changes, so Zotero-sized libraries cost nothing per keystroke.
- **Cite-key completion**: `CitationCompletionProvider` wraps the editor's stock project provider. Typing `@` (bare or after `[`) in markdown offers each key exactly once — even when several `.bib` files carry copies of the same entry — in a menu sized to its content, with title/authors/year as completion documentation (BibLaTeX `date` fields yield a year; author-less entries degrade gracefully). Everything outside a citation context delegates to the wrapped provider, so markdown-oxide/LSP completions keep working; non-markdown buffers are untouched.
- **Unresolved-key verification**: a key resolving to no entry gets error-colored text with a wavy underline, bracketed or bare — Pandoc treats both as citations, and the initial bracketed-only rule confused its very first tester. Flagging only starts once the vault has a bibliography with entries, so `@handles` in bib-less vaults stay prose. Emails, URLs, code spans, link labels, and wikilinks never register.
- **Bare in-text citations** (`@key argues …`) chip and verify like bracketed ones; brackets are deliberately *not* auto-inserted on bare completion accepts, preserving Pandoc's narrative-vs-parenthetical distinction.
- **Hover cards**: hovering a resolved key, bracketed or bare, shows the title/authors/year card through the editor's ordinary hover pipeline (`CitationSemanticsProvider` wraps the stock semantics provider the way the completion wrapper does; LSP hovers, definitions, rename, and inlay hints delegate untouched).
- **Atomic deletion**: backspace right after `[@key]` (or forward-delete right before it) removes the whole citation as one token — one undo restores it — while the cursor inside the group still edits per-character.

## Fork hygiene

Fork-owned crates plus dependency manifests and the (fork-owned) visual test runner; no vendor files touched.

## Tests

- `cargo nextest run -p markdown_live_preview`: **97/97** — 14 new: parser fields/wrapped titles/date-to-year, malformed bib, context detection, resolve + live `.bib` reload, bib file deletion and late creation, bib-less vaults, completion + dedup + replace range, non-markdown delegation, bare-key flagging, atomic delete + undo, hover card (provider-level and through the editor's own hover pipeline).
- **Visual regression**: new `citation_pipeline` scenario in the offscreen runner renders the real app, waits for the bibliography to index off the real filesystem, screenshots the citation styling, types `@` through the input pipeline, asserts the menu opened, and screenshots it. `cargo run -p zed --bin zed_visual_test_runner --features visual-tests`.
- Scoped clippy clean; `cargo check -p zed` passes.

## Follow-ups (not in this PR)

- Zotero / Better BibTeX setup docs: #33.

Release Notes:

- Added a citation pipeline for markdown notes: cite-key completion from the project's `.bib` files, reference details in the completion menu, live re-resolution as bibliographies change, diagnostic styling for citation keys that don't resolve, reference cards on hover, and whole-token deletion of citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TscUVSzJgD87u49bdHoGR6
