### PR TITLE
Ship and download the remote server so SSH remoting works from releases

### DIFF
--- a/.github/workflows/suzuri-release.yml
+++ b/.github/workflows/suzuri-release.yml
@@ -1,6 +1,8 @@
 # Suzuri's release pipeline (AgentFit-style): push a `suzuri-v*` tag and a
 # GitHub Release appears with macOS DMGs (both architectures), a Windows
-# installer, and Linux tarballs (both architectures). Deliberately separate
+# installer, and Linux tarballs (both architectures), plus the
+# `zed-remote-server-<os>-<arch>` binaries a running Suzuri copies onto an SSH
+# host (fetched by version tag; see `suzuri_update`). Deliberately separate
 # from Zed's own release.yml, which targets Namespace runners this fork does
 # not have.
 #
@@ -99,7 +101,10 @@ jobs:
       - uses: actions/upload-artifact@v6
         with:
           name: dmg-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/suzuri-*.dmg
+          path: |
+            target/${{ matrix.target }}/release/suzuri-*.dmg
+            target/zed-remote-server-macos-*.gz
+          if-no-files-found: error
 
   build-windows:
     needs: check-version
@@ -154,7 +159,10 @@ jobs:
       - uses: actions/upload-artifact@v6
         with:
           name: windows-installer
-          path: target/suzuri-windows-x86_64.exe
+          path: |
+            target/suzuri-windows-x86_64.exe
+            target/zed-remote-server-windows-x86_64.zip
+          if-no-files-found: error
 
   build-linux:
     needs: check-version
@@ -226,7 +234,12 @@ jobs:
       - uses: actions/upload-artifact@v6
         with:
           name: linux-${{ matrix.arch }}
-          path: target/release/suzuri-linux-${{ matrix.arch }}.tar.gz
+          # bundle-linux also builds the statically linked musl remote server;
+          # without it in the release, SSH remoting from a shipped build has
+          # nothing to install on the host.
+          path: |
+            target/release/suzuri-linux-${{ matrix.arch }}.tar.gz
+            target/zed-remote-server-linux-${{ matrix.arch }}.gz
           if-no-files-found: error
 
   release:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ The fork's own changes are small and additive:
 | Preview button for `.typ`/`.tex` | `crates/zed/src/zed/quick_action_bar/preview.rs` |
 | Jupyter notebooks enabled by default (temporary; see below) | `crates/feature_flags/src/flags.rs`, `crates/repl/src/notebook/notebook_ui.rs`, `crates/repl/src/repl_editor.rs` |
 | Update notifications | `crates/suzuri_update/`, `crates/zed/src/zed/app_menus.rs` (the Check for Updates entry) |
+| Remote server provisioning on the dev channel (SSH/Docker/WSL remotes; see "Cutting a release") | `crates/auto_update/src/auto_update.rs` (`get_release_asset`), `crates/remote/src/transport/ssh.rs`, `docker.rs`, `wsl.rs` (`ensure_server_binary`) |
 | Settings plumbing | `crates/settings_content/`, `assets/settings/default.json` |
 | Branding, CLI name, release infrastructure | `crates/zed/Cargo.toml` (bundle metadata), `crates/zed/resources/app-icon-suzuri*`, `crates/zed/resources/windows/app-icon-suzuri.ico`, `assets/images/suzuri_logo.svg`, `crates/install_cli/src/install_cli_binary.rs`, `script/bundle-mac`, `script/bundle-windows.ps1`, `script/bundle-linux`, `.github/workflows/suzuri-release.yml` |
 
@@ -286,6 +287,18 @@ upstream Zed's own (`Bump Zed to v1.17.0`), which upstream bumps on its own cade
 and every merge brings along — it tracks the Zed base this fork is built on, not
 Suzuri's releases, and the two number lines are unrelated. `SUZURI_VERSION` lives in
 a fork-owned file precisely so no merge can move it.
+
+**Remote development rides on the release assets.** A shipped build copies
+`zed-remote-server-<os>-<arch>` onto an SSH host, and fetches it from the GitHub
+release for `SUZURI_VERSION` (`suzuri_update::remote_server_download_url`). Upstream's
+`dev` channel refuses to download a server at all and names it `...-dev-build`, so the
+fork patches `ensure_server_binary` in the SSH/Docker/WSL transports and
+`AutoUpdater::get_release_asset` (all tagged `SUZURI:`) to treat `dev` like a release.
+Three consequences: every bundle job must publish its remote server (the workflow's
+upload steps do, with `if-no-files-found: error`); client and server must come from the
+same commit, so never replace a release's assets by hand; and a locally bundled,
+untagged build will look for a release that does not exist — dogfood remoting from a
+debug build, which compiles the server from source instead.
 
 `suzuri_update` only *notifies*; it never installs. Zed's installer (`auto_update`)
 is not wired up, and adopting it would need, at minimum, its hardcoded `Zed` DMG

