### PR TITLE
Log panics and quarantine the file blamed for a launch crash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ The fork's own changes are small and additive:
 | Preview button for `.typ`/`.tex` | `crates/zed/src/zed/quick_action_bar/preview.rs` |
 | Jupyter notebooks enabled by default (temporary; see below) | `crates/feature_flags/src/flags.rs`, `crates/repl/src/notebook/notebook_ui.rs`, `crates/repl/src/repl_editor.rs` |
 | Update notifications | `crates/suzuri_update/`, `crates/zed/src/zed/app_menus.rs` (the Check for Updates entry) |
+| Crash recovery: panic logging and quarantining the file blamed for a launch crash (see "Crash recovery") | `crates/suzuri_recovery/`, `crates/zed/src/main.rs` (panic hook, init), `crates/editor/src/items.rs` (skip on restore), `crates/markdown_live_preview/src/markdown_live_preview.rs` (`register_editor`) |
 | Remote server provisioning on the dev channel (SSH/Docker/WSL remotes; see "Cutting a release") | `crates/auto_update/src/auto_update.rs` (`get_release_asset`), `crates/remote/src/transport/ssh.rs`, `docker.rs`, `wsl.rs` (`ensure_server_binary`) |
 | Settings plumbing | `crates/settings_content/`, `assets/settings/default.json` |
 | Branding, CLI name, release infrastructure | `crates/zed/Cargo.toml` (bundle metadata), `crates/zed/resources/app-icon-suzuri*`, `crates/zed/resources/windows/app-icon-suzuri.ico`, `assets/images/suzuri_logo.svg`, `crates/install_cli/src/install_cli_binary.rs`, `script/bundle-mac`, `script/bundle-windows.ps1`, `script/bundle-linux`, `.github/workflows/suzuri-release.yml` |
@@ -304,3 +305,20 @@ debug build, which compiles the server from source instead.
 is not wired up, and adopting it would need, at minimum, its hardcoded `Zed` DMG
 mount path in `install_release_macos` reconciled with `bundle-mac`'s `-volname Suzuri`,
 plus signing secrets present on every release build.
