### PR TITLE
Open a link's target on a plain click in live preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,7 @@ dependencies = [
  "serde_json",
  "settings",
  "smol",
+ "suzuri_update",
  "tempfile",
  "util",
  "which",

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -461,6 +461,14 @@ enum InlineKind {
     /// A footnote reference (`[^label]`), rendered as a raised chip carrying
     /// the label, the way a preview renders a superscript marker.
     Footnote { label: SharedString },
+    /// A link rendered as its display text, opening its target on a plain
+    /// click the way Obsidian's live preview does. The whole construct is
+    /// concealed rather than just its syntax so the text can own the click;
+    /// putting the cursor next to it hands back the raw markdown to edit.
+    Link {
+        destination: LinkDestination,
+        label: SharedString,
+    },
     /// A LaTeX formula (`$x$` or `$$x$$`), rendered as a typeset image.
     ///
     /// Rendering is asynchronous, so the placeholder reads whatever the shared
@@ -471,6 +479,16 @@ enum InlineKind {
         source: SharedString,
         style: MathStyle,
     },
+}
+
+/// Where a clickable link leads.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum LinkDestination {
+    /// What follows `[[` up to the alias pipe: a note name, with its
+    /// `#heading` part if any, resolved against the whole project.
+    Wikilink(SharedString),
+    /// A markdown link's destination: a URL, or a path relative to the note.
+    Markdown(SharedString),
 }
 
 struct BlockMarker {
@@ -1027,6 +1045,7 @@ fn apply_decorations(editor: &mut Editor, cx: &mut Context<Editor>) {
             InlineKind::Bullet
             | InlineKind::Checkbox { .. }
             | InlineKind::Footnote { .. }
+            | InlineKind::Link { .. }
             | InlineKind::Math { .. } => &marker.range,
         };
         let span = reveal_span.start.to_offset(&snapshot).0..reveal_span.end.to_offset(&snapshot).0;
@@ -1714,31 +1733,56 @@ fn resolve_embed_target(
     best.map(|(_, _, path, absolute)| (path, absolute))
 }
 
+/// A lowercase heading title as a GitHub-style anchor slug: punctuation
+/// dropped, whitespace and hyphens collapsed to single hyphens.
+fn heading_slug(title: &str) -> String {
+    let mut slug = String::with_capacity(title.len());
+    let mut pending_hyphen = false;
+    for character in title.chars() {
+        if character.is_alphanumeric() || character == '_' {
+            if pending_hyphen && !slug.is_empty() {
+                slug.push('-');
+            }
+            pending_hyphen = false;
+            slug.push(character);
+        } else if character.is_whitespace() || character == '-' {
+            pending_hyphen = true;
+        }
+    }
+    slug
+}
+
+/// An ATX heading's level and trimmed title, or `None` for any other line.
+fn heading_title(line: &str) -> Option<(usize, &str)> {
+    let hashes = line
+        .chars()
+        .take_while(|character| *character == '#')
+        .count();
+    if !(1..=6).contains(&hashes) {
+        return None;
+    }
+    line.get(hashes..)
+        .map(str::trim)
+        .map(|title| (hashes, title))
+}
+
 /// The slice of a note under one heading: from that heading to the next one at
 /// the same or a higher level. Returns `None` when the note has no such
 /// heading, which the card reports rather than silently embedding everything.
 fn embed_section(text: &str, section: &str) -> Option<String> {
     let wanted = section.trim().to_lowercase();
-    let heading_level = |line: &str| {
-        let hashes = line
-            .chars()
-            .take_while(|character| *character == '#')
-            .count();
-        (1..=6).contains(&hashes).then_some(hashes)
-    };
 
     let mut lines = text.lines().enumerate();
     let (start, level) = lines.find_map(|(index, line)| {
-        let level = heading_level(line)?;
-        let title = line[level..].trim().to_lowercase();
-        (title == wanted).then_some((index, level))
+        let (level, title) = heading_title(line)?;
+        (title.to_lowercase() == wanted).then_some((index, level))
     })?;
 
     let end = text
         .lines()
         .enumerate()
         .skip(start + 1)
-        .find(|(_, line)| heading_level(line).is_some_and(|found| found <= level))
+        .find(|(_, line)| heading_title(line).is_some_and(|(found, _)| found <= level))
         .map_or(text.lines().count(), |(index, _)| index);
     Some(
         text.lines()
@@ -1864,6 +1908,9 @@ fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPl
     // element at its measured width.
     let collapsed_text = match &marker.kind {
         InlineKind::Hide { .. } => Some(SharedString::new_static("")),
+        // The label stands in for the link in the display text, so soft
+        // wrapping and the cursor's column math see the width that is drawn.
+        InlineKind::Link { label, .. } => Some(label.clone()),
         InlineKind::Bullet
         | InlineKind::Checkbox { .. }
         | InlineKind::Footnote { .. }
@@ -1901,6 +1948,31 @@ fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPl
                     toggle_task_marker(&editor, &marker_range, checked, cx);
                 })
                 .into_any_element()
+            })
+        }
+        InlineKind::Link { destination, label } => {
+            let destination = destination.clone();
+            let label = label.clone();
+            Arc::new(move |fold_id, _, cx: &mut App| {
+                let theme_settings = theme_settings::ThemeSettings::get_global(cx);
+                let editor = editor.clone();
+                let destination = destination.clone();
+                div()
+                    .id(fold_id)
+                    .cursor_pointer()
+                    .font(theme_settings.buffer_font.clone())
+                    .text_size(theme_settings.buffer_font_size(cx))
+                    .text_color(cx.theme().colors().text_accent)
+                    .hover(|style| style.underline())
+                    .child(label.clone())
+                    // Opening the note is the link's job, so it claims the
+                    // press instead of letting the editor place the cursor
+                    // (which would reveal the source under the pointer).
+                    .on_mouse_down(MouseButton::Left, |_, window, _| window.prevent_default())
+                    .on_click(move |_, window, cx| {
+                        open_link(&editor, &destination, window, cx);
+                    })
+                    .into_any_element()
             })
         }
         InlineKind::Footnote { label } => {
@@ -2013,6 +2085,15 @@ fn marker_content_key(kind: &InlineKind) -> u64 {
         InlineKind::Footnote { label } => {
             use std::hash::{Hash as _, Hasher as _};
             let mut hasher = collections::FxHasher::default();
+            label.hash(&mut hasher);
+            4 + hasher.finish()
+        }
+        // Both take part: the label is what is drawn, the destination is
+        // what a click opens, and either can change over an unchanged range.
+        InlineKind::Link { destination, label } => {
+            use std::hash::{Hash as _, Hasher as _};
+            let mut hasher = collections::FxHasher::default();
+            destination.hash(&mut hasher);
             label.hash(&mut hasher);
             4 + hasher.finish()
         }
@@ -4458,6 +4539,238 @@ fn render_rule_block(
     })
 }
 
