### PR TITLE
Add Linux tarballs to the release workflow

### DIFF
--- a/.github/workflows/suzuri-release.yml
+++ b/.github/workflows/suzuri-release.yml
@@ -1,7 +1,8 @@
 # Suzuri's release pipeline (AgentFit-style): push a `suzuri-v*` tag and a
-# GitHub Release appears with macOS DMGs (both architectures) and a Windows
-# installer. Deliberately separate from Zed's own release.yml, which targets
-# Namespace runners this fork does not have.
+# GitHub Release appears with macOS DMGs (both architectures), a Windows
+# installer, and Linux tarballs (both architectures). Deliberately separate
+# from Zed's own release.yml, which targets Namespace runners this fork does
+# not have.
 #
 # macOS builds sign and notarize automatically when the repo has the same
 # five secrets AgentFit's release flow uses: CERTIFICATE_P12,
@@ -155,8 +156,57 @@ jobs:
           name: windows-installer
           path: target/suzuri-windows-x86_64.exe
 
+  build-linux:
+    needs: check-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The oldest hosted image still offered. The tarball links against
+          # the builder's glibc, so a newer image would shut out users on
+          # older distributions; Zed builds on 20.04 for the same reason.
+          - arch: x86_64
+            runner: ubuntu-22.04
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 350
+    env:
+      CC: clang
+      CXX: clang++
+      # bundle-linux strips debug info anyway; not generating it keeps the
+      # target dir within a hosted runner's disk.
+      CARGO_PROFILE_RELEASE_DEBUG: "false"
+    steps:
+      - uses: actions/checkout@v5
+
+      # Hosted Ubuntu images leave roughly 20G free, and a release build of
+      # the workspace needs more. Toolchains nothing here uses are the
+      # cheapest space to reclaim.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          df -h /
+
+      - name: Install build dependencies
+        run: ./script/linux
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: bundle-linux-${{ matrix.arch }}
+          cache-on-failure: true
+
+      - name: Build tarball
+        run: ./script/bundle-linux
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: linux-${{ matrix.arch }}
+          path: target/release/suzuri-linux-${{ matrix.arch }}.tar.gz
+          if-no-files-found: error
+
   release:
-    needs: [build-mac, build-windows]
+    needs: [build-mac, build-windows, build-linux]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ The fork's own changes are small and additive:
 | Jupyter notebooks enabled by default (temporary; see below) | `crates/feature_flags/src/flags.rs`, `crates/repl/src/notebook/notebook_ui.rs`, `crates/repl/src/repl_editor.rs` |
 | Update notifications | `crates/suzuri_update/`, `crates/zed/src/zed/app_menus.rs` (the Check for Updates entry) |
 | Settings plumbing | `crates/settings_content/`, `assets/settings/default.json` |
-| Branding, CLI name, release infrastructure | `crates/zed/Cargo.toml` (bundle metadata), `crates/zed/resources/app-icon-suzuri*`, `crates/zed/resources/windows/app-icon-suzuri.ico`, `assets/images/suzuri_logo.svg`, `crates/install_cli/src/install_cli_binary.rs`, `script/bundle-mac`, `script/bundle-windows.ps1`, `.github/workflows/suzuri-release.yml` |
+| Branding, CLI name, release infrastructure | `crates/zed/Cargo.toml` (bundle metadata), `crates/zed/resources/app-icon-suzuri*`, `crates/zed/resources/windows/app-icon-suzuri.ico`, `assets/images/suzuri_logo.svg`, `crates/install_cli/src/install_cli_binary.rs`, `script/bundle-mac`, `script/bundle-windows.ps1`, `script/bundle-linux`, `.github/workflows/suzuri-release.yml` |
 
 `git log --author="Harry Wang" --name-only` is the authoritative list of touched files.
 When editing anything outside that set, assume you are modifying upstream code and keep

--- a/README.md
+++ b/README.md
@@ -28,8 +28,19 @@ Download the latest installer:
 - [macOS — Apple Silicon](../../releases/latest/download/suzuri-aarch64.dmg)
 - [macOS — Intel](../../releases/latest/download/suzuri-x86_64.dmg)
 - [Windows](../../releases/latest/download/suzuri-windows-x86_64.exe)
+- [Linux — x86_64](../../releases/latest/download/suzuri-linux-x86_64.tar.gz)
+- [Linux — ARM64](../../releases/latest/download/suzuri-linux-aarch64.tar.gz)
 
 The macOS builds are signed and notarized — open the DMG and drag Suzuri to Applications. The Windows installer is not yet signed, so SmartScreen shows a warning: choose "More info → Run anyway".
