### PR TITLE
Toggle task checkboxes on click instead of revealing source

### DIFF
--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -1936,18 +1936,26 @@ fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPl
             Arc::new(move |fold_id, _, _| {
                 let editor = editor.clone();
                 let marker_range = marker_range.clone();
-                Checkbox::new(
-                    fold_id,
-                    if checked {
-                        ToggleState::Selected
-                    } else {
-                        ToggleState::Unselected
-                    },
-                )
-                .on_click(move |_, _, cx| {
-                    toggle_task_marker(&editor, &marker_range, checked, cx);
-                })
-                .into_any_element()
+                // Toggling is the checkbox's job, so it claims the press
+                // instead of letting the editor place the cursor on the
+                // marker: that would reveal the source, drop this element,
+                // and lose the click before it could fire.
+                div()
+                    .on_mouse_down(MouseButton::Left, |_, window, _| window.prevent_default())
+                    .child(
+                        Checkbox::new(
+                            fold_id,
+                            if checked {
+                                ToggleState::Selected
+                            } else {
+                                ToggleState::Unselected
+                            },
+                        )
+                        .on_click(move |_, _, cx| {
+                            toggle_task_marker(&editor, &marker_range, checked, cx);
+                        }),
+                    )
+                    .into_any_element()
             })
         }
         InlineKind::Link { destination, label } => {


### PR DESCRIPTION
Clicking a rendered task-list checkbox in live preview revealed the raw `- [ ]` instead of checking the box. The toggle handler existed, but the editor's own mouse-down placed the cursor on the marker first, which revealed the source and dropped the checkbox element before its click could fire.

The checkbox placeholder now calls `prevent_default` on left mouse-down, the same guard the link placeholder already uses, so the press toggles the marker in place. The source still reveals when the cursor reaches the marker from the keyboard (Home, or arrow left from the task text), matching how bullets behave.

Verified by `cargo nextest run -p markdown_live_preview` (101 passed) and by clicking checkboxes in a release-fast build.

Release Notes:

- Fixed clicking a task-list checkbox in live preview revealing the source instead of toggling it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aefREz1Y8QQWT84MrXS2b