### PR TITLE
Bump SUZURI_VERSION to 0.4.5

### DIFF
--- a/crates/suzuri_update/src/suzuri_update.rs
+++ b/crates/suzuri_update/src/suzuri_update.rs
@@ -55,7 +55,7 @@ use workspace::{
 /// Bump it in the same commit that gets tagged `suzuri-v<this version>`; the
 /// `check-version` job in `.github/workflows/suzuri-release.yml` enforces that
 /// the two agree.
-pub const SUZURI_VERSION: &str = "0.4.4";
+pub const SUZURI_VERSION: &str = "0.4.5";
 
 /// The repository whose releases describe newer Suzuri builds.
 const RELEASE_REPOSITORY: &str = "harrywang/suzuri";


### PR DESCRIPTION
Bumps `SUZURI_VERSION` to 0.4.5 for the first release that includes #43, which fixes #37: the release workflow now publishes the `zed-remote-server-<os>-<arch>` binaries and the client downloads the one for its version from the GitHub release, so SSH remoting works from a shipped build.

After merging, tag the merge commit and push the tag:

```sh
git tag suzuri-v0.4.5 <merge commit>
git push origin suzuri-v0.4.5
```

The `check-version` job refuses a tag that disagrees with the constant, and the v0.4.4 run in progress is unaffected: it builds from its own tagged commit and ships without the remote server assets, as before.

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxFtVT4V8D2nry4Tx4Wufc
