### PR TITLE
Bump SUZURI_VERSION to 0.4.3

### DIFF
--- a/crates/suzuri_update/src/suzuri_update.rs
+++ b/crates/suzuri_update/src/suzuri_update.rs
@@ -52,7 +52,7 @@ use workspace::{
 /// Bump it in the same commit that gets tagged `suzuri-v<this version>`; the
 /// `check-version` job in `.github/workflows/suzuri-release.yml` enforces that
 /// the two agree.
-pub const SUZURI_VERSION: &str = "0.4.2";
+pub const SUZURI_VERSION: &str = "0.4.3";
 
 /// The repository whose releases describe newer Suzuri builds.
 const RELEASE_REPOSITORY: &str = "harrywang/suzuri";


### PR DESCRIPTION
Release bump for `suzuri-v0.4.3`, whose headline change is the bibliography-backed citation pipeline (#32).

`SUZURI_VERSION` is what a running build compares against the newest GitHub release, so it has to agree with the tag; the `check-version` job fails the release otherwise. Tagging follows once this lands.

Since 0.4.2:

- Citation pipeline (#32): cite-key completion from the project's `.bib` files, reference details in the completion menu and on hover, live re-resolution as bibliographies change, diagnostic styling for keys that don't resolve, and whole-token deletion of citations.

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TscUVSzJgD87u49bdHoGR6