### PR TITLE
editor: Land standalone concealment fixes ahead of native typography

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ The fork's own changes are small and additive:
 | LaTeX math rendering for live preview | `crates/math_render/` |
 | PDF viewer (adopted from zed#51040) | `crates/pdf_viewer/` |
 | Live Typst/LaTeX preview | `crates/typeset_preview/` |
-| Concealment + highlight hooks live preview needs | `crates/editor/src/display_map.rs`, `display_map/fold_map.rs`, `fold.rs` |
+| Concealment + highlight hooks live preview needs | `crates/editor/src/display_map.rs`, `display_map/fold_map.rs`, `fold.rs`, `crates/editor/src/selections_collection.rs` |
 | Markdown attachments: drag-and-drop and clipboard paste | `crates/editor/src/items.rs` |
 | Project panel header (file/sort/refresh/collapse) and typeset preview menu entry | `crates/project_panel/src/project_panel.rs` |
 | Built-in markdown-oxide language server | `crates/languages/src/markdown_oxide.rs`, `crates/languages/src/lib.rs` |

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -1054,6 +1054,21 @@ impl FoldSnapshot {
         })
     }
 
+    // SUZURI: Source selections inside display-only concealments must retain their exact endpoints.
+    pub(crate) fn is_offset_concealed<T: ToOffset>(&self, offset: T) -> bool {
+        let buffer_offset = offset.to_offset(&self.inlay_snapshot.buffer);
+        let inlay_offset = self.inlay_snapshot.to_inlay_offset(buffer_offset);
+        let (_, _, item) = self
+            .transforms
+            .find::<InlayOffset, _>((), &inlay_offset, Bias::Right);
+        item.is_some_and(|transform| {
+            transform
+                .placeholder
+                .as_ref()
+                .is_some_and(|placeholder| placeholder.is_concealment)
+        })
+    }
+
     #[ztracing::instrument(skip_all)]
     pub fn is_line_folded(&self, buffer_row: MultiBufferRow) -> bool {
         let mut inlay_point = self

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -727,6 +727,17 @@ impl FoldMap {
                             .collapsed_text
                             .clone()
                             .unwrap_or_else(|| ELLIPSIS.into());
+                        // SUZURI: Zed's display-to-buffer mapping assumes a fold occupies at
+                        // least one display column. A zero-width concealment makes the points
+                        // before and after the hidden text the same display point, and bias
+                        // then resolves past the concealed source: Vim's linewise `dd`, `yy`,
+                        // and `cc` lost a heading's hidden prefix. Keep concealments visually
+                        // empty (the renderer draws nothing) but never zero-width.
+                        let placeholder_text = if is_concealment && placeholder_text.is_empty() {
+                            SharedString::new_static("\u{200b}")
+                        } else {
+                            placeholder_text
+                        };
                         let chars_bitmap = placeholder_text
                             .char_indices()
                             .fold(0u128, |bitmap, (idx, _)| {

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -1261,7 +1261,7 @@ where
     // Transforms `Anchor -> DisplayPoint -> Point -> DisplayPoint -> D`
     // todo(lw): We should be able to short circuit the `Anchor -> DisplayPoint -> Point` to `Anchor -> Point`
     // SUZURI: A real fold elsewhere must not make a concealment swallow source selection endpoints.
-    let points = selections.into_iter().flat_map(|source| {
+    let points = selections.into_iter().flat_map(move |source| {
         resolve_selections_display(Some(source), map).map(move |display| {
             let start = if map.fold_snapshot().is_offset_concealed(source.start) {
                 source.start.to_point(map.buffer_snapshot())

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -1260,15 +1260,32 @@ where
 {
     // Transforms `Anchor -> DisplayPoint -> Point -> DisplayPoint -> D`
     // todo(lw): We should be able to short circuit the `Anchor -> DisplayPoint -> Point` to `Anchor -> Point`
-    let (to_convert, selections) = resolve_selections_display(selections, map).tee();
-    let mut converted_endpoints =
-        map.buffer_snapshot()
-            .dimensions_from_points::<D>(to_convert.flat_map(|s| {
-                let start = map.display_point_to_point(s.start, Bias::Left);
-                let end = map.display_point_to_point(s.end, Bias::Right);
-                assert!(start <= end, "start: {:?}, end: {:?}", start, end);
-                [start, end]
-            }));
+    // SUZURI: A real fold elsewhere must not make a concealment swallow source selection endpoints.
+    let points = selections.into_iter().flat_map(|source| {
+        resolve_selections_display(Some(source), map).map(move |display| {
+            let start = if map.fold_snapshot().is_offset_concealed(source.start) {
+                source.start.to_point(map.buffer_snapshot())
+            } else {
+                map.display_point_to_point(display.start, Bias::Left)
+            };
+            let end = if map.fold_snapshot().is_offset_concealed(source.end) {
+                source.end.to_point(map.buffer_snapshot())
+            } else {
+                map.display_point_to_point(display.end, Bias::Right)
+            };
+            Selection {
+                id: display.id,
+                start,
+                end,
+                reversed: display.reversed,
+                goal: display.goal,
+            }
+        })
+    });
+    let (to_convert, selections) = coalesce_selections(points).tee();
+    let mut converted_endpoints = map.buffer_snapshot().dimensions_from_points::<D>(
+        to_convert.flat_map(|selection| [selection.start, selection.end]),
+    );
     selections.map(move |s| {
         let start = converted_endpoints.next().unwrap();
         let end = converted_endpoints.next().unwrap();

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -214,7 +214,10 @@ impl EditorTestContext {
     }
 
     pub fn display_text(&mut self) -> String {
+        // SUZURI: Concealments occupy one zero-width display column (see fold_map.rs);
+        // tests compare visible text, so drop the U+200B placeholders.
         self.update_editor(|editor, _, cx| editor.display_text(cx))
+            .replace('\u{200b}', "")
     }
 
     pub fn buffer<F, T>(&mut self, read: F) -> T

--- a/crates/markdown_live_preview/src/tests.rs
+++ b/crates/markdown_live_preview/src/tests.rs
@@ -3775,6 +3775,37 @@ async fn test_citation_key_start_finds_pandoc_contexts(cx: &mut TestAppContext) 
 // behavior of its own. They exist so an upstream merge that changes those
 // semantics fails here, loudly, instead of silently degrading live preview.
 
+#[gpui::test]
+async fn test_concealed_source_selection_with_unrelated_fold_contract(cx: &mut TestAppContext) {
+    let mut cx = markdown_test_context(cx).await;
+    cx.set_state("ˇabove\n**text**\nfold start\nfold end");
+    cx.executor().run_until_parked();
+    cx.update_editor(|editor, window, cx| {
+        let buffer = editor.buffer().read(cx).snapshot(cx);
+        editor.set_concealments(
+            std::any::TypeId::of::<EditorTestContext>(),
+            vec![editor::display_map::Concealment {
+                range: buffer.anchor_before(Point::new(1, 0))
+                    ..buffer.anchor_after(Point::new(1, 2)),
+                placeholder: editor::display_map::FoldPlaceholder {
+                    collapsed_text: Some("".into()),
+                    ..Default::default()
+                },
+                content_key: 0,
+            }],
+            cx,
+        );
+        editor.fold_ranges(vec![Point::new(2, 0)..Point::new(3, 8)], false, window, cx);
+        editor.change_selections(Default::default(), window, cx, |selections| {
+            selections.select_ranges([Point::new(1, 0)..Point::new(1, 8)]);
+        });
+        let snapshot = editor.display_snapshot(cx);
+        let selection = editor.selections.newest::<Point>(&snapshot);
+        assert_eq!(selection.start, Point::new(1, 0));
+        assert_eq!(selection.end, Point::new(1, 8));
+    });
+}
+
 /// Live preview's text decorations all hang off `HighlightKey::MarkdownLivePreview`,
 /// keyed per decoration kind. Highlights written under one key must not be
 /// disturbed when another key is cleared, or disabling one decoration would


### PR DESCRIPTION
Stage 1 of landing native heading typography (#52 / #36). Everything here stands on its own and does not depend on the per-line typography API, so it can merge ahead of #52's revision.

Three commits are cherry-picked from #52 with `-x`, preserving @silouanwright's authorship:

- `Preserve concealed source endpoints when resolving folded selections` — a display-only concealment must not move an explicit source endpoint past hidden syntax when a real fold exists elsewhere. `fold_map.rs`, `selections_collection.rs`.
- `Pin concealed source selection boundaries in the consumer contract` — the contract test for the above. Of the five tests in the original commit, only this one is API-independent; the other four call `style_lines` and stay with #52.
- `Keep the snapshot reference in the selection iterator` — the `move` the first commit needs to compile on its own.

One new commit:

- `editor: Never emit a zero-width concealment transform`. Zed's display-to-buffer mapping assumes a fold occupies at least one display column. The fork's concealments used an empty placeholder, so the display point at a concealed line start was shared by "before" and "after" the hidden text, and bias resolved past it: Vim's linewise `dd` on the line above, `yy`, and `cc` all lost a heading's concealed `## ` prefix. Real folds, glyph bullets, and any non-empty placeholder were unaffected. This substitutes a single U+200B when a concealment's placeholder is empty; the renderer already draws nothing, so nothing visible changes. `EditorTestContext::display_text` strips the placeholder so tests keep comparing visible text.

Verified on the native-heading consumer branch: with its four `crates/vim` fixes reverted and only this guard in place, all 26 Vim heading scenarios pass and all 115 live-preview tests pass. This lets the consumer PR drop its `crates/vim` changes entirely.

`CLAUDE.md` gains `selections_collection.rs` on the existing concealment-hooks row rather than #52's nine-file typography row, which belongs with #52.

Validation on this branch: `cargo fmt --all -- --check` clean. `cargo nextest run -p editor -p markdown_live_preview -p vim`: 1698 passed, 1 skipped, 0 failed. `./script/clippy -p editor -p markdown_live_preview` (release, all targets, deny warnings): clean.

Release Notes:

- Fixed Vim linewise operations losing concealed syntax at the start of the next line in markdown live preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjVUQHichLc7TjeceFfTPq
