### PR TITLE
Bump SUZURI_VERSION to 0.4.4

### DIFF
--- a/crates/suzuri_update/src/suzuri_update.rs
+++ b/crates/suzuri_update/src/suzuri_update.rs
@@ -52,7 +52,7 @@ use workspace::{
 /// Bump it in the same commit that gets tagged `suzuri-v<this version>`; the
 /// `check-version` job in `.github/workflows/suzuri-release.yml` enforces that
 /// the two agree.
-pub const SUZURI_VERSION: &str = "0.4.3";
+pub const SUZURI_VERSION: &str = "0.4.4";
 
 /// The repository whose releases describe newer Suzuri builds.
 const RELEASE_REPOSITORY: &str = "harrywang/suzuri";


### PR DESCRIPTION
# Objective

Cut v0.4.4, the first release Linux users can install from. `SUZURI_VERSION` is still `0.4.3`, which is already released, so `check-version` would reject a `suzuri-v0.4.4` tag until this constant moves.

## Solution

Bump `SUZURI_VERSION` to `0.4.4` in `crates/suzuri_update/src/suzuri_update.rs`. One line; the tag `suzuri-v0.4.4` goes on the merge of this PR.

Two commits since v0.4.3, both release infrastructure:

- #40 — the workflow builds x86_64 and aarch64 Linux tarballs, and `suzuri_update` picks the matching one on Linux hosts.
- #41 — the aarch64 tarball links compiler-rt builtins so it links at all. The prebuilt libwebrtc archive carries SME-enabled libyuv routines calling `__arm_tpidr2_save`, which the hosted `ubuntu-22.04-arm` image's GCC 11 libgcc does not define.

## Testing

The builds are already proven on exactly this tree — `git diff 5af1031 main` is empty, so main is byte-identical to the branch CI last built:

| Job | Result |
| --- | --- |
| build-linux (aarch64, ubuntu-22.04-arm) | ✅ run 33830897289, with the compiler-rt step |
| build-linux (x86_64, ubuntu-22.04) | ✅ run 33827461634 |
| build-mac (aarch64-apple-darwin) | ✅ run 33827461634 |
| build-mac (x86_64-apple-darwin) | ✅ run 33827461634 |
| build-windows | ✅ run 33827461634 |

Run 33827461634 predates the compiler-rt step, but that step is scoped to `build-linux`, so it cannot affect the mac and Windows results. What has never run to completion is the `release` job, which only fires on a `suzuri-v*` tag: it was skipped in 33827461634 (aarch64 red) and cancelled in 33830897289. Tagging this merge is what exercises it.

Not verified locally: this changes one string constant, and nothing reads it at compile time beyond the `check-version` job's `sed`, which this satisfies by construction.

Release Notes:

- Added Linux downloads: the release now publishes x86_64 and aarch64 tarballs alongside the macOS DMGs and the Windows installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYyrhZPPHanEGG2HwuQSXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYyrhZPPHanEGG2HwuQSXF)_