+fn open_link(
+    editor: &WeakEntity<Editor>,
+    destination: &LinkDestination,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    match destination {
+        LinkDestination::Wikilink(target) => open_wikilink(editor, target, window, cx),
+        LinkDestination::Markdown(destination) => {
+            open_markdown_link(editor, destination, window, cx)
+        }
+    }
+}
+
+/// Opens a markdown link's destination: a URL goes to the browser, anything
+/// else is a file path relative to the note (absolute paths are taken as
+/// they are), opened in the workspace. A `#fragment` on a file puts the
+/// cursor on the heading it names. A path with no file behind it is reported
+/// in a toast rather than silently doing nothing.
+fn open_markdown_link(
+    editor: &WeakEntity<Editor>,
+    destination: &str,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let destination = destination.trim();
+    if destination.is_empty() {
+        return;
+    }
+    let has_scheme = destination.split_once(':').is_some_and(|(scheme, _)| {
+        !scheme.is_empty()
+            && scheme
+                .chars()
+                .all(|character| character.is_ascii_alphanumeric() || "+-.".contains(character))
+    });
+    if has_scheme {
+        cx.open_url(destination);
+        return;
+    }
+
+    let (path, fragment) = match destination.split_once('#') {
+        Some((path, fragment)) => (path, Some(fragment.to_string())),
+        None => (destination, None),
+    };
+    // Markdown links percent-encode spaces; the filesystem stores them raw.
+    let decoded = urlencoding::decode(path)
+        .map(|decoded| decoded.into_owned())
+        .unwrap_or_else(|_| path.to_string());
+    let Some((workspace, project, source_directory)) = editor
+        .read_with(cx, |editor, cx| {
+            Some((
+                editor.workspace()?,
+                editor.project()?.clone(),
+                buffer_base_directory(editor, cx),
+            ))
+        })
+        .ok()
+        .flatten()
+    else {
+        return;
+    };
+
+    if decoded.is_empty() {
+        // `[text](#heading)` stays in the current note.
+        if let Some(fragment) = fragment {
+            editor
+                .update(cx, |editor, cx| {
+                    jump_to_heading(editor, &fragment, window, cx)
+                })
+                .log_err();
+        }
+        return;
+    }
+
+    let path = Path::new(&decoded);
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        let Some(source_directory) = source_directory else {
+            return;
+        };
+        source_directory.join(path)
+    };
+    let fs = project.read(cx).fs().clone();
+    window
+        .spawn(cx, async move |cx| {
+            if !fs.is_file(&path).await {
+                workspace.update(cx, |workspace, cx| {
+                    workspace.show_toast(
+                        workspace::Toast::new(
+                            workspace::notifications::NotificationId::Named(
+                                "markdown-live-preview-link".into(),
+                            ),
+                            format!("No file at \u{201c}{}\u{201d}.", path.display()),
+                        )
+                        .autohide(),
+                        cx,
+                    );
+                });
+                return anyhow::Ok(());
+            }
+            let open = workspace.update_in(cx, |workspace, window, cx| {
+                // A file inside the project opens as one of its own; anything
+                // else is opened by absolute path, which the workspace adds
+                // as a single-file worktree.
+                match project.read(cx).find_project_path(&path, cx) {
+                    Some(project_path) => workspace.open_path(project_path, None, true, window, cx),
+                    None => workspace.open_abs_path(
+                        path.clone(),
+                        workspace::OpenOptions::default(),
+                        window,
+                        cx,
+                    ),
+                }
+            })?;
+            let item = open.await?;
+            if let Some(fragment) = fragment
+                && let Some(opened) = item.downcast::<Editor>()
+            {
+                opened.update_in(cx, |editor, window, cx| {
+                    jump_to_heading(editor, &fragment, window, cx)
+                })?;
+            }
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
+}
+
+/// Opens the note a wikilink names, resolved like an embed's target, and
+/// puts the cursor on the heading when the link carries one
+/// (`[[Note#Heading]]`). `[[#Heading]]` names a heading of the current note
+/// and only moves the cursor. A name no note answers to is reported in a
+/// toast rather than silently doing nothing.
+fn open_wikilink(editor: &WeakEntity<Editor>, target: &str, window: &mut Window, cx: &mut App) {
+    let (note, section) = match target.split_once('#') {
+        Some((note, section)) => (note.trim(), Some(section.trim().to_string())),
+        None => (target.trim(), None),
+    };
+    let Some((workspace, project, source_directory)) = editor
+        .read_with(cx, |editor, cx| {
+            Some((
+                editor.workspace()?,
+                editor.project()?.clone(),
+                buffer_base_directory(editor, cx),
+            ))
+        })
+        .ok()
+        .flatten()
+    else {
+        return;
+    };
+
+    if note.is_empty() {
+        if let Some(section) = section {
+            editor
+                .update(cx, |editor, cx| {
+                    jump_to_heading(editor, &section, window, cx)
+                })
+                .log_err();
+        }
+        return;
+    }
+
+    let Some((path, _)) = resolve_embed_target(&project, source_directory.as_deref(), note, cx)
+    else {
+        workspace.update(cx, |workspace, cx| {
+            workspace.show_toast(
+                workspace::Toast::new(
+                    workspace::notifications::NotificationId::Named(
+                        "markdown-live-preview-wikilink".into(),
+                    ),
+                    format!("No note named \u{201c}{note}\u{201d} in this project."),
+                )
+                .autohide(),
+                cx,
+            );
+        });
+        return;
+    };
+
+    let open = workspace.update(cx, |workspace, cx| {
+        workspace.open_path(path, None, true, window, cx)
+    });
+    window
+        .spawn(cx, async move |cx| {
+            let item = open.await?;
+            if let Some(section) = section
+                && let Some(opened) = item.downcast::<Editor>()
+            {
+                opened.update_in(cx, |editor, window, cx| {
+                    jump_to_heading(editor, &section, window, cx)
+                })?;
+            }
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
+}
+
+/// Moves the cursor to the first heading titled `section` (case-insensitive,
+/// any level), scrolling it into view. Markdown fragments usually spell the
+/// heading as a slug (`#my-heading` for `# My Heading`), so a slug of the
+/// title matches too. A note without that heading is left where it is.
+fn jump_to_heading(
+    editor: &mut Editor,
+    section: &str,
+    window: &mut Window,
+    cx: &mut Context<Editor>,
+) {
+    let wanted = section.to_lowercase();
+    let snapshot = editor.buffer().read(cx).snapshot(cx);
+    let row = (0..=snapshot.max_point().row).find(|row| {
+        let line: String = snapshot
+            .text_for_range(
+                Point::new(*row, 0)..Point::new(*row, snapshot.line_len(MultiBufferRow(*row))),
+            )
+            .collect();
+        heading_title(&line).is_some_and(|(_, title)| {
+            let title = title.to_lowercase();
+            title == wanted || heading_slug(&title) == wanted
+        })
+    });
+    if let Some(row) = row {
+        let start = Point::new(row, 0);
+        editor.change_selections(
+            editor::SelectionEffects::scroll(editor::scroll::Autoscroll::center()),
+            window,
+            cx,
+            |selections| selections.select_ranges([start..start]),
+        );
+    }
+}
+
 /// Opens the note a transclusion is showing, in the workspace the embedding
 /// editor belongs to.
 fn open_embedded_note(
@@ -6074,18 +6387,6 @@ impl Extraction<'_> {
                             _ => {}
                         }
                     }
-                    if let Some(open) = open_bracket {
-                        self.hide(open.byte_range(), node.byte_range());
-                    }
-                    if let Some(close) = close_bracket {
-                        self.hide(close.start_byte()..node.end_byte(), node.byte_range());
-                    }
-                    if let (Some(open), Some(close)) = (open_bracket, close_bracket)
-                        && open.end_byte() < close.start_byte()
-                    {
-                        let range = self.anchor_range(open.end_byte()..close.start_byte());
-                        self.link_text.push(range);
-                    }
                     // A standalone link wrapping an image renders as an image
                     // widget built from just the inner image markdown: the
                     // markdown renderer degrades a link-wrapped image to
@@ -6105,6 +6406,51 @@ impl Extraction<'_> {
                                 None
                             }
                         });