+
+The Linux build is a plain tarball. Extract it somewhere permanent, put its `bin/suzuri` on your PATH, and optionally copy its `share/` folder into `~/.local/share` for an app-menu entry and icon:
+
+```sh
+mkdir -p ~/.local/bin
+tar -xzf suzuri-linux-x86_64.tar.gz -C ~/.local
+ln -sf ~/.local/suzuri.app/bin/suzuri ~/.local/bin/suzuri
+cp -r ~/.local/suzuri.app/share/. ~/.local/share/
+```
 
 Or build from source, the same way Zed builds:
 

--- a/crates/suzuri_update/src/suzuri_update.rs
+++ b/crates/suzuri_update/src/suzuri_update.rs
@@ -313,6 +313,7 @@ fn download_url_for_host<'a>(release: &'a GithubRelease, os: &str, arch: &str) -
     let matches = |asset: &GithubReleaseAsset| match os {
         "macos" => asset.name.ends_with(".dmg") && asset.name.contains(arch),
         "windows" => asset.name.ends_with(".exe") && asset.name.contains("windows"),
+        "linux" => asset.name.ends_with(".tar.gz") && asset.name.contains(arch),
         _ => false,
     };
 
@@ -486,6 +487,8 @@ mod tests {
                 "suzuri-aarch64.dmg",
                 "suzuri-x86_64.dmg",
                 "suzuri-windows-x86_64.exe",
+                "suzuri-linux-x86_64.tar.gz",
+                "suzuri-linux-aarch64.tar.gz",
             ],
         );
 
@@ -501,9 +504,14 @@ mod tests {
             download_url_for_host(&release, "windows", "x86_64"),
             Some("https://example.test/suzuri-windows-x86_64.exe")
         );
-        // Linux has no artifact in the release workflow; callers fall back to
-        // the release page rather than offering a macOS disk image.
-        assert_eq!(download_url_for_host(&release, "linux", "x86_64"), None);
+        assert_eq!(
+            download_url_for_host(&release, "linux", "x86_64"),
+            Some("https://example.test/suzuri-linux-x86_64.tar.gz")
+        );
+        assert_eq!(
+            download_url_for_host(&release, "linux", "aarch64"),
+            Some("https://example.test/suzuri-linux-aarch64.tar.gz")
+        );
     }
 
     #[test]

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -145,12 +145,17 @@ fi
 # Move everything that should end up in the final package
 # into a temp directory.
 temp_dir=$(mktemp -d)
-zed_dir="${temp_dir}/zed$suffix.app"
+# SUZURI: the extracted folder is user-facing, like the DMG volume name on
+# macOS. Everything inside it keeps Zed's layout: the CLI locates the editor
+# at ../libexec/zed-editor relative to itself.
+zed_dir="${temp_dir}/suzuri.app"
 
 # Binary
 mkdir -p "${zed_dir}/bin" "${zed_dir}/libexec"
 cp "${target_dir}/${target_triple}/release/zed" "${zed_dir}/libexec/zed-editor"
-cp "${target_dir}/${target_triple}/release/cli" "${zed_dir}/bin/zed"
+# SUZURI: the command is `suzuri`, matching the macOS CLI, so it never
+# clobbers a real `zed` on PATH.
+cp "${target_dir}/${target_triple}/release/cli" "${zed_dir}/bin/suzuri"
 
 # Libs
 # Bundle libstdc++ so older supported systems can run binaries built with our
@@ -171,15 +176,17 @@ rm -rf "${zed_dir}/lib/*"
 cp $(find_libs) "${zed_dir}/lib"
 
 # Icons
+# SUZURI: Suzuri's icon under its own name, so an installed Zed's icon is never
+# shadowed; APP_ICON below must agree with the filename.
 mkdir -p "${zed_dir}/share/icons/hicolor/512x512/apps"
-cp "crates/zed/resources/app-icon$suffix.png" "${zed_dir}/share/icons/hicolor/512x512/apps/zed.png"
+cp "crates/zed/resources/app-icon-suzuri.png" "${zed_dir}/share/icons/hicolor/512x512/apps/suzuri.png"
 mkdir -p "${zed_dir}/share/icons/hicolor/1024x1024/apps"
-cp "crates/zed/resources/app-icon$suffix@2x.png" "${zed_dir}/share/icons/hicolor/1024x1024/apps/zed.png"
+cp "crates/zed/resources/app-icon-suzuri@2x.png" "${zed_dir}/share/icons/hicolor/1024x1024/apps/suzuri.png"
 
 # .desktop
 export DO_STARTUP_NOTIFY="true"