+
+## Crash recovery
+
+The dev channel installs no crash handler (`should_install_crash_handler` is false), so
+upstream's fallback prints a panic to stderr and exits. A Dock launch has no stderr, and
+session restore then reopens whatever caused the panic, which is how one bad file turned
+into an app that quit a fraction of a second after every launch (#56). `suzuri_recovery`
+replaces that fallback: the panic and backtrace go into `Zed.log`, and a small
+`suzuri-recovery.json` in the data dir records the file most recently activated in any
+pane. A panic within 30 seconds of that activation blames the file. On the next launch a
+blamed file opens with live preview off (strike one); after two consecutive crashing
+launches it is left out of session restore (strike two). A launch that ends without a panic
+clears all strikes. The suspect is recorded from a `Pane` observer, which subscribes ahead
+of the workspace's own pane handler; that order is load-bearing, because the status bar
+reads the newly active editor's display map inside that handler, which is exactly where
+a layout panic fires. To reproduce a Dock-style crash and see the log line, run a
+source build with `ZED_RELEASE_CHANNEL=nightly` beside the installed app.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5652,6 +5652,7 @@ dependencies = [
  "smallvec",
  "snippet",
  "sum_tree",
+ "suzuri_recovery",
  "task",
  "telemetry",
  "text",
@@ -10807,6 +10808,7 @@ dependencies = [
  "pretty_assertions",
  "project",
  "settings",
+ "suzuri_recovery",
  "tempfile",
  "text",
  "theme",
@@ -17982,6 +17984,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "suzuri_recovery"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gpui",
+ "log",
+ "paths",
+ "serde",
+ "serde_json",
+ "util",
+ "workspace",
+ "zlog",
+]
+
+[[package]]
 name = "suzuri_update"
 version = "0.1.0"
 dependencies = [
@@ -23399,6 +23416,7 @@ dependencies = [
  "snippet_provider",
  "snippets_ui",
  "spin 0.10.0",
+ "suzuri_recovery",
  "suzuri_update",
  "svg_preview",
  "sysinfo 0.39.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ members = [
     "crates/sqlez_macros",
     "crates/streaming_diff",
     "crates/sum_tree",
+    "crates/suzuri_recovery",
     "crates/suzuri_update",
     "crates/svg_preview",
     "crates/syntax_theme",
@@ -476,6 +477,7 @@ sqlez = { path = "crates/sqlez" }
 sqlez_macros = { path = "crates/sqlez_macros" }
 streaming_diff = { path = "crates/streaming_diff" }
 sum_tree = { path = "crates/sum_tree" }
+suzuri_recovery = { path = "crates/suzuri_recovery" }
 suzuri_update = { path = "crates/suzuri_update" }
 svg_preview = { path = "crates/svg_preview" }
 syntax_theme = { path = "crates/syntax_theme" }

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -79,6 +79,7 @@ serde_json.workspace = true
 settings.workspace = true
 smallvec.workspace = true
 snippet.workspace = true
+suzuri_recovery.workspace = true
 sum_tree.workspace = true
 task.workspace = true
 telemetry.workspace = true

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1396,6 +1396,14 @@ impl SerializableItem for Editor {
                 mtime,
                 ..
             } => {
+                // SUZURI: a file blamed for two consecutive crashes on launch is
+                // left out of the restored session; see `suzuri_recovery`.
+                if suzuri_recovery::should_skip_restore(&abs_path, cx) {
+                    return Task::ready(Err(anyhow!(
+                        "not restoring {}: Suzuri crashed twice right after opening it",
+                        abs_path.display()
+                    )));
+                }
                 let opened_buffer = project.update(cx, |project, cx| {
                     let (worktree, path) = project.find_worktree(&abs_path, cx)?;
                     let project_path = ProjectPath {

--- a/crates/markdown_live_preview/Cargo.toml
+++ b/crates/markdown_live_preview/Cargo.toml
@@ -27,6 +27,7 @@ math_render.workspace = true
 multi_buffer.workspace = true
 project.workspace = true
 settings.workspace = true
+suzuri_recovery.workspace = true
 text.workspace = true
 theme.workspace = true
 theme_settings.workspace = true

--- a/crates/markdown_live_preview/src/markdown_live_preview.rs
+++ b/crates/markdown_live_preview/src/markdown_live_preview.rs
@@ -87,6 +87,19 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
         return;
     }
 
+    // A file blamed for the previous launch's panic opens with live preview
+    // off, since this crate's rendering is the likeliest home of a
+    // file-specific panic; `ToggleLivePreview` turns it back on for a retry.
+    let quarantined = editor
+        .buffer()
+        .read(cx)
+        .as_singleton()
+        .and_then(|buffer| {
+            let file = buffer.read(cx).file()?;
+            Some(language::LocalFile::abs_path(file.as_local()?, cx))
+        })
+        .is_some_and(|path| suzuri_recovery::should_disable_live_preview(&path, cx));
+
     let mut subscriptions = Vec::new();
     subscriptions.push(
         cx.subscribe_self(|editor, event: &EditorEvent, cx| match event {
@@ -304,7 +317,7 @@ fn register_editor(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Co
     }
 
     editor.register_addon(LivePreviewAddon {
-        enabled_override: None,
+        enabled_override: quarantined.then_some(false),
         image_cache,
         markers: None,
         applied_blocks: Vec::new(),

--- a/crates/suzuri_recovery/Cargo.toml
+++ b/crates/suzuri_recovery/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "suzuri_recovery"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/suzuri_recovery.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+gpui.workspace = true
+log.workspace = true
+paths.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+util.workspace = true
+workspace.workspace = true
+zlog.workspace = true

--- a/crates/suzuri_recovery/src/suzuri_recovery.rs
+++ b/crates/suzuri_recovery/src/suzuri_recovery.rs
@@ -1,0 +1,426 @@
+//! Crash recovery for Suzuri's release channel.
+//!
+//! Suzuri ships on Zed's `dev` channel, where Zed installs no crash handler: a
+//! panic prints to stderr and exits. Launched from the Dock, stderr goes
+//! nowhere, so nothing records why the app quit. The next launch then restores
+//! the same session, and a file that panics during layout makes the app die a
+//! fraction of a second after every launch, with no clue which file did it.
+//!
+//! Two pieces close that loop:
+//!
+//! 1. [`install_panic_hook`] writes the panic and its backtrace into the Zed
+//!    log before exiting, and stamps the recovery file so the next launch knows
+//!    the previous one died.
+//! 2. Every pane activation records the activated file as the current
+//!    *suspect*. A panic that follows within [`BLAME_WINDOW`] blames that file.
+//!    On the next launch the blamed file opens with live preview off (one
+//!    strike), and is left out of session restore altogether once it has
+//!    crashed two launches in a row. A launch that ends without a panic clears
+//!    all strikes, so a fixed build gets a clean retry.
+//!
+//! The suspect is recorded from a `Pane` observer registered when the pane is
+//! built, which puts its subscriber ahead of the workspace's own pane handler.
+//! That order matters: the status bar reads the newly active editor's display
+//! map synchronously inside that handler, which is where a layout panic fires.
+
+use anyhow::{Context as _, Result};
+use gpui::{App, AppContext as _, Context, DismissEvent, Global, Window};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use util::ResultExt as _;
+use workspace::{
+    AppState, ItemHandle, Pane, Workspace,
+    notifications::{
+        NotificationId, show_app_notification, simple_message_notification::MessageNotification,
+    },
+    pane::Event as PaneEvent,
+};
+
+/// How long after a file is activated a panic is still blamed on it. Layout of
+/// a freshly activated file happens within a frame, so a panic further out is
+/// treated as unrelated rather than quarantining a file that was merely open.
+const BLAME_WINDOW: Duration = Duration::from_secs(30);
+
+const RECOVERY_FILE_NAME: &str = "suzuri-recovery.json";
+
+#[derive(Default, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+struct RecoveryFile {
+    /// The file most recently activated in a pane, and when.
+    #[serde(default)]
+    suspect: Option<Suspect>,
+    /// Stamped by the panic hook; consumed by the next launch.
+    #[serde(default)]
+    panicked_at: Option<u64>,
+    /// Consecutive launches that panicked right after activating each file.
+    #[serde(default)]
+    strikes: BTreeMap<PathBuf, u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+struct Suspect {
+    path: PathBuf,
+    noted_at: u64,
+}
+
+/// The file the previous launch's panic was blamed on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Blamed {
+    pub path: PathBuf,
+    pub strikes: u32,
+}
+
+struct GlobalRecovery {
+    blamed: Option<Blamed>,
+    pending_notification: Option<Blamed>,
+}
+
+impl Global for GlobalRecovery {}
+
+fn recovery_path() -> PathBuf {
+    paths::data_dir().join(RECOVERY_FILE_NAME)
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0)
+}
+
+fn read_file(path: &Path) -> RecoveryFile {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => serde_json::from_str(&contents).unwrap_or_else(|error| {
+            log::warn!(
+                "ignoring unreadable recovery file {}: {error}",
+                path.display()
+            );
+            RecoveryFile::default()
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => RecoveryFile::default(),
+        Err(error) => {
+            log::warn!("could not read recovery file {}: {error}", path.display());
+            RecoveryFile::default()
+        }
+    }
+}
+
+fn write_file(path: &Path, file: &RecoveryFile) -> Result<()> {
+    let contents = serde_json::to_string_pretty(file)?;
+    std::fs::write(path, contents).with_context(|| format!("writing {}", path.display()))
+}
+
+/// Installs the panic hook Suzuri uses in place of `crashes::force_backtrace`.
+///
+/// Besides printing to stderr and exiting like the original, it writes the
+/// panic and its backtrace into the Zed log, where a Dock launch can still be
+/// diagnosed, and stamps the recovery file so the next launch can blame the
+/// file that was activated just before.
+pub fn install_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let backtrace = std::backtrace::Backtrace::force_capture();
+        let path = recovery_path();
+        let mut file = read_file(&path);
+        let suspect = file
+            .suspect
+            .as_ref()
+            .map(|suspect| format!(" (last activated file: {})", suspect.path.display()))
+            .unwrap_or_default();
+        log::error!("Suzuri panicked{suspect}: {info}\n{backtrace}");
+        zlog::flush();
+
+        file.panicked_at = Some(unix_now());
+        if let Err(error) = write_file(&path, &file) {
+            eprintln!("could not record the panic in {}: {error}", path.display());
+        }
+
+        // The rest mirrors `crashes::force_backtrace`: a terminal launch still
+        // gets the backtrace on stderr, and exiting keeps macOS from raising
+        // its own crash dialog.
+        unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
+        previous(info);
+        if cfg!(target_os = "macos") {
+            std::process::exit(1);
+        }
+    }));
+}
+
+/// Consumes the previous launch's outcome from the recovery file.
+///
+/// A panic within [`BLAME_WINDOW`] of the last activation adds a strike to that
+/// file and returns it. A launch that did not panic clears every strike.
+fn settle(file: &mut RecoveryFile, now: u64) -> Option<Blamed> {
+    let panicked_at = file.panicked_at.take();
+    let suspect = file.suspect.take();
+
+    let Some(panicked_at) = panicked_at else {
+        file.strikes.clear();
+        return None;
+    };
+
+    // `now` only guards against a clock that ran backwards between launches:
+    // a suspect noted after the panic it is being blamed for is not a suspect.
+    let suspect = suspect.filter(|suspect| {
+        suspect.noted_at <= panicked_at
+            && suspect.noted_at <= now
+            && panicked_at - suspect.noted_at <= BLAME_WINDOW.as_secs()
+    })?;
+
+    let strikes = file.strikes.entry(suspect.path.clone()).or_insert(0);
+    *strikes += 1;
+    Some(Blamed {
+        path: suspect.path,
+        strikes: *strikes,
+    })
+}
+
+fn note_suspect(path: &Path, suspect: &Path, now: u64) {
+    let mut file = read_file(path);
+    file.suspect = Some(Suspect {
+        path: suspect.to_path_buf(),
+        noted_at: now,
+    });
+    write_file(path, &file).log_err();
+}
+
+pub fn init(cx: &mut App) {
+    let path = recovery_path();
+    let mut file = read_file(&path);
+    let blamed = settle(&mut file, unix_now());
+    write_file(&path, &file).log_err();
+
+    if let Some(blamed) = &blamed {
+        log::warn!(
+            "the previous launch panicked within {}s of activating {}; strike {}",
+            BLAME_WINDOW.as_secs(),
+            blamed.path.display(),
+            blamed.strikes
+        );
+    }
+    cx.set_global(GlobalRecovery {
+        blamed: blamed.clone(),
+        pending_notification: blamed,
+    });
+
+    cx.observe_new(
+        |_: &mut Pane, _window: Option<&mut Window>, cx: &mut Context<Pane>| {
+            cx.subscribe_self(|pane, event: &PaneEvent, cx| {
+                let item = match event {
+                    PaneEvent::AddItem { item } => item.boxed_clone(),
+                    PaneEvent::ActivateItem { .. } => match pane.active_item() {
+                        Some(item) => item,
+                        None => return,
+                    },
+                    _ => return,
+                };
+                if let Some(abs_path) = abs_path_of(cx.entity_id(), item.as_ref(), cx) {
+                    note_suspect(&recovery_path(), &abs_path, unix_now());
+                }
+            })
+            .detach();
+        },
+    )
+    .detach();
+
+    cx.observe_new(
+        |_: &mut Workspace, _window: Option<&mut Window>, cx: &mut Context<Workspace>| {
+            let Some(blamed) = cx
+                .global_mut::<GlobalRecovery>()
+                .pending_notification
+                .take()
+            else {
+                return;
+            };
+            // The workspace being built is mid-update here, and the notification
+            // is delivered by updating every workspace.
+            cx.defer(move |cx| show_recovery_notification(blamed, cx));
+        },
+    )
+    .detach();
+}
+
+/// Resolves an item's file through the workspace that owns `pane`.
+///
+/// The pane keeps its project private, and the window's root view is not set
+/// yet when the first pane is built, so the workspace is found through the
+/// store instead.
+fn abs_path_of(pane: gpui::EntityId, item: &dyn ItemHandle, cx: &App) -> Option<PathBuf> {
+    let project_path = item.project_path(cx)?;
+    let app_state = AppState::global(cx);
+    let store = app_state.workspace_store.read(cx);
+    store.workspaces().find_map(|workspace| {
+        let workspace = workspace.upgrade()?;
+        let workspace = workspace.read(cx);
+        if !workspace
+            .panes()
+            .iter()
+            .any(|candidate| candidate.entity_id() == pane)
+        {
+            return None;
+        }
+        workspace
+            .project()
+            .read(cx)
+            .absolute_path(&project_path, cx)
+    })
+}
+
+/// Strikes against `path` from the previous launch's panic, if it was blamed.
+pub fn strikes_against(path: &Path, cx: &App) -> Option<u32> {
+    cx.try_global::<GlobalRecovery>()?
+        .blamed
+        .as_ref()
+        .filter(|blamed| blamed.path == path)
+        .map(|blamed| blamed.strikes)
+}
+
+/// One strike: the file opens, but without live preview, since the fork's
+/// rendering is the likeliest home of a file-specific panic.
+pub fn should_disable_live_preview(path: &Path, cx: &App) -> bool {
+    strikes_against(path, cx).is_some()
+}
+
+/// Two strikes: the file crashed even without live preview, so session restore
+/// leaves it out and the user gets a working window to open it from by hand.
+pub fn should_skip_restore(path: &Path, cx: &App) -> bool {
+    strikes_against(path, cx).is_some_and(|strikes| strikes >= 2)
+}
+
+fn show_recovery_notification(blamed: Blamed, cx: &mut App) {
+    struct CrashRecovery;
+
+    let name = blamed
+        .path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| blamed.path.display().to_string());
+    let message = if blamed.strikes >= 2 {
+        format!(
+            "Suzuri crashed again right after opening {name}, so it was not reopened. The panic is in the log."
+        )
+    } else {
+        format!(
+            "Suzuri crashed right after opening {name}, so it was reopened with live preview off. The panic is in the log."
+        )
+    };
+
+    show_app_notification(NotificationId::unique::<CrashRecovery>(), cx, move |cx| {
+        cx.new(|cx| {
+            MessageNotification::new(message.clone(), cx)
+                .primary_message("Open Log")
+                .primary_on_click(|_, cx| {
+                    cx.open_with_system(paths::log_file());
+                    cx.emit(DismissEvent);
+                })
+                .show_suppress_button(false)
+        })
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn suspect(path: &str, noted_at: u64) -> Option<Suspect> {
+        Some(Suspect {
+            path: PathBuf::from(path),
+            noted_at,
+        })
+    }
+
+    #[test]
+    fn a_clean_launch_clears_strikes_and_blames_nobody() {
+        let mut file = RecoveryFile {
+            suspect: suspect("/notes/a.md", 100),
+            panicked_at: None,
+            strikes: BTreeMap::from([(PathBuf::from("/notes/a.md"), 1)]),
+        };
+        assert_eq!(settle(&mut file, 200), None);
+        assert_eq!(file, RecoveryFile::default());
+    }
+
+    #[test]
+    fn a_panic_right_after_activation_blames_the_file_and_counts_strikes() {
+        let mut file = RecoveryFile {
+            suspect: suspect("/notes/a.md", 100),
+            panicked_at: Some(101),
+            strikes: BTreeMap::new(),
+        };
+        assert_eq!(
+            settle(&mut file, 200),
+            Some(Blamed {
+                path: PathBuf::from("/notes/a.md"),
+                strikes: 1
+            })
+        );
+        assert_eq!(file.suspect, None);
+        assert_eq!(file.panicked_at, None);
+
+        file.suspect = suspect("/notes/a.md", 300);
+        file.panicked_at = Some(320);
+        assert_eq!(
+            settle(&mut file, 400),
+            Some(Blamed {
+                path: PathBuf::from("/notes/a.md"),
+                strikes: 2
+            })
+        );
+    }
+
+    #[test]
+    fn a_panic_long_after_activation_is_not_blamed_on_the_file() {
+        let mut file = RecoveryFile {
+            suspect: suspect("/notes/a.md", 100),
+            panicked_at: Some(100 + BLAME_WINDOW.as_secs() + 1),
+            strikes: BTreeMap::from([(PathBuf::from("/notes/b.md"), 1)]),
+        };
+        assert_eq!(settle(&mut file, 1000), None);
+        assert_eq!(file.suspect, None);
+        assert_eq!(file.panicked_at, None);
+        assert_eq!(
+            file.strikes,
+            BTreeMap::from([(PathBuf::from("/notes/b.md"), 1)]),
+            "an unattributed panic keeps existing strikes"
+        );
+    }
+
+    #[test]
+    fn a_suspect_noted_after_the_panic_is_not_blamed() {
+        let mut file = RecoveryFile {
+            suspect: suspect("/notes/a.md", 150),
+            panicked_at: Some(100),
+            strikes: BTreeMap::new(),
+        };
+        assert_eq!(settle(&mut file, 200), None);
+    }
+
+    #[test]
+    fn the_recovery_file_round_trips_and_tolerates_absence() {
+        let dir = std::env::temp_dir().join(format!(
+            "suzuri-recovery-test-{}-{}",
+            std::process::id(),
+            unix_now()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(RECOVERY_FILE_NAME);
+
+        assert_eq!(read_file(&path), RecoveryFile::default());
+
+        note_suspect(&path, Path::new("/notes/a.md"), 100);
+        let mut file = read_file(&path);
+        assert_eq!(file.suspect, suspect("/notes/a.md", 100));
+
+        file.panicked_at = Some(101);
+        write_file(&path, &file).unwrap();
+        assert_eq!(read_file(&path), file);
+
+        std::fs::write(&path, "not json").unwrap();
+        assert_eq!(read_file(&path), RecoveryFile::default());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -209,6 +209,7 @@ sidebar.workspace = true
 smol.workspace = true
 snippet_provider.workspace = true
 snippets_ui.workspace = true
+suzuri_recovery.workspace = true
 suzuri_update.workspace = true
 svg_preview.workspace = true
 sysinfo.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -416,7 +416,9 @@ fn main() {
             )),
         )
     } else {
-        crashes::force_backtrace();
+        // SUZURI: the dev channel has no crash handler, so log the panic and
+        // remember the file it followed; see `suzuri_recovery`.
+        suzuri_recovery::install_panic_hook();
         None
     };
 
@@ -782,6 +784,7 @@ fn main() {
         feedback::init(cx);
         markdown_preview::init(cx);
         markdown_live_preview::init(cx);
+        suzuri_recovery::init(cx);
         tabular_data_preview::init(cx);
         svg_preview::init(cx);
         onboarding::init(cx);


### PR DESCRIPTION
Follow-up to #56 and #57. The crash there is fixed, but the way it presented is not: on the dev channel Zed installs no crash handler, so a panic prints to stderr and exits, a Dock launch has no stderr, and session restore then reopens the file that caused it. One bad file turned into an app that quit a fraction of a second after every launch, with nothing in the log and no clue which file did it.

## What this adds

A fork-owned crate, `suzuri_recovery`, replaces the dev-channel fallback (`crashes::force_backtrace`) in `main.rs`:

- **The panic is logged.** The panic hook writes the message and backtrace into `Zed.log` before exiting, naming the file that was most recently activated, and stamps a small `suzuri-recovery.json` in the data dir.
- **The file is quarantined.** Every pane activation records the activated file as the current suspect. A panic within 30 seconds of that blames the file. On the next launch a blamed file opens with live preview off (strike one) and a notification says why, with an Open Log button; after two consecutive crashing launches it is left out of session restore (strike two). A launch that ends without a panic clears all strikes, so a fixed build gets a clean retry.

The suspect is recorded from a `Pane` observer, whose subscriber is registered before the workspace subscribes to the pane and therefore runs first. That order is load-bearing: the status bar reads the newly active editor's display map synchronously inside the workspace's pane handler, which is exactly where the #56 panic fired.

## Vendor surface

Three small tagged hunks outside fork-owned crates: the panic-hook swap and init call in `crates/zed/src/main.rs`, a restore skip at the top of the abs-path branch of `Editor::deserialize` in `crates/editor/src/items.rs`, and the `enabled_override` in live preview's `register_editor`. Plus one dependency line each in the `zed`, `editor`, and `markdown_live_preview` manifests.

## Verification

- Unit tests for the blame logic and the recovery file (5 tests), plus the full live-preview suite: 111 passed. Clippy clean on the new crate with warnings denied.
- End to end on a debug build run on the nightly channel beside the installed app, using Zed's `zed: test panic` action: the panic and backtrace land in `Zed.log` naming the note; the relaunch shows the strike-one notification and the note in source mode; a second panic inside the window leads to a relaunch with the note left out and the strike-two notification; a panic outside the window adds no strike; a clean quit and relaunch clears strikes.

CLAUDE.md gains a row in the fork table and a short "Crash recovery" section.

Release Notes:

- Added crash recovery: a panic is now written to the log, and a file that crashed Suzuri right after opening is reopened without live preview, then left out of session restore if it crashes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4NwXmBd8hguybeCREENEW