+                    if let (Some(open), Some(close)) = (open_bracket, close_bracket)
+                        && open.end_byte() < close.start_byte()
+                    {
+                        let range = self.anchor_range(open.end_byte()..close.start_byte());
+                        self.link_text.push(range);
+                    }
+                    // A link with a destination and plain text becomes a
+                    // click target that opens it. Link text carrying its own
+                    // markup (`[**bold**](x)`) keeps the bracket-only
+                    // concealment below, which renders that markup, since the
+                    // click target draws its label as plain text.
+                    let destination = (node.kind() == "inline_link" && wrapped_image.is_none())
+                        .then(|| self.link_node_destination(node))
+                        .flatten();
+                    let plain_label = match (open_bracket, close_bracket) {
+                        (Some(open), Some(close)) => self
+                            .text
+                            .get(open.end_byte()..close.start_byte())
+                            .map(str::trim)
+                            .filter(|label| {
+                                !label.is_empty()
+                                    && !label
+                                        .contains(['*', '_', '`', '[', ']', '!', '<', '\\', '\n'])
+                            }),
+                        _ => None,
+                    };
+                    if let (Some(destination), Some(label)) = (destination, plain_label) {
+                        self.inline.push(InlineMarker {
+                            range: self.anchor_range(node.byte_range()),
+                            kind: InlineKind::Link {
+                                destination: LinkDestination::Markdown(SharedString::from(
+                                    destination,
+                                )),
+                                label: SharedString::from(label.to_string()),
+                            },
+                        });
+                        push_children(node, &mut stack);
+                        continue;
+                    }
+                    if let Some(open) = open_bracket {
+                        self.hide(open.byte_range(), node.byte_range());
+                    }
+                    if let Some(close) = close_bracket {
+                        self.hide(close.start_byte()..node.end_byte(), node.byte_range());
+                    }
                     if let Some(image_node) = wrapped_image
                         && self.is_alone_on_line(node)
                     {
@@ -6127,9 +6473,28 @@ impl Extraction<'_> {
                 }
                 "uri_autolink" | "email_autolink" => {
                     let range = node.byte_range();
-                    if range.len() >= 2 {
-                        self.hide(range.start..range.start + 1, range.clone());
-                        self.hide(range.end - 1..range.end, range.clone());
+                    if range.len() < 2 {
+                        continue;
+                    }
+                    let inner = range.start + 1..range.end - 1;
+                    match self.text.get(inner.clone()).map(str::trim) {
+                        // `<https://..>` opens like any other link; the
+                        // angle brackets are its only syntax.
+                        Some(url) if node.kind() == "uri_autolink" && !url.is_empty() => {
+                            self.inline.push(InlineMarker {
+                                range: self.anchor_range(range.clone()),
+                                kind: InlineKind::Link {
+                                    destination: LinkDestination::Markdown(SharedString::from(
+                                        url.to_string(),
+                                    )),
+                                    label: SharedString::from(url.to_string()),
+                                },
+                            });
+                        }
+                        _ => {
+                            self.hide(range.start..range.start + 1, range.clone());
+                            self.hide(range.end - 1..range.end, range.clone());
+                        }
                     }
                 }
                 "image" => {
@@ -6200,20 +6565,24 @@ impl Extraction<'_> {
                     continue;
                 }
 
-                let reveal = start..end;
-                if let Some(pipe) = inner.find('|') {
-                    // `[[target|alias]]`: show only the alias.
-                    self.hide(start..start + 2 + pipe + 1, reveal.clone());
-                    self.hide(end - 2..end, reveal.clone());
-                    let alias_start = start + 2 + pipe + 1;
-                    let range = self.anchor_range(alias_start..end - 2);
-                    self.link_text.push(range);
-                } else {
-                    self.hide(start..start + 2, reveal.clone());
-                    self.hide(end - 2..end, reveal.clone());
-                    let range = self.anchor_range(start + 2..end - 2);
-                    self.link_text.push(range);
-                }
+                // `[[target|alias]]` shows only the alias. The link text is
+                // also colored as a link for when the cursor reveals the raw
+                // `[[..]]`.
+                let (target, label, label_start) = match inner.find('|') {
+                    Some(pipe) => (&inner[..pipe], &inner[pipe + 1..], start + 2 + pipe + 1),
+                    None => (inner, inner, start + 2),
+                };
+                let range = self.anchor_range(label_start..end - 2);
+                self.link_text.push(range);
+                self.inline.push(InlineMarker {
+                    range: self.anchor_range(start..end),
+                    kind: InlineKind::Link {
+                        destination: LinkDestination::Wikilink(SharedString::from(
+                            target.trim().to_string(),
+                        )),
+                        label: SharedString::from(label.trim().to_string()),
+                    },
+                });
             }
         }
         self.prose_regions = regions;
