### PR TITLE
Keep the macOS release build within the hosted runner's disk

### DIFF
--- a/.github/workflows/suzuri-release.yml
+++ b/.github/workflows/suzuri-release.yml
@@ -65,12 +65,37 @@ jobs:
         target: [aarch64-apple-darwin, x86_64-apple-darwin]
     runs-on: macos-15
     timeout-minutes: 180
+    env:
+      # Shrink the target dir to fit hosted-runner disks, as the Linux and
+      # Windows jobs already do. Nothing consumes the debug info: Suzuri does
+      # not upload symbols to Sentry, and bundle-mac's dsymutil step tolerates
+      # a binary without them (it warns and writes an empty .dwarf).
+      CARGO_PROFILE_RELEASE_DEBUG: "false"
     steps:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v5
         with:
           node-version: 20
+
+      # Hosted macOS images leave roughly 40G free, and the 0.4.6 build ran
+      # out at the final link. The unused Xcode versions and simulator
+      # runtimes are the cheapest space to reclaim.
+      - name: Free disk space
+        run: |
+          df -h /
+          selected="$(cd "$(xcode-select -p)/../.." && pwd -P)"
+          [ -n "$selected" ] || { echo "could not resolve the selected Xcode"; exit 1; }
+          echo "keeping $selected"
+          for xcode in /Applications/Xcode*.app; do
+            if [ "$(cd "$xcode" && pwd -P)" != "$selected" ]; then
+              sudo rm -rf "$xcode"
+            fi
+          done
+          sudo xcrun simctl runtime delete all || true
+          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches \
+            ~/Library/Android /usr/local/share/dotnet || true
+          df -h /
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -90,6 +115,12 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: ./script/bundle-mac ${{ matrix.target }}
+
+      # Runs even when the build fails so the next disk-space failure shows
+      # how far over the limit it was, not just where it started.
+      - name: Report disk space after build
+        if: always()
+        run: df -h /
 
       - name: Rename artifact
         run: |


### PR DESCRIPTION
The aarch64 macOS job of the `suzuri-v0.4.6` release run ([34170168323](https://github.com/harrywang/suzuri/actions/runs/34170168323)) failed at the final link:

```
LLVM ERROR: IO failure on output stream: No space left on device
```

The runner reported 41G free before the build. A release build with `debug = "limited"`, thin LTO, a restored cache from the 1.19 Zed base sitting next to the fresh 1.20 artifacts, and dsymutil's `.dwarf` output used all of it. The x86_64 job was cancelled as a side effect and the release step was skipped. The mac job had no disk management at all, unlike the Linux and Windows jobs.

## Changes to the `build-mac` job

- **`CARGO_PROFILE_RELEASE_DEBUG: "false"`**, matching what the Linux and Windows jobs already set. Nothing consumes the debug info: Suzuri does not upload symbols to Sentry, and `bundle-mac`'s dsymutil step accepts a binary without them (verified locally: it warns "no debug symbols in executable" and exits 0 with a small `.dwarf`). This is the largest saving, since it shrinks every rlib and object file in the target dir as well as the final link.
- **A "Free disk space" step** that removes every Xcode except the selected one, deletes simulator runtimes, and drops the Android SDK and dotnet. This mirrors the Linux job's step. Each unused Xcode is 10 to 15G on the hosted image. The step fails loudly if it cannot resolve the selected Xcode rather than deleting all of them.
- **A "Report disk space after build" step** with `if: always()`, so the next disk failure shows the peak usage instead of only the starting point.

## Not changed

The cache key. `Swatinem/rust-cache` already includes the `Cargo.lock` hash in its key and falls back to a prefix match, so after an upstream merge it restores the previous base's cache and prunes stale artifacts only when it saves. Excluding the fallback is not an option the action offers. The two changes above give enough headroom to absorb that doubling.

## Verification

- Prettier passes on the workflow file, and it parses as YAML.
- The job itself can only be exercised by a release run. The workflow has `workflow_dispatch`, so if the in-progress rerun of 0.4.6 fails again, this can be dispatched against the existing tag without re-tagging.

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmYig7zCDfd13VQrJ6TDVb
