### PR TITLE
markdown_live_preview: Reveal the image file from an image's right-click menu

### DIFF
--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -40,7 +40,7 @@ use multi_buffer::{
 use project::{PathChange, Project, ProjectPath};
 use settings::{RegisterSetting, Settings};
 use text::Point;
-use ui::{Checkbox, ToggleState, prelude::*};
+use ui::{Checkbox, ContextMenu, ContextMenuEntry, ToggleState, prelude::*};
 use util::ResultExt as _;
 
 actions!(
@@ -4054,6 +4054,10 @@ fn render_image_block(
         let drag_range = range.clone();
         let move_editor = editor.clone();
         let move_drag_range = range.clone();
+        let menu_editor = editor.clone();
+        let menu_range = range.clone();
+        let menu_destination = destination.clone();
+        let menu_base_directory = base_directory.clone();
 
         // A direct image element lets the selection border hug the image
         // exactly; reference-style images (no inline destination) fall back
@@ -4218,6 +4222,28 @@ fn render_image_block(
                         if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
                             addon.selected_image = Some(select_range.clone());
                         }
+                        cx.notify();
+                    })
+                    .log_err();
+            })
+            // The editor's own right-click menu acts on the markdown buffer,
+            // so its "Reveal in Finder" would open the note's folder, not the
+            // image's. Stopping propagation here keeps that menu from
+            // deploying and replaces it with one that targets the image file.
+            .on_mouse_down(MouseButton::Right, move |event, window, cx| {
+                cx.stop_propagation();
+                let image_path = menu_destination.as_deref().and_then(|destination| {
+                    local_image_path(destination, menu_base_directory.as_deref())
+                });
+                let range = menu_range.clone();
+                menu_editor
+                    .update(cx, |editor, cx| {
+                        if let Some(addon) = editor.addon_mut::<LivePreviewAddon>() {
+                            addon.selected_image = Some(range);
+                        }
+                        let menu =
+                            image_context_menu(image_path, editor.project().cloned(), window, cx);
+                        editor.deploy_mouse_context_menu(event.position, menu, window, cx);
                         cx.notify();
                     })
                     .log_err();
@@ -5800,23 +5826,7 @@ fn resolve_image_source(
             destination.to_string(),
         ))));
     }
-    // Markdown links percent-encode spaces; the filesystem stores them raw.
-    let decoded = urlencoding::decode(destination)
-        .map(|decoded| decoded.into_owned())
-        .unwrap_or_else(|_| destination.to_string());
-    let path = std::path::Path::new(&decoded);
-    let path = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        base_directory?.join(path)
-    };
-    // Canonicalizing proves the file exists *and* collapses `..` and symlinks,
-    // so a note that spells its image `../images/x.png` keys the cache by the
-    // same path the worktree reports when that file changes. Without it the two
-    // spellings hash differently and the eviction below silently matches
-    // nothing — which is the common case, since a shared `images/` folder
-    // beside the notes is an ordinary vault layout.
-    let path = std::fs::canonicalize(&path).ok()?;
+    let path = local_image_path(destination, base_directory)?;
     // Deliberately not `ImageSource::Resource`: that reads through gpui's
     // app-level asset cache, which has no eviction, so a file rewritten in
     // place would keep serving its first-decoded bitmap. Routing every local
@@ -5829,6 +5839,62 @@ fn resolve_image_source(
             image_cache.load(&resource, window, cx)
         })
     })))
+}
+
+/// The on-disk file an image link points at, or `None` for remote and
+/// data-URI images and for links whose file does not exist.
+fn local_image_path(destination: &str, base_directory: Option<&Path>) -> Option<PathBuf> {
+    if destination.starts_with("data:")
+        || destination.starts_with("http://")
+        || destination.starts_with("https://")
+    {
+        return None;
+    }
+    // Markdown links percent-encode spaces; the filesystem stores them raw.
+    let decoded = urlencoding::decode(destination)
+        .map(|decoded| decoded.into_owned())
+        .unwrap_or_else(|_| destination.to_string());
+    let path = Path::new(&decoded);
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base_directory?.join(path)
+    };
+    // Canonicalizing proves the file exists *and* collapses `..` and symlinks,
+    // so a note that spells its image `../images/x.png` keys the cache by the
+    // same path the worktree reports when that file changes. Without it the two
+    // spellings hash differently and the eviction in `register_editor` silently
+    // matches nothing — which is the common case, since a shared `images/`
+    // folder beside the notes is an ordinary vault layout.
+    std::fs::canonicalize(&path).ok()
+}
+
+/// The right-click menu for an image widget. Its reveal entry targets the
+/// image file, where the editor's default menu would target the note.
+fn image_context_menu(
+    image_path: Option<PathBuf>,
+    project: Option<Entity<Project>>,
+    window: &mut Window,
+    cx: &mut App,
+) -> Entity<ContextMenu> {
+    ContextMenu::build(window, cx, |menu, _, _| {
+        let reveal_path = image_path.clone();
+        menu.item(
+            ContextMenuEntry::new(ui::utils::reveal_in_file_manager_label(false))
+                .disabled(image_path.is_none())
+                .handler(move |_, cx| {
+                    let Some(path) = reveal_path.as_deref() else {
+                        return;
+                    };
+                    match project.as_ref() {
+                        Some(project) => {
+                            project.update(cx, |project, cx| project.reveal_path(path, cx))
+                        }
+                        None => cx.reveal_path(path),
+                    }
+                }),
+        )
+    })
 }
 
 fn block_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -883,6 +883,74 @@ fn drop_image_on_row(cx: &mut EditorTestContext, row: u32, target_row: u32) {
     cx.executor().run_until_parked();
 }
 