@@ -6580,6 +6949,19 @@ impl Extraction<'_> {
             .filter_map(|index| image_node.child(index))
             .find(|child| child.kind() == "image_description")?;
         self.text.get(description.byte_range())
+    }
+
+    /// A link's destination as written, or `None` for a link without one
+    /// (`[text]()`).
+    fn link_node_destination(&self, link_node: tree_sitter::Node) -> Option<String> {
+        let destination = (0..link_node.child_count())
+            .filter_map(|index| link_node.child(index))
+            .find(|child| child.kind() == "link_destination")?;
+        self.text
+            .get(destination.byte_range())
+            .map(str::trim)
+            .filter(|destination| !destination.is_empty())
+            .map(|destination| destination.to_string())
     }
 
     fn image_destination(&self, image_node: tree_sitter::Node) -> Option<String> {

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -1241,6 +1241,197 @@ async fn test_wikilinks_conceal(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_wikilinks_become_click_targets(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        see [[CLAUDE]] and [[notes/plan|the plan]] and [[Note#Method]] here
+    "});
+    cx.executor().run_until_parked();
+    let links: Vec<(String, String)> = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .expect("markdown buffer should produce markers")
+            .inline
+            .iter()
+            .filter_map(|marker| match &marker.kind {
+                InlineKind::Link {
+                    destination: LinkDestination::Wikilink(target),
+                    label,
+                } => Some((target.to_string(), label.to_string())),
+                _ => None,
+            })
+            .collect()
+    });
+    assert_eq!(
+        links,
+        vec![
+            ("CLAUDE".to_string(), "CLAUDE".to_string()),
+            ("notes/plan".to_string(), "the plan".to_string()),
+            ("Note#Method".to_string(), "Note#Method".to_string()),
+        ]
+    );
+
+    // The cursor next to a link hands back the raw markdown to edit.
+    cx.set_state(indoc::indoc! {"
+        plain line
+        see [[CLAUDE]]ˇ and [[notes/plan|the plan]] here
+    "});
+    cx.executor().run_until_parked();
+    let display = cx.display_text();
+    assert!(
+        display.contains("see [[CLAUDE]] and the plan here"),
+        "{display}"
+    );
+}
+
+#[gpui::test]
+async fn test_markdown_links_become_click_targets(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state(indoc::indoc! {"
+        ˇplain line
+        see [Schedule](schedule-fall-2026.md) and [the site](https://example.com) and <https://zed.dev>
+        marked up [**bold** link](x.md) and [ref link][ref] and [empty]()
+    "});
+    cx.executor().run_until_parked();
+    let links: Vec<(String, String)> = cx.update_editor(|editor, _, cx| {
+        extract_markers(editor, cx)
+            .expect("markdown buffer should produce markers")
+            .inline
+            .iter()
+            .filter_map(|marker| match &marker.kind {
+                InlineKind::Link {
+                    destination: LinkDestination::Markdown(destination),
+                    label,
+                } => Some((destination.to_string(), label.to_string())),
+                _ => None,
+            })
+            .collect()
+    });
+    assert_eq!(
+        links,
+        vec![
+            ("schedule-fall-2026.md".to_string(), "Schedule".to_string()),
+            ("https://example.com".to_string(), "the site".to_string()),
+            ("https://zed.dev".to_string(), "https://zed.dev".to_string()),
+        ]
+    );
+    // Links that are not click targets still conceal their syntax.
+    let display = cx.display_text();
+    assert!(
+        display.contains("see Schedule and the site and https://zed.dev"),
+        "{display}"
+    );
+    assert!(
+        display.contains("marked up bold link and ref link and empty"),
+        "{display}"
+    );
+}
+
+#[gpui::test]
+async fn test_clicking_a_wikilink_opens_the_note(cx: &mut TestAppContext) {
+    use project::Fs as _;
+
+    init_test(cx);
+    let fs = project::FakeFs::new(cx.executor());
+    fs.create_dir("/vault".as_ref())
+        .await
+        .expect("failed to create the vault");
+    fs.insert_file("/vault/Note.md", b"see [[Method]] here\n".to_vec())
+        .await;
+    fs.insert_file(
+        "/vault/Method.md",
+        b"# Method\n\n## Sampling\n\nWe sampled 40 participants.\n".to_vec(),
+    )
+    .await;
+    let project = project::Project::test(fs.clone(), ["/vault".as_ref()], cx).await;
+    let registry = project.read_with(cx, |project, _| project.languages().clone());
+    registry.add(language::markdown_lang());
+    registry.add(markdown_inline_lang());
+    let (workspace, cx) = cx
+        .add_window_view(|window, cx| workspace::Workspace::test_new(project.clone(), window, cx));
+
+    let open = |name: &str, cx: &mut gpui::VisualTestContext| {
+        let path = project
+            .read_with(cx, |project, cx| {
+                project.find_project_path(format!("/vault/{name}"), cx)
+            })
+            .expect("the note is in the vault");
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.open_path(path, None, true, window, cx)
+        })
+    };
+    let note = open("Note.md", cx)
+        .await
+        .expect("failed to open the note")
+        .downcast::<Editor>()
+        .expect("a markdown file opens in an editor");
+    cx.run_until_parked();
+
+    let active_file = |cx: &mut gpui::VisualTestContext| {
+        workspace.read_with(cx, |workspace, cx| {
+            let editor = workspace.active_item_as::<Editor>(cx)?;
+            let buffer = editor.read(cx).buffer().read(cx).as_singleton()?;
+            Some(buffer.read(cx).file()?.path().as_unix_str().to_string())
+        })
+    };
+    assert_eq!(active_file(cx).as_deref(), Some("Note.md"));
+
+    // A plain click on the link opens its note.
+    let link = note.downgrade();
+    cx.update(|window, cx| open_wikilink(&link, "Method", window, cx));
+    cx.run_until_parked();
+    assert_eq!(active_file(cx).as_deref(), Some("Method.md"));
+
+    // A heading link lands the cursor on that heading.
+    cx.update(|window, cx| open_wikilink(&link, "Method#sampling", window, cx));
+    cx.run_until_parked();
+    let cursor = workspace.read_with(cx, |workspace, cx| {
+        let editor = workspace
+            .active_item_as::<Editor>(cx)
+            .expect("an editor is active");
+        let editor = editor.read(cx);
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        editor.selections.newest_anchor().head().to_point(&snapshot)
+    });
+    assert_eq!(cursor, Point::new(2, 0));
+
+    // A name no note answers to leaves the reader where they are.
+    cx.update(|window, cx| open_wikilink(&link, "Nowhere", window, cx));
+    cx.run_until_parked();
+    assert_eq!(active_file(cx).as_deref(), Some("Method.md"));
+
+    // A markdown link resolves its path relative to the note, and a fragment
+    // spelled as a slug still finds its heading.
+    cx.update(|window, cx| open_markdown_link(&link, "Note.md", window, cx));
+    cx.run_until_parked();
+    assert_eq!(active_file(cx).as_deref(), Some("Note.md"));
+    cx.update(|window, cx| open_markdown_link(&link, "./Method.md#sampling", window, cx));
+    cx.run_until_parked();
+    assert_eq!(active_file(cx).as_deref(), Some("Method.md"));
+    let cursor = workspace.read_with(cx, |workspace, cx| {
+        let editor = workspace
+            .active_item_as::<Editor>(cx)
+            .expect("an editor is active");
+        let editor = editor.read(cx);
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        editor.selections.newest_anchor().head().to_point(&snapshot)
+    });
+    assert_eq!(cursor, Point::new(2, 0));
+
+    // A path with no file behind it leaves the reader where they are.
+    cx.update(|window, cx| open_markdown_link(&link, "Missing.md", window, cx));
+    cx.run_until_parked();
+    assert_eq!(active_file(cx).as_deref(), Some("Method.md"));
+}
+
+#[test]
+fn test_heading_slug() {
+    assert_eq!(heading_slug("my heading"), "my-heading");
+    assert_eq!(heading_slug("fall 2026 -- schedule!"), "fall-2026-schedule");
+    assert_eq!(heading_slug("  spaced  "), "spaced");
+}
+
+#[gpui::test]
 async fn test_obsidian_image_embed_renders_as_block(cx: &mut TestAppContext) {
     let mut cx = markdown_test_context(cx).await;
     cx.set_state(indoc::indoc! {"

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -103,7 +103,7 @@ use {
     feature_flags::FeatureFlagAppExt as _,
     git_ui::project_diff::ProjectDiff,
     gpui::{
-        App, AppContext as _, Bounds, Entity, Focusable as _, KeyBinding, Modifiers,
+        App, AppContext as _, Bounds, Entity, Focusable as _, KeyBinding, Modifiers, Pixels,
         VisualTestAppContext, WindowBounds, WindowHandle, WindowOptions, point, px, size,
     },
     image::RgbaImage,
@@ -653,6 +653,23 @@ fn run_visual_tests(project_path: PathBuf, update_baseline: bool) -> Result<()> 
         }
         Err(e) => {
             eprintln!("✗ citation_pipeline: FAILED - {}", e);
+            failed += 1;
+        }
+    }
+
+    // Run Test 12: Live preview links open their target on a plain click
+    println!("\n--- Test 12: link_click (4 variants) ---");
+    match run_link_click_visual_tests(app_state.clone(), &mut cx, update_baseline) {
+        Ok(TestResult::Passed) => {
+            println!("✓ link_click: PASSED");
+            passed += 1;
+        }
+        Ok(TestResult::BaselineUpdated(_)) => {
+            println!("✓ link_click: Baselines updated");
+            updated += 1;
+        }
+        Err(e) => {
+            eprintln!("✗ link_click: FAILED - {}", e);
             failed += 1;
         }
     }
@@ -2749,6 +2766,275 @@ fn run_citation_pipeline_visual_tests(
             Ok(TestResult::BaselineUpdated(path))
         }
     }
+}
+
+/// Drives live preview's click-to-open links in a real rendered window: a
+/// vault note carrying a wikilink and a markdown file link. Captures the
+/// note's rendering, then clicks the markdown link and the wikilink and
+/// checks each opened its target, and finally clicks past the end of a link's
+/// line to show the raw markdown coming back for editing.
+#[cfg(target_os = "macos")]
+fn run_link_click_visual_tests(
+    app_state: Arc<AppState>,
+    cx: &mut VisualTestAppContext,
+    update_baseline: bool,
+) -> Result<TestResult> {
+    let temp_dir = tempfile::tempdir()?;
+    let temp_path = temp_dir.keep();
+    let canonical_temp = temp_path.canonicalize()?;
+    let vault_dir = canonical_temp.join("vault");
+    std::fs::create_dir_all(vault_dir.join("notes"))?;
+    std::fs::write(
+        vault_dir.join("Note.md"),
+        "# Link check\n\n\
+         A wikilink [[Method]] opens a note in this vault.\n\n\
+         A markdown link opens a file beside this one: [Schedule](schedule-fall-2026.md)\n\n\
+         Also: alias [[notes/plan|the plan]], heading [[Method#Sampling]], \
+         site [Zed](https://zed.dev), missing [[Nowhere]], \
+         formatted [**bold** link](Method.md).\n",
+    )?;
+    std::fs::write(
+        vault_dir.join("Method.md"),
+        "# Method\n\nIntro paragraph.\n\n## Sampling\n\nWe sampled 40 participants.\n",
+    )?;
+    std::fs::write(
+        vault_dir.join("schedule-fall-2026.md"),
+        "# Fall 2026 schedule\n\nWeek 1: introductions.\n",
+    )?;
+    std::fs::write(vault_dir.join("notes/plan.md"), "# The plan\n\nStep one.\n")?;
+
+    let project = cx.update(|cx| {
+        project::Project::local(
+            app_state.client.clone(),
+            app_state.node_runtime.clone(),
+            app_state.user_store.clone(),
+            app_state.languages.clone(),
+            app_state.fs.clone(),
+            None,
+            project::LocalProjectFlags {
+                init_worktree_trust: false,
+                ..Default::default()
+            },
+            cx,
+        )
+    });
+
+    let bounds = Bounds {
+        origin: point(px(0.0), px(0.0)),
+        size: size(px(1280.0), px(800.0)),
+    };
+    let workspace_window: WindowHandle<Workspace> = cx.update(|cx| {
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                focus: false,
+                show: false,
+                ..Default::default()
+            },
+            |window, cx| {
+                cx.new(|cx| Workspace::new(None, project.clone(), app_state.clone(), window, cx))
+            },
+        )
+    })?;
+    cx.run_until_parked();
+
+    let add_worktree_task = workspace_window.update(cx, |workspace, _window, cx| {
+        workspace.project().update(cx, |project, cx| {
+            project.find_or_create_worktree(&vault_dir, true, cx)
+        })
+    })?;
+    cx.background_executor.allow_parking();
+    cx.foreground_executor
+        .block_test(add_worktree_task)
+        .context("Failed to add vault worktree")?;
+    cx.background_executor.forbid_parking();
+    cx.run_until_parked();
+
+    let open_note = |cx: &mut VisualTestAppContext| -> Result<Entity<editor::Editor>> {
+        let open_task = workspace_window.update(cx, |workspace, window, cx| {
+            let worktree = workspace
+                .project()
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .context("vault worktree missing")?;
+            let worktree_id = worktree.read(cx).id();
+            let rel_path: std::sync::Arc<util::rel_path::RelPath> =
+                util::rel_path::rel_path("Note.md").into();
+            let project_path: project::ProjectPath = (worktree_id, rel_path).into();
+            anyhow::Ok(workspace.open_path(project_path, None, true, window, cx))
+        })??;
+        cx.background_executor.allow_parking();
+        let opened = cx.foreground_executor.block_test(open_task);
+        cx.background_executor.forbid_parking();
+        let item = opened.context("Failed to open Note.md")?;
+        cx.run_until_parked();
+        item.downcast::<editor::Editor>()
+            .context("Note.md did not open in an editor")
+    };
+    let editor = open_note(cx)?;
+
+    // Live preview needs a settled parse and a render before the links exist
+    // as click targets and the editor knows where it was drawn.
+    let rendering = run_visual_test(
+        "link_rendering",
+        workspace_window.into(),
+        cx,
+        update_baseline,
+    );
+
+    // The window position of the character at `offset`, nudged into the
+    // middle of its line and a few pixels into the glyph so the click lands
+    // on the link element rather than its edge.
+    let pixel_at = |offset: usize, cx: &mut VisualTestAppContext| -> Result<gpui::Point<Pixels>> {
+        workspace_window.update(cx, |_workspace, window, cx| {
+            editor.update(cx, |editor, cx| {
+                let snapshot = editor.snapshot(window, cx);
+                let anchor = snapshot
+                    .buffer_snapshot()
+                    .anchor_after(editor::MultiBufferOffset(offset));
+                let origin = editor.last_bounds().context("editor never drew")?.origin;
+                // `to_pixel_point` is relative to the text area, which sits
+                // to the right of the gutter.
+                let position = editor
+                    .to_pixel_point(anchor, &snapshot, window, cx)
+                    .context("offset is off screen")?;
+                let style = editor.style(cx).clone();
+                let rem_size = window.rem_size();
+                let font_id = window.text_system().resolve_font(&style.text.font());
+                let font_size = style.text.font_size.to_pixels(rem_size);
+                let line_height = style.text.line_height_in_pixels(rem_size);
+                let gutter = snapshot
+                    .gutter_dimensions(font_id, font_size, &style, window, cx)
+                    .full_width();
+                anyhow::Ok(origin + position + point(gutter + px(6.0), line_height / 2.0))
+            })
+        })?
+    };
+    let offset_of = |needle: &str, cx: &mut VisualTestAppContext| -> Result<usize> {
+        let text = cx.update(|cx| editor.read(cx).buffer().read(cx).snapshot(cx).text());
+        text.find(needle)
+            .with_context(|| format!("{needle:?} is not in the note"))
+    };
+    let active_file = |cx: &mut VisualTestAppContext| -> Option<String> {
+        workspace_window
+            .read_with(cx, |workspace, cx| {
+                let editor = workspace.active_item_as::<editor::Editor>(cx)?;
+                let buffer = editor.read(cx).buffer().read(cx).as_singleton()?;
+                Some(buffer.read(cx).file()?.path().as_unix_str().to_string())
+            })
+            .ok()
+            .flatten()
+    };
+    // Opening a file reads the real filesystem on tasks the test dispatcher
+    // cannot see the end of; poll for the tab with parking allowed.
+    let wait_for_active = |file: &str, cx: &mut VisualTestAppContext| -> bool {
+        cx.background_executor.allow_parking();
+        let mut found = false;
+        for _ in 0..200 {
+            cx.run_until_parked();
+            if active_file(cx).as_deref() == Some(file) {
+                found = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        cx.background_executor.forbid_parking();
+        cx.run_until_parked();
+        found
+    };
+
+    // A plain click on the markdown link opens the file it names.
+    let schedule = offset_of("[Schedule]", cx)?;
+    let target = pixel_at(schedule, cx)?;
+    cx.simulate_mouse_move(workspace_window.into(), target, None, Modifiers::default());
+    cx.simulate_click(workspace_window.into(), target, Modifiers::default());
+    let opened = wait_for_active("schedule-fall-2026.md", cx);
+    let markdown_link = run_visual_test(
+        "link_click_opens_file",
+        workspace_window.into(),
+        cx,
+        update_baseline,
+    );
+    anyhow::ensure!(
+        opened,
+        "clicking [Schedule](schedule-fall-2026.md) did not open it; active: {:?}",
+        active_file(cx)
+    );
+
+    // Back on the note, a plain click on the wikilink opens its note.
+    open_note(cx)?;
+    anyhow::ensure!(wait_for_active("Note.md", cx), "Note.md did not come back");
+    let method = offset_of("[[Method]]", cx)?;
+    let target = pixel_at(method, cx)?;
+    cx.simulate_mouse_move(workspace_window.into(), target, None, Modifiers::default());
+    cx.simulate_click(workspace_window.into(), target, Modifiers::default());
+    anyhow::ensure!(
+        wait_for_active("Method.md", cx),
+        "clicking [[Method]] did not open it; active: {:?}",
+        active_file(cx)
+    );
+    let wikilink = run_visual_test(
+        "wikilink_click_opens_note",
+        workspace_window.into(),
+        cx,
+        update_baseline,
+    );
+
+    // Clicking past the end of the line a link closes puts the cursor right
+    // after it, which touches the link and hands back its raw markdown,
+    // Obsidian-style. Reveal is per construct: a link earlier in the line
+    // would stay rendered.
+    open_note(cx)?;
+    anyhow::ensure!(wait_for_active("Note.md", cx), "Note.md did not come back");
+    let link_source = "[Schedule](schedule-fall-2026.md)";
+    let line_end = offset_of(link_source, cx)? + link_source.len();
+    let mut target = pixel_at(line_end, cx)?;
+    target.x += px(40.0);
+    cx.simulate_mouse_move(workspace_window.into(), target, None, Modifiers::default());
+    cx.simulate_click(workspace_window.into(), target, Modifiers::default());
+    cx.run_until_parked();
+    let source_reveal = run_visual_test(
+        "link_source_reveal",
+        workspace_window.into(),
+        cx,
+        update_baseline,
+    );
+    anyhow::ensure!(
+        active_file(cx).as_deref() == Some("Note.md"),
+        "clicking past the line end must not open anything"
+    );
+    let revealed = editor.update(cx, |editor, cx| editor.display_text(cx));
+    anyhow::ensure!(
+        revealed.contains(link_source),
+        "the cursor at the line end did not reveal the link's source:\n{revealed}"
+    );
+
+    workspace_window
+        .update(cx, |workspace, _window, cx| {
+            workspace.project().update(cx, |project, cx| {
+                let worktree_ids: Vec<_> =
+                    project.worktrees(cx).map(|wt| wt.read(cx).id()).collect();
+                for id in worktree_ids {
+                    project.remove_worktree(id, cx);
+                }
+            });
+        })
+        .log_err();
+    cx.update_window(workspace_window.into(), |_, window, _cx| {
+        window.remove_window();
+    })
+    .log_err();
+    cx.run_until_parked();
+
+    let results = [rendering?, markdown_link?, wikilink?, source_reveal?];
+    Ok(results
+        .into_iter()
+        .find_map(|result| match result {
+            TestResult::BaselineUpdated(path) => Some(TestResult::BaselineUpdated(path)),
+            TestResult::Passed => None,
+        })
+        .unwrap_or(TestResult::Passed))
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

Wikilinks and markdown links in live preview now open their target on a plain click, the way Obsidian's live preview does. Clicking beside a link still reveals its raw markdown for editing.

- `[[Note]]`, `[[Note|alias]]`, `[[Note#Heading]]` open the note, resolved the same way `![[embed]]` transclusions already are. A heading target puts the cursor on that heading; `[[#Heading]]` moves within the current note.
- `[text](path.md)` opens the file relative to the note (absolute paths as written, percent-encoding decoded). A `#fragment` jumps to the heading, matching either the title or its GitHub-style slug. Files outside the project open by absolute path.
- `[text](https://…)` and `<https://…>` open in the browser.
- A missing note or file shows an autohiding toast instead of silently doing nothing.
- Link text carrying its own markup (`[**bold** link](x.md)`) keeps the old bracket-only concealment so the markup still renders; reference links and empty destinations are unchanged.

The link is concealed as one inline element (a `Link` marker with a `Wikilink` or `Markdown` destination) so the text can own the click and claim mouse-down before the editor places the cursor. The display text still carries the label so wrapping and column math see the drawn width. Reveal stays per construct: a link ends its line, so a click past the line end reveals it.

## Testing

- New unit tests cover marker extraction for both link kinds, opening a file relative to the note, the slug fragment jump, and the missing-target case. All 101 tests in `markdown_live_preview` pass.
- A new visual test (`link_click`, Test 12 in the runner) opens a vault in a rendered window, clicks a markdown link and a wikilink with simulated mouse events, checks each opened its target, and captures the end-of-line source reveal. All 12 visual tests pass:

  ```sh
  cargo run --profile release-fast -p zed --bin zed_visual_test_runner --features visual-tests
  ```

- Clippy with `-D warnings` is clean on `markdown_live_preview` and the visual test runner binary.

`Cargo.lock` gains the `suzuri_update` line cargo has been regenerating locally since #43.

Release Notes:

- Added click-to-open for wikilinks and markdown links in live preview: a plain click opens the linked note, file, or URL, and clicking beside the link reveals its source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgFz1Vzdnxk3Tv4Hi7qkZa
