### PR TITLE
Bump SUZURI_VERSION to 0.4.6

### DIFF
--- a/crates/suzuri_update/src/suzuri_update.rs
+++ b/crates/suzuri_update/src/suzuri_update.rs
@@ -55,7 +55,7 @@ use workspace::{
 /// Bump it in the same commit that gets tagged `suzuri-v<this version>`; the
 /// `check-version` job in `.github/workflows/suzuri-release.yml` enforces that
 /// the two agree.
-pub const SUZURI_VERSION: &str = "0.4.5";
+pub const SUZURI_VERSION: &str = "0.4.6";
 
 /// The repository whose releases describe newer Suzuri builds.
 const RELEASE_REPOSITORY: &str = "harrywang/suzuri";


### PR DESCRIPTION
Release 0.4.6. Merge after #53 so the release carries remote PDF support, then tag `suzuri-v0.4.6` on the merge commit.

Since 0.4.5 main carries: click-to-open for links in live preview (#45), task-list checkboxes toggling on click (#49), "Reveal in Finder" on an image widget revealing the image file (#47), opening PDFs in remote SSH/Docker/WSL projects (#53), and the Zed base moving from 1.19.0 to 1.20.0 (#48).

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmYig7zCDfd13VQrJ6TDVb
