### PR TITLE
Never soft-wrap inside a link placeholder before it is measured

### DIFF
--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -128,6 +128,16 @@ impl LineFragmentBuilder {
         }
     }
 
+    /// Shaped width of `text` in the wrap font, summed per character.
+    fn text_width(&self, text: &str) -> Pixels {
+        text.chars()
+            .map(|ch| {
+                self.text_system
+                    .layout_width(self.font_id, self.font_size, ch)
+            })
+            .sum()
+    }
+
     fn replacement_width(&mut self, ch: char) -> Option<Pixels> {
         let replacement_char = replacement(ch)?;
         let width = *self
@@ -635,9 +645,17 @@ impl WrapSnapshot {
                             });
                             break;
                         } else {
-                            if let Some(width) =
-                                chunk.renderer.as_ref().and_then(|r| r.measured_width)
-                            {
+                            if let Some(renderer) = chunk.renderer.as_ref() {
+                                // SUZURI: a rendered chunk is drawn as one element, so it
+                                // must never be split across wrap rows even before its first
+                                // layout has measured it. Wrapping its text as plain
+                                // characters lets an overlong placeholder (a link label with
+                                // no spaces) be broken mid-word, and a wrap row that starts
+                                // inside a fold placeholder trips `FoldPoint::to_offset`.
+                                // Until measured, estimate the width from the text.
+                                let width = renderer
+                                    .measured_width
+                                    .unwrap_or_else(|| fragment_builder.text_width(chunk.text));
                                 line_fragments
                                     .push(gpui::LineFragment::element(width, chunk.text.len()));
                             } else {

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -1902,6 +1902,23 @@ fn request_math_render(key: MathKey, text_color: Hsla, cx: &mut App) {
     .detach();
 }
 
+/// Chunks carry their character positions in a `u128` bitmap, so the tab map
+/// assumes no chunk exceeds 128 bytes. A placeholder is emitted as a single
+/// chunk, so a label longer than that must be cut down (at a character
+/// boundary) before it becomes display text; the rendered element still
+/// shows the full label, and the measured width replaces this text's width
+/// after the first layout.
+fn placeholder_display_text(label: &SharedString) -> SharedString {
+    const MAX_CHUNK_BYTES: usize = 128;
+    if label.len() <= MAX_CHUNK_BYTES {
+        label.clone()
+    } else {
+        label[..label.floor_char_boundary(MAX_CHUNK_BYTES)]
+            .to_string()
+            .into()
+    }
+}
+
 fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPlaceholder {
     // Pure hides collapse to zero-width text; bullets and checkboxes keep the
     // default placeholder text, whose visual is replaced by the rendered
@@ -1910,7 +1927,7 @@ fn fold_placeholder(marker: &InlineMarker, editor: WeakEntity<Editor>) -> FoldPl
         InlineKind::Hide { .. } => Some(SharedString::new_static("")),
         // The label stands in for the link in the display text, so soft
         // wrapping and the cursor's column math see the width that is drawn.
-        InlineKind::Link { label, .. } => Some(label.clone()),
+        InlineKind::Link { label, .. } => Some(placeholder_display_text(label)),
         InlineKind::Bullet
         | InlineKind::Checkbox { .. }
         | InlineKind::Footnote { .. }

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -4603,3 +4603,81 @@ async fn test_wide_table_scrolls_horizontally_in_place(cx: &mut TestAppContext) 
         "the grid should have scrolled left: {first_cell:?} vs {container:?}"
     );
 }
+
+#[gpui::test]
+async fn test_link_label_wider_than_the_wrap_width_does_not_panic(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    // A link's label stands in for its source as the placeholder's display
+    // text, so a bare-URL label wider than the wrap width gives the wrapper
+    // no word boundary to break at. It must break before the placeholder,
+    // never inside it: a wrap row starting mid-placeholder trips the fold
+    // map's offset assertion and takes the whole app down. Bounded wrapping
+    // uses the 80-column preferred line length, which this label exceeds.
+    cx.update_editor(|editor, _, cx| {
+        editor.set_soft_wrap_mode(language::language_settings::SoftWrap::Bounded, cx)
+    });
+    let url =
+        "https://www.example.com/students/support/policies/academic-integrity/and/conduct/overview";
+    assert!(url.len() > 80 && url.len() < 128);
+    cx.set_state(&format!(
+        "ˇ\n\nPlease review [{url}]({url}) before class.\n"
+    ));
+    cx.executor().run_until_parked();
+    cx.update_editor(|editor, window, cx| {
+        editor.snapshot(window, cx);
+    });
+}
+
+#[gpui::test]
+async fn test_link_label_over_128_bytes_does_not_panic(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    // The tab map tracks a chunk's characters in a `u128` bitmap, so a
+    // placeholder whose display text exceeds 128 bytes overflows its byte
+    // range arithmetic. The label must be cut down before it becomes the
+    // placeholder's text.
+    cx.update_editor(|editor, _, cx| {
+        editor.set_soft_wrap_mode(language::language_settings::SoftWrap::EditorWidth, cx)
+    });
+    let url = format!(
+        "https://www.example.com/{}",
+        "students/support/policies/academic-integrity/".repeat(12)
+    );
+    cx.set_state(&format!(
+        "ˇ\n\nPlease review [{url}]({url}) before class.\n"
+    ));
+    cx.executor().run_until_parked();
+    cx.update_editor(|editor, window, cx| {
+        editor.snapshot(window, cx);
+    });
+}
+
+#[gpui::test]
+async fn test_soft_wrapped_line_of_links_before_a_heading_does_not_panic(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    // Regression test for harrywang/suzuri#56: the reporter's file, verbatim.
+    // Before a link placeholder has been measured, its label was wrapped as
+    // plain characters, so a label containing spaces could be broken at one of
+    // them. The heading's replace block then summarised the wrapped text at a
+    // row boundary inside the placeholder, and the fold map's offset assertion
+    // took the app down before a window was usable.
+    cx.update_editor(|editor, _, cx| {
+        editor.set_soft_wrap_mode(language::language_settings::SoftWrap::Bounded, cx)
+    });
+    cx.set_state(concat!(
+        "- One-year house outlooks that are often mistaken for CMAs: ",
+        "[Allianz Global Investors](https://www.allianzgi.com/en/insights/outlook-and-commentary/outlook-2026), ",
+        "[Pictet](https://am.pictet.com/us/en/investment-views/multi-asset/2025/annual-outlook-for-2026), ",
+        "[Nordea](https://www.nordea.com/en/news/setting-the-plan-for-your-financial-year-2026-get-insights-from-our-local-experts), ",
+        "[Columbia Threadneedle](https://www.columbiathreadneedle.com/en/gb/intermediary/global-outlooks-2026/), ",
+        "[Goldman Sachs AM](https://am.gs.com/en-us/advisors/insights/article/investment-outlook/public-markets-2026), ",
+        "[Wellington](https://www.wellington.com/en/insights/2026-macro-outlook). ",
+        "These carry views, not full return-volatility-correlation grids.\n",
+        "\n",
+        "### Access mode per publisher\n",
+        "ˇ",
+    ));
+    cx.executor().run_until_parked();
+    cx.update_editor(|editor, window, cx| {
+        editor.snapshot(window, cx);
+    });
+}


### PR DESCRIPTION
Fixes #56.

Opening a markdown note with a long, soft-wrapping line holding several links, followed by a heading, killed the app on `assertion failed: transform.placeholder.is_none()` in `fold_map.rs` before a window was usable. Once such a note was in the restored session, every Dock launch died in a fraction of a second with nothing in the log, since the dev channel's panic hook only writes to stderr.

## Cause

A link's label is its placeholder's display text, so soft wrapping and cursor column math see the width that is drawn. Until the placeholder element's first layout, the wrap map has no measured width and wrapped the label as plain characters. A label containing spaces (`Allianz Global Investors`) could then be broken at one of them. The heading's replace block summarised the wrapped text at that row boundary, which seeks to a fold point inside the placeholder transform, and the fold map asserts that never happens.

## Fix

- `wrap_map.rs` (tagged `SUZURI:`): treat every rendered chunk as one unbreakable line fragment, estimating its width from its text until the element has been measured. The line wrapper never breaks inside an element fragment, so a wrap row can no longer start mid-placeholder.
- `markdown_live_preview.rs`: cut link placeholder text down to 128 bytes, the tab map's per-chunk character bitmap limit, before it becomes display text. The rendered element still shows the full label.

## Tests

Three regression tests in `markdown_live_preview`: the reporter's three-line file verbatim, a bare-URL label wider than the wrap width with no space to break at, and a label over 128 bytes. The first two fail on the exact assertion from the report without the wrap-map hunk and pass with it. The full crate suite (106 tests) passes.

## Manual verification

A release-fast build opened the new `link-wrap-crash-check.md` note in the testbed vault in live preview, survived resizing the window from 640 to 1472 pixels wide so every line rewrapped, and after a quit relaunched with no arguments into the restored session with that note open. stderr stayed empty throughout.

Upstream Zed has the same latent shape through LSP folding ranges with `collapsedText`, so the wrap-map hunk is a candidate for an upstream PR.

Release Notes:

- Fixed a crash on opening a markdown note whose soft-wrapping line holds several links before a heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4NwXmBd8hguybeCREENEW