-export APP_CLI="zed"
-export APP_ICON="zed"
+export APP_CLI="suzuri"
+export APP_ICON="suzuri"
 export APP_ARGS="%U"
 if [[ "$channel" == "preview" ]]; then
   export APP_NAME="Zed Preview"
@@ -188,8 +195,10 @@ elif [[ "$channel" == "nightly" ]]; then
   export APP_NAME="Zed Nightly"
   APP_ID="dev.zed.Zed-Nightly"
 elif [[ "$channel" == "dev" ]]; then
-  export APP_NAME="Zed Devel"
-  APP_ID="dev.zed.Zed-Dev"
+  # SUZURI: dev is Suzuri's release channel (see CLAUDE.md), so this branch
+  # carries its branding. The identifier matches Cargo.toml's bundle metadata.
+  export APP_NAME="Suzuri"
+  APP_ID="app.suzuri.Suzuri"
 else
   export APP_NAME="Zed"
   APP_ID="dev.zed.Zed"
@@ -204,11 +213,11 @@ cp "assets/licenses.md" "${zed_dir}/licenses.md"
 
 # Create archive out of everything that's in the temp directory
 arch=$(uname -m)
-archive="zed-linux-${arch}.tar.gz"
+archive="suzuri-linux-${arch}.tar.gz"
 
 rm -rf "${archive}"
 remove_match="zed(-[a-zA-Z0-9]+)?-linux-$(uname -m)\.tar\.gz"
 ls "${target_dir}/release" | grep -E ${remove_match} | xargs -d "\n" -I {} rm -f "${target_dir}/release/{}" || true
-tar -czvf "${target_dir}/release/$archive" -C ${temp_dir} "zed$suffix.app"
+tar -czvf "${target_dir}/release/$archive" -C ${temp_dir} "suzuri.app"
 
 gzip -f --stdout --best "${target_dir}/${remote_server_triple}/release/remote_server" > "${target_dir}/zed-remote-server-linux-${arch}.gz"


### PR DESCRIPTION
Closes #39.

The release workflow now builds Linux tarballs for x86_64 and aarch64 on GitHub-hosted runners (`ubuntu-22.04` and `ubuntu-22.04-arm`), alongside the macOS DMGs and Windows installer. The oldest hosted image is used deliberately: the tarball links against the builder's glibc, so a newer image would shut out users on older distributions.

## What changed

- **`.github/workflows/suzuri-release.yml`** — new `build-linux` matrix job. It installs Zed's dependency list with `script/linux`, frees the unused toolchains from the hosted image, disables debug info (the bundle script strips it anyway), and runs `script/bundle-linux`. The `release` job now waits on it.
- **`script/bundle-linux`** — Zed's script with the dev-channel branch rebranded. The tarball's internal layout (`bin/`, `libexec/zed-editor`, `lib/`, `share/`) stays Zed's, because the CLI locates the editor relative to itself. What changes: the extracted folder is `suzuri.app`, the CLI is `bin/suzuri` (matching the macOS command, never clobbering a real `zed`), the icon and desktop entry carry Suzuri's name and the `app.suzuri.Suzuri` id from the bundle metadata, and the archive is `suzuri-linux-<arch>.tar.gz`. Every hunk is tagged `SUZURI:`.
- **`crates/suzuri_update`** — the update notification now picks the matching tarball for Linux hosts instead of falling back to the release page. Test updated.
- **`README.md`** — download links and a four-line install snippet for Linux.
- **`CLAUDE.md`** — `script/bundle-linux` added to the fork-owned file table.

## Verification

- `bash -n script/bundle-linux`, workflow YAML parsed, `cargo fmt` clean.
- `cargo nextest run -p suzuri_update`: 11 passed.
- The workflow itself has not run yet; it only triggers on a `suzuri-v*` tag or manual dispatch. A `workflow_dispatch` run from this branch before the next release would confirm the hosted runners have enough disk and that `ubuntu-22.04-arm` picks up for this repository.

## Not included

A Flatpak, which the issue also mentions. Zed's `script/flatpak/bundle-flatpak` needs `flatpak-builder` plus a manifest with Zed's app ids and release metadata rewritten; that is a separate piece of work once the tarball is confirmed to run.

Release Notes:

- Added Linux builds (x86_64 and ARM64 tarballs) to every release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdAoJiVdPU8Xu75Szb6bwJ