+/// Right-clicking an image widget must open the widget's own menu, whose
+/// reveal entry targets the image file, rather than the editor's default
+/// menu, whose reveal entry targets the note. The two are told apart by the
+/// cursor: the default menu moves it to the clicked line first. The menu
+/// itself cannot be observed here — it takes focus through next-frame
+/// callbacks, which the test platform only runs from inside gpui.
+#[gpui::test]
+async fn test_right_clicking_an_image_opens_the_image_menu(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state("ˇtop\n\n![shot](a.png)\n\nbottom");
+    cx.executor().run_until_parked();
+
+    let image = cx
+        .cx
+        .debug_bounds("MDLP-IMAGE-a.png")
+        .expect("the image widget should have been laid out");
+    cx.cx.simulate_event(MouseDownEvent {
+        position: image.center(),
+        button: MouseButton::Right,
+        modifiers: Modifiers::default(),
+        click_count: 1,
+        first_mouse: false,
+    });
+    cx.executor().run_until_parked();
+
+    cx.assert_editor_state("ˇtop\n\n![shot](a.png)\n\nbottom");
+    let selected_row = cx.update_editor(|editor, _, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        editor
+            .addon::<LivePreviewAddon>()
+            .and_then(|addon| addon.selected_image.clone())
+            .map(|range| range.start.to_point(&snapshot).row)
+    });
+    assert_eq!(
+        selected_row,
+        Some(2),
+        "the right-clicked image should be selected"
+    );
+}
+
+#[test]
+fn test_local_image_path_resolves_only_files_on_disk() {
+    let dir = tempfile::tempdir().expect("failed to create a temp dir");
+    let notes = dir.path().join("notes");
+    let images = dir.path().join("images");
+    std::fs::create_dir_all(&notes).unwrap();
+    std::fs::create_dir_all(&images).unwrap();
+    std::fs::write(images.join("my shot.png"), b"png").unwrap();
+
+    assert_eq!(
+        local_image_path("../images/my%20shot.png", Some(&notes)),
+        Some(std::fs::canonicalize(images.join("my shot.png")).unwrap())
+    );
+    assert_eq!(
+        local_image_path("../images/missing.png", Some(&notes)),
+        None
+    );
+    assert_eq!(
+        local_image_path("https://example.com/shot.png", Some(&notes)),
+        None
+    );
+    assert_eq!(
+        local_image_path("data:image/png;base64,AAAA", Some(&notes)),
+        None
+    );
+    assert_eq!(local_image_path("shot.png", None), None);
+}
+
 /// The whole gesture, end to end, through real event dispatch: press on one
 /// of two image widgets, drag past the arming threshold, cross the document,
 /// release. This is what catches wiring bugs the unit tests cannot — most


### PR DESCRIPTION
Right-clicking a live-preview image opened the editor's default context menu, whose "Reveal in Finder" acts on the markdown buffer, so it opened the note's folder rather than the image's.

The image widget now stops the right-click from reaching the editor and deploys its own menu with a reveal entry that targets the image file on disk. The entry is disabled for remote, data-URI, and missing images. Right-clicking also selects the widget, so the highlighted image is the one the menu acts on.

The path resolution shared with image rendering moves into `local_image_path`, so rendering and the menu agree on percent-decoding and canonicalization.

Fork-owned crate only; no vendor files touched.

Verified with `cargo nextest run -p markdown_live_preview` (103 passed) and clippy with CI's flags. The new gesture test pins that the editor's default menu does not fire (the cursor stays put) and the widget gets selected; the menu's focus cannot be observed from this crate because the test platform's frame driver is crate-private to gpui. Not yet smoke-tested in a bundled build.

Release Notes:

- Fixed "Reveal in Finder" on a live-preview image's right-click menu revealing the note instead of the image file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uBne95cJKPLubCWhQkvgp
