### PR TITLE
Bump SUZURI_VERSION to 0.4.7

### DIFF
--- a/crates/suzuri_update/src/suzuri_update.rs
+++ b/crates/suzuri_update/src/suzuri_update.rs
@@ -55,7 +55,7 @@ use workspace::{
 /// Bump it in the same commit that gets tagged `suzuri-v<this version>`; the
 /// `check-version` job in `.github/workflows/suzuri-release.yml` enforces that
 /// the two agree.
-pub const SUZURI_VERSION: &str = "0.4.6";
+pub const SUZURI_VERSION: &str = "0.4.7";
 
 /// The repository whose releases describe newer Suzuri builds.
 const RELEASE_REPOSITORY: &str = "harrywang/suzuri";


### PR DESCRIPTION
Bumps `SUZURI_VERSION` to 0.4.7 ahead of tagging `suzuri-v0.4.7`.

This release carries the fix for #56 (#57), the crash on opening a markdown note whose soft-wrapping line holds several links before a heading, and the upstream Zed merge of 2026-09-12.

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4NwXmBd8hguybeCREENEW
