### PR TITLE
Flatten downloaded artifacts before publishing the release

### DIFF
--- a/.github/workflows/suzuri-release.yml
+++ b/.github/workflows/suzuri-release.yml
@@ -251,6 +251,32 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      # An artifact whose files come from different directories keeps them
+      # under their common parent, so the DMGs and tarballs land in
+      # subdirectories next to the top-level remote server archives. The
+      # release glob below is not recursive; v0.4.5 shipped without its DMGs
+      # and tarballs for exactly this reason, so flatten first and refuse to
+      # publish unless every expected asset is present.
+      - name: Collect release assets
+        run: |
+          find artifacts -mindepth 2 -type f -exec mv {} artifacts/ \;
+          find artifacts -mindepth 1 -type d -delete
+          ls -l artifacts
+          missing=0
+          for asset in \
+            suzuri-aarch64.dmg suzuri-x86_64.dmg \
+            suzuri-windows-x86_64.exe \
+            suzuri-linux-x86_64.tar.gz suzuri-linux-aarch64.tar.gz \
+            zed-remote-server-macos-aarch64.gz zed-remote-server-macos-x86_64.gz \
+            zed-remote-server-windows-x86_64.zip \
+            zed-remote-server-linux-x86_64.gz zed-remote-server-linux-aarch64.gz; do
+            if [ ! -f "artifacts/${asset}" ]; then
+              echo "::error::Expected release asset ${asset} is missing."
+              missing=1
+            fi
+          done
+          exit "${missing}"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
The v0.4.5 release published the Windows installer and all five remote server archives but none of the DMGs or Linux tarballs.

Cause: #43 made each bundle job upload two files from different directories (for example `target/aarch64-apple-darwin/release/suzuri-aarch64.dmg` and `target/zed-remote-server-macos-aarch64.gz`). `actions/upload-artifact` then keeps files under their common parent, so the DMG sits at `aarch64-apple-darwin/release/` inside the artifact and the tarballs at `release/`, while the remote servers are top level. The release step's `files: artifacts/*` is not recursive, so it only saw the top-level files. The Windows job was unaffected because both of its files already live directly in `target/`.

Fix: a `Collect release assets` step in the release job moves every downloaded file to the top level and fails the job if any of the ten expected assets is missing, so a repeat of this ends with no release rather than a partial one.

The missing v0.4.5 files are being attached to the existing release by hand from the same run's artifacts, so no re-tag is needed; the next tag exercises this step.

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxFtVT4V8D2nry4Tx4Wufc