--- a/crates/auto_update/Cargo.toml
+++ b/crates/auto_update/Cargo.toml
@@ -27,6 +27,7 @@ serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 smol.workspace = true
+suzuri_update.workspace = true # SUZURI: remote server download URL
 tempfile.workspace = true
 util.workspace = true
 workspace.workspace = true

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -676,6 +676,15 @@ impl AutoUpdater {
         arch: &str,
         cx: &mut AsyncApp,
     ) -> Result<ReleaseAsset> {
+        // SUZURI: Suzuri publishes its remote servers as GitHub release assets;
+        // the release index queried below only knows Zed's builds.
+        if asset == "zed-remote-server" {
+            return Ok(ReleaseAsset {
+                version: suzuri_update::SUZURI_VERSION.to_string(),
+                url: suzuri_update::remote_server_download_url(os, arch),
+            });
+        }
+
         let client = this.read_with(cx, |this, _| this.client.clone());
 
         let (system_id, metrics_id, is_staff) = if client.telemetry().metrics_enabled() {

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -218,7 +218,9 @@ impl DockerExecConnection {
                 let commit = commit.map(|s| s.full()).unwrap_or_default();
                 format!("{}-{}", version, commit)
             }
-            ReleaseChannel::Dev => "build".to_string(),
+            // SUZURI: dev builds are releases here, so name the server by
+            // version like the other channels; a fixed name would keep reusing
+            // a stale server on the host after the client updates.
             _ => version.to_string(),
         };
         let binary_name = format!(
@@ -272,16 +274,12 @@ impl DockerExecConnection {
             return Ok(dst_path.into());
         }
 
+        // SUZURI: dev builds download their server like a release does; see
+        // suzuri_update::remote_server_download_url for where from.
         let wanted_version = cx.update(|cx| match release_channel {
-            ReleaseChannel::Nightly => Ok(None),
-            ReleaseChannel::Dev => {
-                anyhow::bail!(
-                    "ZED_BUILD_REMOTE_SERVER is not set and no remote server exists at ({:?})",
-                    dst_path
-                )
-            }
-            _ => Ok(Some(AppVersion::global(cx))),
-        })?;
+            ReleaseChannel::Nightly => None,
+            _ => Some(AppVersion::global(cx)),
+        });
 
         let tmp_path_gz = paths::remote_server_dir_relative().join(
             RelPath::from_unix_str(&format!(

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -837,10 +837,10 @@ impl SshRemoteConnection {
         version: Version,
         cx: &mut AsyncApp,
     ) -> Result<Arc<RelPath>> {
-        let version_str = match release_channel {
-            ReleaseChannel::Dev => "build".to_string(),
-            _ => version.to_string(),
-        };
+        // SUZURI: dev builds are releases here, so name the server by version
+        // like the other channels; a fixed name would keep reusing a stale
+        // server on the host after the client updates.
+        let version_str = version.to_string();
         let binary_name = format!(
             "zed-remote-server-{}-{}{}",
             release_channel.dev_name(),
@@ -893,16 +893,12 @@ impl SshRemoteConnection {
             return Ok(dst_path.into());
         }
 
+        // SUZURI: dev builds download their server like a release does; see
+        // suzuri_update::remote_server_download_url for where from.
         let wanted_version = cx.update(|cx| match release_channel {
-            ReleaseChannel::Nightly => Ok(None),
-            ReleaseChannel::Dev => {
-                anyhow::bail!(
-                    "ZED_BUILD_REMOTE_SERVER is not set and no remote server exists at ({:?})",
-                    dst_path
-                )
-            }
-            _ => Ok(Some(AppVersion::global(cx))),
-        })?;
+            ReleaseChannel::Nightly => None,
+            _ => Some(AppVersion::global(cx)),
+        });
 
         let tmp_path_compressed = remote_server_dir_relative().join(
             RelPath::from_unix_str(&format!(

--- a/crates/remote/src/transport/wsl.rs
+++ b/crates/remote/src/transport/wsl.rs
@@ -194,10 +194,10 @@ impl WslRemoteConnection {
         version: Version,
         cx: &mut AsyncApp,
     ) -> Result<Arc<RelPath>> {
-        let version_str = match release_channel {
-            ReleaseChannel::Dev => "build".to_string(),
-            _ => version.to_string(),
-        };
+        // SUZURI: dev builds are releases here, so name the server by version
+        // like the other channels; a fixed name would keep reusing a stale
+        // server on the host after the client updates.
+        let version_str = version.to_string();
 
         let binary_name = format!(
             "zed-remote-server-{}-{}",

--- a/crates/suzuri_update/src/suzuri_update.rs
+++ b/crates/suzuri_update/src/suzuri_update.rs
@@ -14,6 +14,9 @@
 //!
 //! The version being compared is [`SUZURI_VERSION`], not the crate version —
 //! see that constant for why.
+//!
+//! The same constant also names the release a running build fetches its
+//! remote server from; see [`remote_server_download_url`].
 
 use anyhow::{Context as _, Result};
 use gpui::{
@@ -306,6 +309,21 @@ fn release_page_url(tag_name: &str) -> String {
     format!("https://github.com/{RELEASE_REPOSITORY}/releases/tag/{tag_name}")
 }
 
+/// Where this build fetches the remote server it copies onto an SSH host.
+///
+/// Zed's client asks its own release index for that binary, which knows nothing
+/// about Suzuri builds and, on the `dev` channel Suzuri ships on, refuses to ask
+/// at all. The release workflow publishes the same `zed-remote-server-<os>-<arch>`
+/// artifacts Zed does under this build's own tag, so the asset named here is
+/// the server built from the same commit as the client requesting it.
+pub fn remote_server_download_url(os: &str, arch: &str) -> String {
+    let extension = if os == "windows" { "zip" } else { "gz" };
+    format!(
+        "https://github.com/{RELEASE_REPOSITORY}/releases/download/\
+         {RELEASE_TAG_PREFIX}{SUZURI_VERSION}/zed-remote-server-{os}-{arch}.{extension}"
+    )
+}
+
 /// Picks the asset a user on this OS and CPU should download, matching on shape
 /// rather than exact filenames so that renaming an artifact in the release
 /// workflow degrades to the release page instead of linking to a 404.
@@ -477,6 +495,24 @@ mod tests {
         // though plain semver ordering would say otherwise.
         assert!(!is_newer(&Version::new(0, 2, 0), &current));
         assert!(!is_newer(&Version::new(0, 1, 9), &current));
+    }
+
+    #[test]
+    fn test_remote_server_download_url_names_this_builds_release() {
+        assert_eq!(
+            remote_server_download_url("linux", "x86_64"),
+            format!(
+                "https://github.com/harrywang/suzuri/releases/download/\
+                 suzuri-v{SUZURI_VERSION}/zed-remote-server-linux-x86_64.gz"
+            )
+        );
+        assert_eq!(
+            remote_server_download_url("windows", "aarch64"),
+            format!(
+                "https://github.com/harrywang/suzuri/releases/download/\
+                 suzuri-v{SUZURI_VERSION}/zed-remote-server-windows-aarch64.zip"
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #37.

SSH remoting fails from every shipped Suzuri build with `ZED_BUILD_REMOTE_SERVER is not set and no remote server exists at (".zed_server/zed-remote-server-dev-build")`. Two things are missing, and this PR adds both:

**1. Releases never carried the remote server.** `bundle-linux`, `bundle-mac`, and `bundle-windows.ps1` already build `remote_server` next to the app (Linux as a static musl binary), but the upload steps only kept the app. The first commit adds the `zed-remote-server-<os>-<arch>` gz/zip to each bundle job's artifact, so the release ends up with the same set of server binaries Zed's releases do.

**2. The client had no way to fetch one.** Suzuri ships on Zed's `dev` channel (deliberately, to keep Zed's auto-updater dormant). On that channel `ensure_server_binary` names the server `...-dev-build`, assumes it was compiled from source, and bails when it is absent; the other channels ask Zed's release index, which knows nothing about Suzuri. The second commit:

- names the server by version on `dev` like the other channels, so a stale server left on a host from an older Suzuri is not reused;
- requests a versioned download on `dev` instead of bailing (SSH and Docker; WSL already did);
- answers `AutoUpdater::get_release_asset` for `zed-remote-server` with the GitHub release asset for `SUZURI_VERSION`, via a new `suzuri_update::remote_server_download_url`.

Four small `SUZURI:`-tagged hunks in vendor files (`auto_update.rs`, `transport/ssh.rs`, `docker.rs`, `wsl.rs`) plus one new `auto_update -> suzuri_update` dependency. CLAUDE.md gains the table row and a "Cutting a release" note explaining the coupling.

**Both halves have to ship in the same release.** A client from this branch looks for `https://github.com/harrywang/suzuri/releases/download/suzuri-v<SUZURI_VERSION>/zed-remote-server-linux-x86_64.gz`, so the first release that fixes #37 is the first tag cut after this merges (0.4.5). The v0.4.4 build currently running will still lack the assets.

**Verification**

- `cargo check -p auto_update -p remote -p suzuri_update` passes.
- `cargo nextest run -p suzuri_update -p auto_update`: 27 pass, including the new `test_remote_server_download_url_names_this_builds_release`. The one failure, `auto_update::test_auto_update_downloads` ("database not initialized"), fails identically on the untouched upstream file and is unrelated.
- Not exercised end to end: needs a tagged release for the asset URL to resolve. After 0.4.5 is out, connect to a Linux host from the bundled app and confirm `~/.zed_server/zed-remote-server-dev-<version>` appears.

Release Notes:

- Fixed SSH remote projects failing because no remote server binary was published or downloadable; releases now ship `zed-remote-server` for Linux, macOS, and Windows and the client fetches the one matching its version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxFtVT4V8D2nry4Tx4Wufc
